### PR TITLE
Offchain - Remove requirement for msg to be finalised to be excluded from batch

### DIFF
--- a/core/services/ocr2/plugins/ccip/execution_reporting_plugin.go
+++ b/core/services/ocr2/plugins/ccip/execution_reporting_plugin.go
@@ -483,7 +483,7 @@ func (r *ExecutionReportingPlugin) buildBatch(
 
 	for _, msg := range report.sendRequestsWithMeta {
 		msgLggr := lggr.With("messageID", hexutil.Encode(msg.MessageId[:]))
-		if msg.executed && msg.finalized {
+		if msg.executed {
 			msgLggr.Infow("Skipping message already executed", "seqNr", msg.SequenceNumber)
 			continue
 		}

--- a/core/services/ocr2/plugins/ccip/execution_reporting_plugin_test.go
+++ b/core/services/ocr2/plugins/ccip/execution_reporting_plugin_test.go
@@ -589,7 +589,7 @@ func TestBuildBatch(t *testing.T) {
 			expectedSeqNrs:        []ObservedMessage{{SeqNr: uint64(1)}},
 		},
 		{
-			name:                  "unfinalized executed log",
+			name:                  "executed non finalized messages should be skipped",
 			reqs:                  []evm2EVMOnRampCCIPSendRequestedWithMeta{msg2},
 			inflight:              []InflightInternalExecutionReport{},
 			tokenLimit:            big.NewInt(0),
@@ -597,7 +597,7 @@ func TestBuildBatch(t *testing.T) {
 			srcPrices:             map[common.Address]*big.Int{srcNative: big.NewInt(1)},
 			dstPrices:             map[common.Address]*big.Int{destNative: big.NewInt(1)},
 			offRampNoncesBySender: map[common.Address]uint64{sender1: 0},
-			expectedSeqNrs:        []ObservedMessage{{SeqNr: uint64(1)}},
+			expectedSeqNrs:        nil,
 		},
 		{
 			name:                  "finalized executed log",


### PR DESCRIPTION
Removing the requirement for a message to be finalised to be excluded from a batch and loosen the requirement to skip any executed messages.