### PR TITLE
Backport upstream fix chainlink/pull/10405

### DIFF
--- a/core/web/common.go
+++ b/core/web/common.go
@@ -15,10 +15,6 @@ var (
 )
 
 func getChain(legacyChains evm.LegacyChainContainer, chainIDstr string) (chain evm.Chain, err error) {
-	if legacyChains.Len() > 1 {
-		return nil, ErrMultipleChains
-	}
-
 	if chainIDstr != "" && chainIDstr != "<nil>" {
 		// evm keys are expected to be parsable as a big int
 		_, ok := big.NewInt(0).SetString(chainIDstr, 10)
@@ -30,6 +26,10 @@ func getChain(legacyChains evm.LegacyChainContainer, chainIDstr string) (chain e
 			return nil, ErrMissingChainID
 		}
 		return chain, nil
+	}
+
+	if legacyChains.Len() > 1 {
+		return nil, ErrMultipleChains
 	}
 
 	chain, err = legacyChains.Default()


### PR DESCRIPTION
## Motivation

The fix -- BCF-2610: fix web interfaces to work with multiple chains [1] applied to CCIP version -- `v2.5.0-ccip1.1.1`.

[1]: https://github.com/smartcontractkit/chainlink/pull/10405 (move len check to match previous behavior: PR #10405)


## Solution