### PR TITLE
Makefile readability improvements

### DIFF
--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -2,42 +2,43 @@ BIN_DIR = bin
 export GOPATH ?= $(shell go env GOPATH)
 export GO111MODULE ?= on
 
-LINUX=LINUX
-OSX=OSX
-WINDOWS=WIN32
-OSFLAG :=
+LINUX   = LINUX
+OSX     = OSX
+WINDOWS = WIN32
+OSFLAG  := 
 ifeq ($(OS),Windows_NT)
-	OSFLAG = $(WINDOWS)
+    OSFLAG = $(WINDOWS)
 else
-	UNAME_S := $(shell uname -s)
+    UNAME_S := $(shell uname -s)
+
 ifeq ($(UNAME_S),Linux)
-		OSFLAG = $(LINUX)
+	OSFLAG = $(LINUX)
 endif
+
 ifeq ($(UNAME_S),Darwin)
-		OSFLAG = $(OSX)
+	OSFLAG = $(OSX)
 endif
 endif
+
 
 install_qa_tools:
 ifeq ($(OSFLAG),$(WINDOWS))
 	echo "If you are running windows and know how to install what is needed, please contribute by adding it here!"
 	echo "You will need nodejs, golang, k3d, and helm."
 	exit 1
-else
-
-# linux and mac can use asdf to install all of the dependencies
-ifeq ($(shell which asdf), )
+endif
 
 # install asdf
+ifeq ($(shell which asdf),)
 ifeq ($(OSFLAG),$(LINUX))
 	echo "You will need to install asdf via your linux installer https://asdf-vm.com/guide/getting-started.html"
 	exit 1
-else
+endif
 ifeq ($(OSFLAG),$(OSX))
 	brew install asdf
 endif
 endif
-endif
+
 # install the plugins if needed and then install the dependencies
 	asdf plugin-add nodejs || true
 	asdf plugin-add golang || true
@@ -45,11 +46,12 @@ endif
 	asdf plugin-add helm || true
 	asdf plugin-add kubectl || true
 	asdf install
-endif
+
 # Now install the helm charts that are needed (should be os agnostic)
 	helm repo add chainlink-qa https://raw.githubusercontent.com/smartcontractkit/qa-charts/gh-pages/
 	helm repo add bitnami https://charts.bitnami.com/bitnami
 	helm repo update
+
 
 .PHONY: install_gotestfmt
 install_gotestfmt:
@@ -68,7 +70,11 @@ build_test_image:
 #Build a chainlink docker image for local testing and push to k3d registry
 .PHONY: build_push_docker_image
 build_push_docker_image:
-	docker build -f ../core/chainlink.Dockerfile --build-arg COMMIT_SHA=$(git rev-parse HEAD) --build-arg CHAINLINK_USER=chainlink -t localhost:5000/chainlink:develop ../ ; docker push localhost:5000/chainlink:develop
+	docker build -f ../core/chainlink.Dockerfile \
+	--build-arg COMMIT_SHA=$(shell git rev-parse HEAD) \
+	--build-arg CHAINLINK_USER=chainlink \
+	-t localhost:5000/chainlink:develop ../
+	docker push localhost:5000/chainlink:develop
 
 ## Test Runner
 .PHONY: run
@@ -208,8 +214,10 @@ test_reorg_automation: ## Run the automation reorg tests
 # example usage: make build_docker_image image=chainlink tag=latest
 .PHONY: build_docker_image
 build_docker_image:
-	docker build -f ../core/chainlink.Dockerfile --build-arg COMMIT_SHA=$(git rev-parse HEAD) --build-arg CHAINLINK_USER=chainlink -t $(image):$(tag) ../
-
+	docker build -f ../core/chainlink.Dockerfile \
+	--build-arg COMMIT_SHA=$(git rev-parse HEAD) \
+	--build-arg CHAINLINK_USER=chainlink \
+	-t $(image):$(tag) ../
 
 # image: the name for the chainlink image being built, example: image=chainlink
 # tag: the tag for the chainlink image being built, example: tag=latest


### PR DESCRIPTION
Remove extra conditional around IF windows then exit Add line breaks to the docker build commands

## Motivation
To create a first pull request
Makefile can be more readable

## Solution
Remove extra conditional around an exit condition.
Add line breaks around the docker build targets.