### PR TITLE
Update sonar-project.properties to point to correct repo

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,4 @@
-sonar.projectKey=smartcontractkit_chainlink
+sonar.projectKey=smartcontractkit_chainlink-ccip
 sonar.sources=.
 sonar.python.version=3.8
 


### PR DESCRIPTION
This was triggering [SonarQube comments on really old PRs](https://github.com/smartcontractkit/chainlink/pull/66#issuecomment-1689522326). Point it back to the correct repo.