### PR TITLE
create packages for plugins

### DIFF
--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -31,6 +31,8 @@ import (
 	relaylogger "github.com/smartcontractkit/chainlink-relay/pkg/logger"
 	"github.com/smartcontractkit/chainlink-relay/pkg/loop"
 	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/commitplugin"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/executionplugin"
 
 	ocr2keeper21core "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evm21/core"
 
@@ -42,7 +44,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ocr2key"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/models"
-	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/dkg"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/dkg/persistence"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/functions"
@@ -287,13 +288,13 @@ func (d *Delegate) cleanupEVM(jb job.Job, q pg.Queryer, relayID relay.ID) error 
 			d.lggr.Errorw("failed to derive ocr2keeper filter names from spec", "err", err, "spec", spec)
 		}
 	case types.CCIPCommit:
-		err = ccip.UnregisterCommitPluginLpFilters(context.Background(), d.lggr, jb, d.pipelineRunner, d.legacyChains, pg.WithQueryer(q))
+		err = commitplugin.UnregisterLpFilters(context.Background(), d.lggr, jb, d.pipelineRunner, d.legacyChains, pg.WithQueryer(q))
 		if err != nil {
 			d.lggr.Errorw("failed to unregister ccip commit plugin filters", "err", err, "spec", spec)
 		}
 		return nil
 	case types.CCIPExecution:
-		err = ccip.UnregisterExecPluginLpFilters(context.Background(), d.lggr, jb, d.legacyChains, pg.WithQueryer(q))
+		err = executionplugin.UnregisterLpFilters(context.Background(), d.lggr, jb, d.legacyChains, pg.WithQueryer(q))
 		if err != nil {
 			d.lggr.Errorw("failed to unregister ccip exec plugin filters", "err", err, "spec", spec)
 		}
