### PR TITLE
Fix GH integration-chaos-tests, operator-ui-ci workflows

### DIFF
--- a/.github/workflows/integration-chaos-tests.yml
+++ b/.github/workflows/integration-chaos-tests.yml
@@ -1,3 +1,4 @@
+---
 #name: Integration Chaos Test
 #on:
 #  schedule:

--- a/.github/workflows/operator-ui-ci.yml
+++ b/.github/workflows/operator-ui-ci.yml
@@ -1,3 +1,4 @@
+---
 #name: Operator UI CI
 #on:
 #  pull_request:


### PR DESCRIPTION
## Motivation

When the following workflows

- .github/workflows/integration-chaos-tests.yml
- .github/workflows/operator-ui-ci.yml

were merged into this repo from upstream [smartcontractkit/chainlink](https://github.com/smartcontractkit/chainlink), their contents was commented out. It made them invalid, per YAML spec. As result it's (likely) tripping the workflow engine execution.



## Solution

Add a YAML instruction that does nothing -- section separator (`---`)