### PR TITLE
Add network input with env var

### DIFF
--- a/integration-tests/ccip-tests/ccip-example.env
+++ b/integration-tests/ccip-tests/ccip-example.env
@@ -12,7 +12,7 @@ export CHAINLINK_VERSION="0.4.0-beta.0+core2.1.0" # Version of the chainlink-cci
 # is overlooked by ccip tests. The tests are run with networks provided
 # from index 1 onwards (AVALANCHE_FUJI,SEPOLIA in this example)
 # You need provide at least two networks (from index 1) to run the ccip tests
-export SELECTED_NETWORKS="SIMULATED,AVALANCHE_FUJI,SEPOLIA"
+export SELECTED_NETWORKS="SIMULATED,AVALANCHE_FUJI,SEPOLIA,BASE_GOERLI"
 
 # The following env vars are used to run the tests on non-simulated networks.
 # Ignore the following when the tests are run using simulated networks
@@ -105,11 +105,11 @@ export CCIP_TEST_DURATION=10m
 
 # Rate unit to use for the load test. The ccip-send requests will be triggerred at a rate of <CCIP_LOAD_TEST_RATEUNIT> duration.
 # Default value is 1s unless specified
-export CCIP_LOAD_TEST_RATEUNIT=1s
+export CCIP_LOAD_TEST_RATEUNIT=1h
 
 # Rate to use for the load test. Default value is 2 unless specified
 # The ccip-send requests will be triggerred at a rate of <CCIP_LOAD_TEST_RATE> per <CCIP_LOAD_TEST_RATEUNIT>
-export CCIP_LOAD_TEST_RATE=2
+export CCIP_LOAD_TEST_RATE=1
 
 # Chaos interval to use for the load test. Default value is 1m unless specified
 # The chaos interval is the duration to wait before subsequent chaos condition is applied in the test environment.

--- a/integration-tests/ccip-tests/ccip-example.env
+++ b/integration-tests/ccip-tests/ccip-example.env
@@ -12,7 +12,7 @@ export CHAINLINK_VERSION="0.4.0-beta.0+core2.1.0" # Version of the chainlink-cci
 # is overlooked by ccip tests. The tests are run with networks provided
 # from index 1 onwards (AVALANCHE_FUJI,SEPOLIA in this example)
 # You need provide at least two networks (from index 1) to run the ccip tests
-export SELECTED_NETWORKS="SIMULATED,AVALANCHE_FUJI,SEPOLIA,BASE_GOERLI"
+export SELECTED_NETWORKS="SIMULATED,AVALANCHE_FUJI,SEPOLIA"
 
 # The following env vars are used to run the tests on non-simulated networks.
 # Ignore the following when the tests are run using simulated networks
@@ -105,11 +105,11 @@ export CCIP_TEST_DURATION=10m
 
 # Rate unit to use for the load test. The ccip-send requests will be triggerred at a rate of <CCIP_LOAD_TEST_RATEUNIT> duration.
 # Default value is 1s unless specified
-export CCIP_LOAD_TEST_RATEUNIT=1h
+export CCIP_LOAD_TEST_RATEUNIT=1s
 
 # Rate to use for the load test. Default value is 2 unless specified
 # The ccip-send requests will be triggerred at a rate of <CCIP_LOAD_TEST_RATE> per <CCIP_LOAD_TEST_RATEUNIT>
-export CCIP_LOAD_TEST_RATE=1
+export CCIP_LOAD_TEST_RATE=2
 
 # Chaos interval to use for the load test. Default value is 1m unless specified
 # The chaos interval is the duration to wait before subsequent chaos condition is applied in the test environment.