@@ -1365,7 +1366,7 @@ func (d *Delegate) newServicesCCIPCommit(lggr logger.SugaredLogger, jb job.Job, 
 	logError := func(msg string) {
 		lggr.ErrorIf(d.jobORM.RecordError(jb.ID, msg), "unable to record error")
 	}
-	return ccip.NewCommitServices(lggr, jb, d.legacyChains, d.isNewlyCreatedJob, d.pipelineRunner, oracleArgsNoPlugin, logError)
+	return commitplugin.InitServices(lggr, jb, d.legacyChains, d.isNewlyCreatedJob, d.pipelineRunner, oracleArgsNoPlugin, logError)
 }
 
 func (d *Delegate) newServicesCCIPExecution(lggr logger.SugaredLogger, jb job.Job, bootstrapPeers []commontypes.BootstrapperLocator, kb ocr2key.KeyBundle, ocrDB *db, lc ocrtypes.LocalConfig, transmitterID string) ([]job.ServiceCtx, error) {
@@ -1413,7 +1414,7 @@ func (d *Delegate) newServicesCCIPExecution(lggr logger.SugaredLogger, jb job.Jo
 	logError := func(msg string) {
 		lggr.ErrorIf(d.jobORM.RecordError(jb.ID, msg), "unable to record error")
 	}
-	return ccip.NewExecutionServices(lggr, jb, d.legacyChains, d.isNewlyCreatedJob, oracleArgsNoPlugin, logError)
+	return executionplugin.InitServices(lggr, jb, d.legacyChains, d.isNewlyCreatedJob, oracleArgsNoPlugin, logError)
 }
 
 // errorLog implements [loop.ErrorLog]

--- a/core/services/ocr2/plugins/ccip/commitplugin/factory.go
+++ b/core/services/ocr2/plugins/ccip/commitplugin/factory.go
@@ -1,0 +1,101 @@
+package commitplugin
+
+import (
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/cache"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipdata"
+)
+
+type Factory struct {
+	// Configuration derived from the job spec which does not change
+	// between plugin instances (ie between SetConfigs onchain)
+	config StaticConfig
+
+	// Dynamic readers
+	readersMu          *sync.Mutex
+	destPriceRegReader ccipdata.PriceRegistryReader
+	destPriceRegAddr   common.Address
+}
+
+// NewReportingPlugin returns the ccip CommitReportingPlugin and satisfies the ReportingPluginFactory interface.
+func (rf *Factory) NewReportingPlugin(config types.ReportingPluginConfig) (types.ReportingPlugin, types.ReportingPluginInfo, error) {
+	destPriceReg, err := rf.config.commitStore.ChangeConfig(config.OnchainConfig, config.OffchainConfig)
+	if err != nil {
+		return nil, types.ReportingPluginInfo{}, err
+	}
+	if err = rf.updateDynamicReaders(destPriceReg); err != nil {
+		return nil, types.ReportingPluginInfo{}, err
+	}
+
+	if err != nil {
+		return nil, types.ReportingPluginInfo{}, err
+	}
+
+	return &CommitReportingPlugin{
+			sourceChainSelector:     rf.config.sourceChainSelector,
+			sourceNative:            rf.config.sourceNative,
+			onRampReader:            rf.config.onRampReader,
+			commitStoreReader:       rf.config.commitStore,
+			priceGetter:             rf.config.priceGetter,
+			F:                       config.F,
+			lggr:                    rf.config.lggr.Named("CommitReportingPlugin"),
+			inflightReports:         newInflightCommitReportsContainer(rf.config.commitStore.OffchainConfig().InflightCacheExpiry),
+			destPriceRegistryReader: rf.destPriceRegReader,
+			tokenDecimalsCache: cache.NewTokenToDecimals(
+				rf.config.lggr,
+				rf.config.destLP,
+				rf.config.offRamp,
+				rf.destPriceRegReader,
+				rf.config.destClient,
+				int64(rf.config.commitStore.OffchainConfig().DestFinalityDepth),
+			),
+			gasPriceEstimator: rf.config.commitStore.GasPriceEstimator(),
+		},
+		types.ReportingPluginInfo{
+			Name:          "CCIPCommit",
+			UniqueReports: false, // See comment in CommitStore constructor.
+			Limits: types.ReportingPluginLimits{
+				MaxQueryLength:       0,
+				MaxObservationLength: ccip.MaxObservationLength,
+				MaxReportLength:      MaxCommitReportLength,
+			},
+		}, nil
+}
+
+// newFactory return a new CommitReportingPluginFactory.
+func newFactory(config StaticConfig) *Factory {
+	return &Factory{
+		config:    config,
+		readersMu: &sync.Mutex{},
+	}
+}
+
+func (rf *Factory) updateDynamicReaders(newPriceRegAddr common.Address) error {
+	rf.readersMu.Lock()
+	defer rf.readersMu.Unlock()
+	// TODO: Investigate use of Close() to cleanup.
+	// TODO: a true price registry upgrade on an existing lane may want some kind of start block in its config? Right now we
+	// essentially assume that plugins don't care about historical price reg logs.
+	if rf.destPriceRegAddr == newPriceRegAddr {
+		// No-op
+		return nil
+	}
+	// Close old reader if present and open new reader if address changed
+	if rf.destPriceRegReader != nil {
+		if err := rf.destPriceRegReader.Close(); err != nil {
+			return err
+		}
+	}
+	destPriceRegistryReader, err := ccipdata.NewPriceRegistryReader(rf.config.lggr, newPriceRegAddr, rf.config.destLP, rf.config.destClient)
+	if err != nil {
+		return err
+	}
+	rf.destPriceRegReader = destPriceRegistryReader
+	rf.destPriceRegAddr = newPriceRegAddr
+	return nil
+}

--- a/core/services/ocr2/plugins/ccip/commitplugin/inflight_test.go
+++ b/core/services/ocr2/plugins/ccip/commitplugin/inflight_test.go
@@ -1,4 +1,4 @@
-package ccip
+package commitplugin
 
 import (
 	"math/big"
@@ -20,7 +20,7 @@ func TestCommitInflight(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	c := newInflightCommitReportsContainer(time.Hour)
 
-	c.inFlightPriceUpdates = append(c.inFlightPriceUpdates, InflightPriceUpdate{
+	c.inFlightPriceUpdates = append(c.inFlightPriceUpdates, inflightPriceUpdate{
 		gasPrices:     []ccipdata.GasPrice{},
 		createdAt:     time.Now(),
 		epochAndRound: ccipcalc.MergeEpochAndRound(2, 4),
@@ -96,7 +96,7 @@ func TestCommitInflight(t *testing.T) {
 	assert.Equal(t, big.NewInt(10), latestInflightTokenPriceUpdates[token].value)
 
 	// larger epoch and round overrides existing price update
-	c.inFlightPriceUpdates = append(c.inFlightPriceUpdates, InflightPriceUpdate{
+	c.inFlightPriceUpdates = append(c.inFlightPriceUpdates, inflightPriceUpdate{
 		tokenPrices: []ccipdata.TokenPrice{
 			{Token: token, Value: big.NewInt(9999)},
 		},
@@ -117,7 +117,7 @@ func TestCommitInflight(t *testing.T) {
 func Test_inflightCommitReportsContainer_expire(t *testing.T) {
 	c := &inflightCommitReportsContainer{
 		cacheExpiry: time.Minute,
-		inFlight: map[[32]byte]InflightCommitReport{
+		inFlight: map[[32]byte]inflightReport{
 			common.HexToHash("1"): {
 				report:    ccipdata.CommitStoreReport{},
 				createdAt: time.Now().Add(-5 * time.Minute),
@@ -127,15 +127,15 @@ func Test_inflightCommitReportsContainer_expire(t *testing.T) {
 				createdAt: time.Now().Add(-10 * time.Second),
 			},
 		},
-		inFlightPriceUpdates: []InflightPriceUpdate{
+		inFlightPriceUpdates: []inflightPriceUpdate{
 			{
 				gasPrices:     []ccipdata.GasPrice{{DestChainSelector: 100, Value: big.NewInt(0)}},
-				createdAt:     time.Now().Add(-PRICE_EXPIRY_MULTIPLIER * time.Minute),
+				createdAt:     time.Now().Add(-priceExpiryMultiplier * time.Minute),
 				epochAndRound: ccipcalc.MergeEpochAndRound(10, 5),
 			},
 			{
 				gasPrices:     []ccipdata.GasPrice{{DestChainSelector: 200, Value: big.NewInt(0)}},
-				createdAt:     time.Now().Add(-PRICE_EXPIRY_MULTIPLIER * time.Second),
+				createdAt:     time.Now().Add(-priceExpiryMultiplier * time.Second),
 				epochAndRound: ccipcalc.MergeEpochAndRound(20, 5),
 			},
 		},

--- a/core/services/ocr2/plugins/ccip/commitplugin/plugin_test.go
+++ b/core/services/ocr2/plugins/ccip/commitplugin/plugin_test.go
@@ -1,4 +1,4 @@
-package ccip
+package commitplugin
 
 import (
 	"context"
@@ -68,7 +68,7 @@ func TestGetCommitPluginFilterNamesFromSpec(t *testing.T) {
 				}
 			}
 
-			err := UnregisterCommitPluginLpFilters(context.Background(), lggr, job.Job{OCR2OracleSpec: tc.spec}, prMock, chainSet)
+			err := UnregisterLpFilters(context.Background(), lggr, job.Job{OCR2OracleSpec: tc.spec}, prMock, chainSet)
 			if tc.expectingErr {
 				assert.Error(t, err)
 			} else {

--- a/core/services/ocr2/plugins/ccip/executionplugin/batching.go
+++ b/core/services/ocr2/plugins/ccip/executionplugin/batching.go
@@ -1,10 +1,11 @@
-package ccip
+package executionplugin
 
 import (
 	"context"
 
 	"github.com/pkg/errors"
 
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/abihelpers"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipdata"
@@ -37,12 +38,11 @@ func getProofData(
 	return sendReqs, leaves, tree, nil
 }
 
-func buildExecutionReportForMessages(
+func buildReportFromMessages(
 	msgsInRoot []ccipdata.Event[internal.EVM2EVMMessage],
-	leaves [][32]byte,
 	tree *merklemulti.Tree[[32]byte],
 	commitInterval ccipdata.CommitStoreInterval,
-	observedMessages []ObservedMessage,
+	observedMessages []ccip.ObservedMessage,
 ) (ccipdata.ExecReport, error) {
 	innerIdxs := make([]int, 0, len(observedMessages))
 	var messages []internal.EVM2EVMMessage
@@ -74,7 +74,7 @@ func buildExecutionReportForMessages(
 
 // Validates the given message observations do not exceed the committed sequence numbers
 // in the commitStoreReader.
-func validateSeqNumbers(serviceCtx context.Context, commitStore ccipdata.CommitStoreReader, observedMessages []ObservedMessage) error {
+func validateSeqNumbers(serviceCtx context.Context, commitStore ccipdata.CommitStoreReader, observedMessages []ccip.ObservedMessage) error {
 	nextMin, err := commitStore.GetExpectedNextSequenceNumber(serviceCtx)
 	if err != nil {
 		return err

--- a/core/services/ocr2/plugins/ccip/executionplugin/factory.go
+++ b/core/services/ocr2/plugins/ccip/executionplugin/factory.go
@@ -1,0 +1,102 @@
+package executionplugin
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+
+	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/custom_token_pool"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/cache"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipdata"
+)
+
+type Factory struct {
+	// Config derived from job specs and does not change between instances.
+	config StaticConfig
+
+	destPriceRegReader ccipdata.PriceRegistryReader
+	destPriceRegAddr   common.Address
+	readersMu          *sync.Mutex
+}
+
+func newFactory(config StaticConfig) *Factory {
+	return &Factory{
+		config:    config,
+		readersMu: &sync.Mutex{},
+	}
+}
+
+func (rf *Factory) UpdateDynamicReaders(newPriceRegAddr common.Address) error {
+	rf.readersMu.Lock()
+	defer rf.readersMu.Unlock()
+	// TODO: Investigate use of Close() to cleanup.
+	// TODO: a true price registry upgrade on an existing lane may want some kind of start block in its config? Right now we
+	// essentially assume that plugins don't care about historical price reg logs.
+	if rf.destPriceRegAddr == newPriceRegAddr {
+		// No-op
+		return nil
+	}
+	// Close old reader (if present) and open new reader if address changed.
+	if rf.destPriceRegReader != nil {
+		if err := rf.destPriceRegReader.Close(); err != nil {
+			return err
+		}
+	}
+	destPriceRegistryReader, err := ccipdata.NewPriceRegistryReader(rf.config.lggr, newPriceRegAddr, rf.config.destLP, rf.config.destClient)
+	if err != nil {
+		return err
+	}
+	rf.destPriceRegReader = destPriceRegistryReader
+	rf.destPriceRegAddr = newPriceRegAddr
+	return nil
+}
+
+func (rf *Factory) NewReportingPlugin(config types.ReportingPluginConfig) (types.ReportingPlugin, types.ReportingPluginInfo, error) {
+	destPriceRegistry, destWrappedNative, err := rf.config.offRampReader.ChangeConfig(config.OnchainConfig, config.OffchainConfig)
+	if err != nil {
+		return nil, types.ReportingPluginInfo{}, err
+	}
+	// Open dynamic readers
+	err = rf.UpdateDynamicReaders(destPriceRegistry)
+	if err != nil {
+		return nil, types.ReportingPluginInfo{}, err
+	}
+
+	offchainConfig := rf.config.offRampReader.OffchainConfig()
+	cachedSourceFeeTokens := cache.NewCachedFeeTokens(rf.config.sourceLP, rf.config.sourcePriceRegistry, int64(offchainConfig.SourceFinalityDepth))
+	cachedDestTokens := cache.NewCachedSupportedTokens(rf.config.destLP, rf.config.offRampReader, rf.destPriceRegReader, int64(offchainConfig.DestOptimisticConfirmations))
+
+	cachedTokenPools := cache.NewTokenPools(rf.config.lggr, rf.config.destLP, rf.config.offRampReader, int64(offchainConfig.DestOptimisticConfirmations), 5)
+
+	return &ExecutionReportingPlugin{
+			config:                rf.config,
+			F:                     config.F,
+			lggr:                  rf.config.lggr.Named("ExecutionReportingPlugin"),
+			snoozedRoots:          cache.NewSnoozedRoots(rf.config.offRampReader.OnchainConfig().PermissionLessExecutionThresholdSeconds, offchainConfig.RootSnoozeTime.Duration()),
+			inflightReports:       newInflightExecReportsContainer(offchainConfig.InflightCacheExpiry.Duration()),
+			destPriceRegistry:     rf.destPriceRegReader,
+			destWrappedNative:     destWrappedNative,
+			onchainConfig:         rf.config.offRampReader.OnchainConfig(),
+			offchainConfig:        offchainConfig,
+			cachedDestTokens:      cachedDestTokens,
+			cachedSourceFeeTokens: cachedSourceFeeTokens,
+			cachedTokenPools:      cachedTokenPools,
+			customTokenPoolFactory: func(ctx context.Context, poolAddress common.Address, contractBackend bind.ContractBackend) (custom_token_pool.CustomTokenPoolInterface, error) {
+				return custom_token_pool.NewCustomTokenPool(poolAddress, contractBackend)
+			},
+			gasPriceEstimator: rf.config.offRampReader.GasPriceEstimator(),
+		}, types.ReportingPluginInfo{
+			Name: "CCIPExecution",
+			// Setting this to false saves on calldata since OffRamp doesn't require agreement between NOPs
+			// (OffRamp is only able to execute committed messages).
+			UniqueReports: false,
+			Limits: types.ReportingPluginLimits{
+				MaxObservationLength: ccip.MaxObservationLength,
+				MaxReportLength:      MaxExecutionReportLength,
+			},
+		}, nil
+}

--- a/core/services/ocr2/plugins/ccip/executionplugin/gashelpers.go
+++ b/core/services/ocr2/plugins/ccip/executionplugin/gashelpers.go
@@ -1,4 +1,4 @@
-package ccip
+package executionplugin
 
 import (
 	"math"

--- a/core/services/ocr2/plugins/ccip/executionplugin/gashelpers_test.go
+++ b/core/services/ocr2/plugins/ccip/executionplugin/gashelpers_test.go
@@ -1,4 +1,4 @@
-package ccip
+package executionplugin
 
 import (
 	"math/big"

--- a/core/services/ocr2/plugins/ccip/executionplugin/inflight_test.go
+++ b/core/services/ocr2/plugins/ccip/executionplugin/inflight_test.go
@@ -1,4 +1,4 @@
-package ccip
+package executionplugin
 
 import (
 	"testing"

--- a/core/services/ocr2/plugins/ccip/executionplugin/plugin_test.go
+++ b/core/services/ocr2/plugins/ccip/executionplugin/plugin_test.go
@@ -1,4 +1,4 @@
-package ccip
+package executionplugin
 
 import (
 	"context"
@@ -48,7 +48,7 @@ func TestGetExecutionPluginFilterNamesFromSpec(t *testing.T) {
 	for _, tc := range testCases {
 		chainSet := &mocks.LegacyChainContainer{}
 		t.Run(tc.description, func(t *testing.T) {
-			err := UnregisterExecPluginLpFilters(context.Background(), logger.TestLogger(t), job.Job{OCR2OracleSpec: tc.spec}, chainSet)
+			err := UnregisterLpFilters(context.Background(), logger.TestLogger(t), job.Job{OCR2OracleSpec: tc.spec}, chainSet)
 			if tc.expectingErr {
 				assert.Error(t, err)
 			} else {

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/logpoller.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/logpoller.go
@@ -9,7 +9,6 @@ import (
 
 	evmclient "github.com/smartcontractkit/chainlink/v2/core/chains/evm/client"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
-	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/commit_store"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/evm_2_evm_offramp"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/evm_2_evm_onramp"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/price_registry"
@@ -106,21 +105,6 @@ func (c *LogPollerReader) loadOffRamp(addr common.Address) (*evm_2_evm_offramp.E
 
 	c.dependencyCache.Store(addr, offRamp)
 	return offRamp, nil
-}
-
-func (c *LogPollerReader) loadCommitStore(addr common.Address) (*commit_store.CommitStoreFilterer, error) {
-	commitStore, exists := loadCachedDependency[*commit_store.CommitStoreFilterer](&c.dependencyCache, addr)
-	if exists {
-		return commitStore, nil
-	}
-
-	commitStore, err := commit_store.NewCommitStoreFilterer(addr, c.client)
-	if err != nil {
-		return nil, err
-	}
-
-	c.dependencyCache.Store(addr, commitStore)
-	return commitStore, nil
 }
 
 func loadCachedDependency[T any](cache *sync.Map, addr common.Address) (T, bool) {

--- a/core/services/ocr2/plugins/ccip/internal/oraclelib/backfilled_oracle.go
+++ b/core/services/ocr2/plugins/ccip/internal/oraclelib/backfilled_oracle.go
@@ -13,6 +13,11 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 )
 
+type BackfillArgs struct {
+	SourceLP, DestLP                 logpoller.LogPoller
+	SourceStartBlock, DestStartBlock int64
+}
+
 type BackfilledOracle struct {
 	srcStartBlock, dstStartBlock int64
 	oracleStarted                atomic.Bool

--- a/core/services/ocr2/plugins/ccip/metrics.go
+++ b/core/services/ocr2/plugins/ccip/metrics.go
@@ -12,11 +12,11 @@ import (
 type skipReason string
 
 const (
-	// reasonNotBlessed describes when a report is skipped due to not being blessed.
-	reasonNotBlessed skipReason = "not blessed"
+	// ReasonNotBlessed describes when a report is skipped due to not being blessed.
+	ReasonNotBlessed skipReason = "not blessed"
 
-	// reasonAllExecuted describes when a report is skipped due to messages being all executed.
-	reasonAllExecuted skipReason = "all executed"
+	// ReasonAllExecuted describes when a report is skipped due to messages being all executed.
+	ReasonAllExecuted skipReason = "all executed"
 )
 
 var (
@@ -64,25 +64,25 @@ func measureExecPluginDuration(histogram *prometheus.HistogramVec, timestamp typ
 		Observe(float64(duration))
 }
 
-func measureObservationBuildDuration(timestamp types.ReportTimestamp, duration time.Duration) {
+func MeasureObservationBuildDuration(timestamp types.ReportTimestamp, duration time.Duration) {
 	measureExecPluginDuration(execPluginObservationBuildDuration, timestamp, duration)
 }
 
-func measureBatchBuildDuration(timestamp types.ReportTimestamp, duration time.Duration) {
+func MeasureBatchBuildDuration(timestamp types.ReportTimestamp, duration time.Duration) {
 	measureExecPluginDuration(execPluginBatchBuildDuration, timestamp, duration)
 }
 
-func measureReportsIterationDuration(timestamp types.ReportTimestamp, duration time.Duration) {
+func MeasureReportsIterationDuration(timestamp types.ReportTimestamp, duration time.Duration) {
 	measureExecPluginDuration(execPluginReportsIterationDuration, timestamp, duration)
 }
 
-func measureNumberOfReportsProcessed(timestamp types.ReportTimestamp, count int) {
+func MeasureNumberOfReportsProcessed(timestamp types.ReportTimestamp, count int) {
 	execPluginReportsCount.
 		WithLabelValues(timestampToLabels(timestamp)...).
 		Set(float64(count))
 }
 
-func incSkippedRequests(reason skipReason) {
+func IncSkippedRequests(reason skipReason) {
 	metricReportSkipped.WithLabelValues(string(reason)).Inc()
 }
 
@@ -92,6 +92,7 @@ func timestampToLabels(t types.ReportTimestamp) []string {
 
 // ChainName returns the name of the EVM network based on its chainID
 func ChainName(chainID int64) string {
+	// TODO: use a centralized config for the chains
 	switch chainID {
 	case 1:
 		return "ethereum-mainnet"

--- a/core/services/ocr2/plugins/ccip/observations.go
+++ b/core/services/ocr2/plugins/ccip/observations.go
@@ -60,10 +60,10 @@ func (o ExecutionObservation) Marshal() ([]byte, error) {
 	return json.Marshal(&o)
 }
 
-// getParsableObservations checks the given observations for formatting and value errors.
+// GetParsableObservations checks the given observations for formatting and value errors.
 // It returns all valid observations, potentially being an empty list. It will log
 // malformed observations but never error.
-func getParsableObservations[O CommitObservation | ExecutionObservation](l logger.Logger, observations []types.AttributedObservation) []O {
+func GetParsableObservations[O CommitObservation | ExecutionObservation](l logger.Logger, observations []types.AttributedObservation) []O {
 	var parseableObservations []O
 	for _, ao := range observations {
 		if len(ao.Observation) == 0 {

--- a/core/services/ocr2/plugins/ccip/observations_test.go
+++ b/core/services/ocr2/plugins/ccip/observations_test.go
@@ -19,7 +19,7 @@ func TestObservationFilter(t *testing.T) {
 	obs1 := CommitObservation{Interval: ccipdata.CommitStoreInterval{Min: 1, Max: 10}}
 	b1, err := obs1.Marshal()
 	require.NoError(t, err)
-	nonEmpty := getParsableObservations[CommitObservation](lggr, []types.AttributedObservation{{Observation: b1}, {Observation: []byte{}}})
+	nonEmpty := GetParsableObservations[CommitObservation](lggr, []types.AttributedObservation{{Observation: b1}, {Observation: []byte{}}})
 	require.Equal(t, 1, len(nonEmpty))
 	assert.Equal(t, nonEmpty[0].Interval, obs1.Interval)
 }
@@ -40,7 +40,7 @@ func TestExecutionObservationJsonDeserialization(t *testing.T) {
 		}
 	}`
 
-	observations := getParsableObservations[ExecutionObservation](logger.TestLogger(t), []types.AttributedObservation{{Observation: []byte(json)}})
+	observations := GetParsableObservations[ExecutionObservation](logger.TestLogger(t), []types.AttributedObservation{{Observation: []byte(json)}})
 	assert.Equal(t, 1, len(observations))
 	assert.Equal(t, 2, len(observations[0].Messages))
 	assert.Equal(t, expectedObservation, observations[0])

--- a/core/services/ocr2/plugins/ccip/vars.go
+++ b/core/services/ocr2/plugins/ccip/vars.go
@@ -5,10 +5,7 @@ import (
 )
 
 const (
-	MaxQueryLength       = 0       // empty for both plugins
 	MaxObservationLength = 250_000 // plugins's Observation should make sure to cap to this limit
-	CommitPluginLabel    = "commit"
-	ExecPluginLabel      = "exec"
 )
 
 var ErrCommitStoreIsDown = errors.New("commitStoreReader is down")

--- a/core/services/relay/evm/ccip.go
+++ b/core/services/relay/evm/ccip.go
@@ -7,8 +7,9 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
-	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/commitplugin"
 	ccipconfig "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/config"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/executionplugin"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pg"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/types"
 
@@ -41,7 +42,7 @@ func NewCCIPCommitProvider(lggr logger.Logger, chainSet evm.Chain, rargs relayty
 	if err != nil {
 		return nil, err
 	}
-	fn, err := ccip.CommitReportToEthTxMeta(typ, ver)
+	fn, err := commitplugin.ReportToEthTxMeta(typ, ver)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +79,7 @@ func NewCCIPExecutionProvider(lggr logger.Logger, chainSet evm.Chain, rargs rela
 	if err != nil {
 		return nil, err
 	}
-	fn, err := ccip.ExecReportToEthTxMeta(typ, ver)
+	fn, err := executionplugin.ReportToEthTxMeta(typ, ver)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Extras:
    - un-export several entities
    - code style improvements
    - decouple some plugin libs (some func is declared under one plugin but used in another)
    - re-order methods / functions
    - delete unused vars
