### PR TITLE
Add 'hotfix*' branch regex to the GitHub 'push' workflow triggers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - ccip-develop
       - deployment-test
+      - 'hotfix*'
 
 jobs:
   build-and-publish:


### PR DESCRIPTION
## Motivation

Currently the `push` action is not triggered for our hotfixes.  

## Solution

Add 'hotfix*' to branch triggers for the `push` action. 
