### PR TITLE
CCIP-1142 - Add back failing asserts

### DIFF
--- a/core/services/job/job_orm_test.go
+++ b/core/services/job/job_orm_test.go
@@ -1474,6 +1474,7 @@ func Test_FindPipelineRunIDsByJobID(t *testing.T) {
 		runIDs, err := orm.FindPipelineRunIDsByJobID(jobs[3].ID, 95, 10)
 		require.NoError(t, err)
 		require.Len(t, runIDs, 10)
+		assert.Equal(t, int64(4*(len(jobs)-1)), runIDs[3]-runIDs[7])
 	})
 
 	// Internally these queries are batched by 1000, this tests case requiring concatenation
@@ -1482,6 +1483,7 @@ func Test_FindPipelineRunIDsByJobID(t *testing.T) {
 		runIDs, err := orm.FindPipelineRunIDsByJobID(jobs[3].ID, 95, 100)
 		require.NoError(t, err)
 		require.Len(t, runIDs, 100)
+		assert.Equal(t, int64(67*(len(jobs)-1)), runIDs[12]-runIDs[79])
 	})
 
 	for i := 0; i < 2100; i++ {
@@ -1495,6 +1497,7 @@ func Test_FindPipelineRunIDsByJobID(t *testing.T) {
 		runIDs, err := orm.FindPipelineRunIDsByJobID(jobs[3].ID, 0, 25)
 		require.NoError(t, err)
 		require.Len(t, runIDs, 25)
+		assert.Equal(t, int64(16*(len(jobs)-1)), runIDs[7]-runIDs[23])
 	})
 
 	// Same as previous, but where there are fewer matching jobs than the limit
@@ -1502,6 +1505,7 @@ func Test_FindPipelineRunIDsByJobID(t *testing.T) {
 		runIDs, err := orm.FindPipelineRunIDsByJobID(jobs[3].ID, 143, 190)
 		require.NoError(t, err)
 		require.Len(t, runIDs, 107)
+		assert.Equal(t, int64(16*(len(jobs)-1)), runIDs[7]-runIDs[23])
 	})
 }
 


### PR DESCRIPTION
## Motivation

During the main repo merge, we removed a couple of assertions from job_orm_test.go

We need to align job_orm_test.go with the version in the Chainlink repository . There are probably two ways of doing it:
- Align with the version in the chainlink repo and bring back these assertions; look at what might be causing test failures on CI. There might be some tests misconfig (ccip repository)
- Come up with some alternative approach and suggest another way to verify these tests (chainlink repository)

## Solution

Adding back the problematic asserts seems to cause no error anymore.
