### PR TITLE
Offchain - Sequence numbers range consensus using votes

### DIFF
--- a/core/services/ocr2/plugins/ccip/commit_reporting_plugin_test.go
+++ b/core/services/ocr2/plugins/ccip/commit_reporting_plugin_test.go
@@ -592,9 +592,17 @@ func TestCalculateIntervalConsensus(t *testing.T) {
 		}, 0, 1, 0, 0, true},
 		{
 			"range limit", []commit_store.CommitStoreInterval{
-				{Min: 10, Max: 100},
-				{Min: 1, Max: 1000},
+				{Min: 10, Max: 1000},
+				{Min: 10, Max: 1000},
 			}, 256, 1, 10, 265, false,
+		},
+		{
+			"range selection on equal votes", []commit_store.CommitStoreInterval{
+				{Min: 1, Max: 10},
+				{Min: 1, Max: 10},
+				{Min: 2, Max: 8},
+				{Min: 2, Max: 8},
+			}, 256, 1, 1, 10, false,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Having `f=4` and the following interval observations.
```
        [10, 20]
        [10, 20]
        [10, 20]
        [10, 20]
        [11, 21]
```

Would lead to the following sorted seq nums:
```
min = [10, 10, 10, 10, 11]
max = [20, 20, 20, 20, 21]
```

And the following range would be selected, which would eventually be skipped because it's not the valid one.
```
min[f] -> 11
max[f] -> 21
```

This PR introduces a new way of selecting the sequence number range using votes. The most voted min/max will be selected. So for the example above the selected range would be `[10, 20]`.