--- a/integration-tests/ccip-tests/testsetups/ccip.go
+++ b/integration-tests/ccip-tests/testsetups/ccip.go
@@ -21,13 +21,12 @@ import (
 	mockserver_cfg "github.com/smartcontractkit/chainlink-env/pkg/helm/mockserver-cfg"
 	"github.com/smartcontractkit/chainlink-env/pkg/helm/reorg"
 	"github.com/smartcontractkit/chainlink-testing-framework/blockchain"
+	"github.com/smartcontractkit/chainlink-testing-framework/networks"
 	"github.com/smartcontractkit/chainlink-testing-framework/utils"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/multierr"
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/sync/errgroup"
-
-	"github.com/smartcontractkit/chainlink/integration-tests/networks"
 
 	integrationactions "github.com/smartcontractkit/chainlink/integration-tests/actions"
 	"github.com/smartcontractkit/chainlink/integration-tests/ccip-tests/actions"

--- a/integration-tests/ccip-tests/testsetups/ccip.go
+++ b/integration-tests/ccip-tests/testsetups/ccip.go
@@ -21,12 +21,13 @@ import (
 	mockserver_cfg "github.com/smartcontractkit/chainlink-env/pkg/helm/mockserver-cfg"
 	"github.com/smartcontractkit/chainlink-env/pkg/helm/reorg"
 	"github.com/smartcontractkit/chainlink-testing-framework/blockchain"
-	"github.com/smartcontractkit/chainlink-testing-framework/networks"
 	"github.com/smartcontractkit/chainlink-testing-framework/utils"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/multierr"
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/smartcontractkit/chainlink/integration-tests/networks"
 
 	integrationactions "github.com/smartcontractkit/chainlink/integration-tests/actions"
 	"github.com/smartcontractkit/chainlink/integration-tests/ccip-tests/actions"

--- a/integration-tests/ccip-tests/testsetups/ccip.go
+++ b/integration-tests/ccip-tests/testsetups/ccip.go
@@ -191,47 +191,35 @@ func (p *CCIPTestConfig) setLoadInputs() {
 	}
 }
 
-func (p *CCIPTestConfig) FormNetworkPairs() {
-	for i := 0; i < p.NoOfNetworks; i++ {
-		for j := i + 1; j < p.NoOfNetworks; j++ {
+func (p *CCIPTestConfig) SetNetworkPairs(t *testing.T, lggr zerolog.Logger) error {
+	var allError error
+	// if network pairs are provided, then use them
+	// example usage - CCIP_NETWORK_PAIRS="networkA,networkB|networkC,networkD|networkA,networkC"
+	lanes, _ := utils.GetEnv("CCIP_NETWORK_PAIRS")
+	if lanes != "" {
+		p.NetworkPairs = []NetworkPair{}
+		networkPairs := strings.Split(lanes, "|")
+		for _, pair := range networkPairs {
+			networkNames := strings.Split(pair, ",")
+			if len(networkNames) != 2 {
+				allError = multierr.Append(allError, fmt.Errorf("invalid network pair"))
+			}
+			nets := networks.SetNetworks(networkNames)
 			p.NetworkPairs = append(p.NetworkPairs, NetworkPair{
-				NetworkA: p.AllNetworks[i],
-				NetworkB: p.AllNetworks[j],
+				NetworkA: nets[0],
+				NetworkB: nets[1],
 			})
 		}
+		return allError
 	}
-}
-
-// NewCCIPTestConfig collects all test related CCIPTestConfig from environment variables
-func NewCCIPTestConfig(t *testing.T, lggr zerolog.Logger, tType string) *CCIPTestConfig {
-	var allError error
+	// if network pairs are not provided with CCIP_NETWORK_PAIRS, then form all possible network pair combination from SELECTED_NETWORKS
 	if len(networks.SelectedNetworks) < 3 {
 		lggr.Fatal().
 			Interface("SELECTED_NETWORKS", networks.SelectedNetworks).
 			Msg("Set source and destination network in index 1 & 2 of env variable SELECTED_NETWORKS")
 	}
-	p := &CCIPTestConfig{
-		Test:                t,
-		MsgType:             actions.TokenTransfer,
-		PhaseTimeout:        DefaultPhaseTimeout,
-		TestDuration:        DefaultTestDuration,
-		NodeFunding:         DefaultNodeFunding,
-		NoOfNetworks:        DefaultNoOfNetworks,
-		AllNetworks:         networks.SelectedNetworks[1:],
-		GethResourceProfile: GethResourceProfile,
-	}
-
-	if tType != Smoke {
-		p.CLNodeDBResourceProfile = DONDBResourceProfile
-	}
-
-	if tType == Load {
-		p.EnvTTL = DefaultTTLForLongTests
-		p.CLNodeResourceProfile = DONResourceProfile
-		p.NodeFunding = NodeFundingForLoad
-		p.PhaseTimeout = DefaultPhaseTimeoutForLongTests
-	}
-
+	p.AllNetworks = networks.SelectedNetworks[1:]
+	p.NoOfNetworks = DefaultNoOfNetworks
 	inputNoOfNetworks, _ := utils.GetEnv("CCIP_NO_OF_NETWORKS")
 	if inputNoOfNetworks != "" {
 		n, err := strconv.Atoi(inputNoOfNetworks)
@@ -260,7 +248,7 @@ func NewCCIPTestConfig(t *testing.T, lggr zerolog.Logger, tType string) *CCIPTes
 	// and the provided networks are simulated network, create replicas of the provided networks with
 	// different chain ids
 	if len(p.AllNetworks) < p.NoOfNetworks {
-		if p.AllNetworks[0].Simulated {
+		if simulated {
 			actualNoOfNetworks := len(p.AllNetworks)
 			n := p.AllNetworks[0]
 			for i := 0; i < p.NoOfNetworks-actualNoOfNetworks; i++ {
@@ -281,7 +269,7 @@ func NewCCIPTestConfig(t *testing.T, lggr zerolog.Logger, tType string) *CCIPTes
 	}
 	lggr.Info().Interface("Networks", p.AllNetworks).Msg("Running tests with networks")
 	if p.NoOfNetworks > 2 {
-		p.FormNetworkPairs()
+		p.FormNetworkPairCombinations()
 	} else {
 		p.NetworkPairs = []NetworkPair{
 			{
@@ -294,6 +282,45 @@ func NewCCIPTestConfig(t *testing.T, lggr zerolog.Logger, tType string) *CCIPTes
 	for _, n := range p.NetworkPairs {
 		lggr.Info().Str("NetworkA", n.NetworkA.Name).Str("NetworkB", n.NetworkB.Name).Msg("Network Pairs")
 	}
+
+	return allError
+}
+
+func (p *CCIPTestConfig) FormNetworkPairCombinations() {
+	for i := 0; i < p.NoOfNetworks; i++ {
+		for j := i + 1; j < p.NoOfNetworks; j++ {
+			p.NetworkPairs = append(p.NetworkPairs, NetworkPair{
+				NetworkA: p.AllNetworks[i],
+				NetworkB: p.AllNetworks[j],
+			})
+		}
+	}
+}
+
+// NewCCIPTestConfig collects all test related CCIPTestConfig from environment variables
+func NewCCIPTestConfig(t *testing.T, lggr zerolog.Logger, tType string) *CCIPTestConfig {
+	var allError error
+	p := &CCIPTestConfig{
+		Test:                t,
+		MsgType:             actions.TokenTransfer,
+		PhaseTimeout:        DefaultPhaseTimeout,
+		TestDuration:        DefaultTestDuration,
+		NodeFunding:         DefaultNodeFunding,
+		GethResourceProfile: GethResourceProfile,
+	}
+
+	if tType != Smoke {
+		p.CLNodeDBResourceProfile = DONDBResourceProfile
+	}
+
+	if tType == Load {
+		p.EnvTTL = DefaultTTLForLongTests
+		p.CLNodeResourceProfile = DONResourceProfile
+		p.NodeFunding = NodeFundingForLoad
+		p.PhaseTimeout = DefaultPhaseTimeoutForLongTests
+	}
+
+	allError = multierr.Append(allError, p.SetNetworkPairs(t, lggr))
 
 	ttlDuration, _ := utils.GetEnv("CCIP_KEEP_ENV_TTL")
 	if ttlDuration != "" {

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/slack-go/slack v0.12.2
 	github.com/smartcontractkit/chain-selectors v1.0.1
 	github.com/smartcontractkit/chainlink-env v0.36.0
-	github.com/smartcontractkit/chainlink-testing-framework v1.16.2
+	github.com/smartcontractkit/chainlink-testing-framework v1.16.5-0.20230907234215-8f758ef3a2d9
 	github.com/smartcontractkit/chainlink/integration-tests v0.0.0-20230828183543-6d0939746966
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/libocr v0.0.0-20230816220705-665e93233ae5
@@ -238,7 +238,7 @@ require (
 	github.com/hashicorp/yamux v0.0.0-20200609203250-aecfd211c9ce // indirect
 	github.com/hdevalence/ed25519consensus v0.1.0 // indirect
 	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
-	github.com/holiman/uint256 v1.2.2 // indirect
+	github.com/holiman/uint256 v1.2.3 // indirect
 	github.com/huandu/skiplist v1.2.0 // indirect
 	github.com/huin/goupnp v1.0.3 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1405,8 +1405,8 @@ github.com/henvic/httpretty v0.0.6 h1:JdzGzKZBajBfnvlMALXXMVQWxWMF/ofTy8C3/OSUTx
 github.com/hetznercloud/hcloud-go v1.41.0 h1:KJGFRRc68QiVu4PrEP5BmCQVveCP2CM26UGQUKGpIUs=
 github.com/holiman/bloomfilter/v2 v2.0.3 h1:73e0e/V0tCydx14a0SCYS/EWCxgwLZ18CZcZKVu0fao=
 github.com/holiman/bloomfilter/v2 v2.0.3/go.mod h1:zpoh+gs7qcpqrHr3dB55AMiJwo0iURXE7ZOP9L9hSkA=
-github.com/holiman/uint256 v1.2.2 h1:TXKcSGc2WaxPD2+bmzAsVthL4+pEN0YwXcL5qED83vk=
-github.com/holiman/uint256 v1.2.2/go.mod h1:SC8Ryt4n+UBbPbIBKaG9zbbDlp4jOru9xFZmPzLUTxw=
+github.com/holiman/uint256 v1.2.3 h1:K8UWO1HUJpRMXBxbmaY1Y8IAMZC/RsKB+ArEnnK4l5o=
+github.com/holiman/uint256 v1.2.3/go.mod h1:SC8Ryt4n+UBbPbIBKaG9zbbDlp4jOru9xFZmPzLUTxw=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/go-assert v1.1.5 h1:fjemmA7sSfYHJD7CUqs9qTwwfdNAx7/j2/ZlHXzNB3c=
 github.com/huandu/go-assert v1.1.5/go.mod h1:yOLvuqZwmcHIC5rIzrBhT7D3Q9c3GFnd0JrPVhn/06U=
@@ -2278,8 +2278,8 @@ github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230831134610-680240b97ac
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230831134610-680240b97aca/go.mod h1:RIUJXn7EVp24TL2p4FW79dYjyno23x5mjt1nKN+5WEk=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20230901115736-bbabe542a918 h1:ByVauKFXphRlSNG47lNuxZ9aicu+r8AoNp933VRPpCw=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20230901115736-bbabe542a918/go.mod h1:/yp/sqD8Iz5GU5fcercjrw0ivJF7HDcupYg+Gjr7EPg=
-github.com/smartcontractkit/chainlink-testing-framework v1.16.2 h1:+m/8wd443+ZpRL+GS86dVnMDeZ6+pnut0uVTZhrtIvU=
-github.com/smartcontractkit/chainlink-testing-framework v1.16.2/go.mod h1:xtLIwNaVw/4zWSMnA7j8u1t9tKh0OykvIsYI4xZT3B4=
+github.com/smartcontractkit/chainlink-testing-framework v1.16.5-0.20230907234215-8f758ef3a2d9 h1:cd7KmW4wY7AsqwVCl5W4pmVA6iimSkuX7fObRHUhtxs=
+github.com/smartcontractkit/chainlink-testing-framework v1.16.5-0.20230907234215-8f758ef3a2d9/go.mod h1:Ry6fRPr8TwrIsYVNEF1pguAgzE3QW1s54tbLWnFtfI4=
 github.com/smartcontractkit/go-plugin v0.0.0-20230605132010-0f4d515d1472 h1:x3kNwgFlDmbE/n0gTSRMt9GBDfsfGrs4X9b9arPZtFI=
 github.com/smartcontractkit/go-plugin v0.0.0-20230605132010-0f4d515d1472/go.mod h1:6/1TEzT0eQznvI/gV2CM29DLSkAK/e58mUWKVsPaph0=
 github.com/smartcontractkit/grpc-proxy v0.0.0-20230731113816-f1be6620749f h1:hgJif132UCdjo8u43i7iPN1/MFnu49hv7lFGFftCHKU=


### PR DESCRIPTION
## Motivation
The current way of providing network input to test is through `SELECTED_NETWORKS` env var. If we need to run tests in more than 2 networks over multiple lanes, the network input in `SELECTED_NETWORKS` runs the test for all possible combination of lanes between 2 networks among all provided networks. For example with `SELECTED_NETWORKS=networkA, NetworkB, NetworkC` the test is triggered for all possible combination of these networks - A,B ; B,C; A,C
Often we need to run tests for only specific set of lanes between various networks.

## Solution
Introduce another env var `CCIP_NETWORK_PAIRS` example usage - `CCIP_NETWORK_PAIRS="networkA,networkB|networkC,networkD|networkA,networkC"`
It's` | `delimited list of network pairs. It will help us specify lanes on which tests are to be triggered as opposed to all possible combination of lanes