### PR TITLE
offchain - execution plugin blessed roots cache

### DIFF
--- a/core/services/ocr2/plugins/ccip/internal/cache/blessedroots.go
+++ b/core/services/ocr2/plugins/ccip/internal/cache/blessedroots.go
@@ -1,0 +1,47 @@
+package cache
+
+import (
+	"encoding/hex"
+	"time"
+
+	goc "github.com/patrickmn/go-cache"
+)
+
+type BlessedRootsCache interface {
+	Get(m [32]byte) (val bool, exists bool)
+	Set(m [32]byte, val bool)
+}
+
+var _ BlessedRootsCache = &BlessedRoots{}
+
+type BlessedRoots struct {
+	mem *goc.Cache
+}
+
+func NewBlessedRoots(expiry, cleanup time.Duration) *BlessedRoots {
+	return &BlessedRoots{
+		mem: goc.New(expiry, cleanup),
+	}
+}
+
+func (c *BlessedRoots) Get(m [32]byte) (val bool, exists bool) {
+	rawVal, exists := c.mem.Get(c.merkleRootKey(m))
+	if !exists {
+		return false, false
+	}
+
+	boolVal, is := rawVal.(bool)
+	if !is {
+		return false, false
+	}
+
+	return boolVal, true
+}
+
+func (c *BlessedRoots) Set(m [32]byte, val bool) {
+	c.mem.Set(c.merkleRootKey(m), val, 0)
+}
+
+func (c *BlessedRoots) merkleRootKey(m [32]byte) string {
+	return hex.EncodeToString(m[:])
+}

--- a/core/services/ocr2/plugins/ccip/internal/cache/blessedroots_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/cache/blessedroots_test.go
@@ -1,0 +1,57 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/smartcontractkit/chainlink/v2/core/utils"
+)
+
+func TestBlessedRoots(t *testing.T) {
+	m1 := utils.RandomBytes32()
+	m2 := utils.RandomBytes32()
+	m3 := utils.RandomBytes32()
+
+	t.Run("base", func(t *testing.T) {
+		c := NewBlessedRoots(time.Minute, time.Minute)
+
+		c.Set(m1, true)
+		c.Set(m2, false)
+
+		val, exists := c.Get(m1)
+		assert.True(t, val)
+		assert.True(t, exists)
+
+		val, exists = c.Get(m2)
+		assert.False(t, val)
+		assert.True(t, exists)
+
+		// unset key
+		val, exists = c.Get(m3)
+		assert.False(t, val)
+		assert.False(t, exists)
+
+		// over-write m2
+		c.Set(m2, true)
+		val, exists = c.Get(m2)
+		assert.True(t, val)
+		assert.True(t, exists)
+	})
+
+	t.Run("test expiry", func(t *testing.T) {
+		c := NewBlessedRoots(time.Nanosecond, time.Minute)
+		c.Set(m1, true)
+		time.Sleep(10 * time.Nanosecond) // after 10ns it should've been expired
+		_, exists := c.Get(m1)
+		assert.False(t, exists)
+	})
+
+	t.Run("internal issue", func(t *testing.T) {
+		c := NewBlessedRoots(time.Minute, time.Minute)
+		c.mem.Set(c.merkleRootKey(m1), 1234, 0) // non-bool
+		_, exists := c.Get(m1)
+		assert.False(t, exists)
+	})
+}


### PR DESCRIPTION
## The Issue

If a report is not blessed we keep re-trying until it gets blessed.
This might make multiple commit store rpc requests per second.

## Solution

Retry only after a configurable interval, set at `500ms`.
