### PR TITLE
Make ccipreceiver contract supportsInterface function virtual

### DIFF
--- a/contracts/src/v0.8/ccip/applications/CCIPReceiver.sol
+++ b/contracts/src/v0.8/ccip/applications/CCIPReceiver.sol
@@ -26,7 +26,7 @@ abstract contract CCIPReceiver is IAny2EVMMessageReceiver, IERC165 {
   /// If this returns true, tokens are transferred and ccipReceive is called atomically.
   /// Additionally, if the receiver address does not have code associated with
   /// it at the time of execution (EXTCODESIZE returns 0), only tokens will be transferred.
-  function supportsInterface(bytes4 interfaceId) public pure override returns (bool) {
+  function supportsInterface(bytes4 interfaceId) public pure virtual override returns (bool) {
     return interfaceId == type(IAny2EVMMessageReceiver).interfaceId || interfaceId == type(IERC165).interfaceId;
   }
 


### PR DESCRIPTION
```solidity
// example:

pragma solidity >=0.5.0 <0.7.0;

contract CCIPReceiver {
    function foo() virtual public {} // <--- making this func virtual
}

contract ERC123 {
    function foo() virtual public {}
}

contract Inherited is CCIPReceiver, ERC123 {
    // Derives from multiple bases defining foo(), so we must explicitly override it
    function foo() public override(CCIPReceiver, ERC123) {}
}
```

closes #178 