### PR TITLE
CommitStoreV1.2 validation fix and RMN comments

### DIFF
--- a/contracts/src/v0.8/ccip/ARM.sol
+++ b/contracts/src/v0.8/ccip/ARM.sol
@@ -6,6 +6,7 @@ import {IARM} from "./interfaces/IARM.sol";
 
 import {OwnerIsCreator} from "./../shared/access/OwnerIsCreator.sol";
 
+/// @dev This contract is owned by RMN, if changes required, please notify RMN.
 contract ARM is IARM, OwnerIsCreator, ITypeAndVersion {
   // STATIC CONFIG
   // solhint-disable-next-line chainlink-solidity/all-caps-constant-storage-variables

--- a/contracts/src/v0.8/ccip/ARM.sol
+++ b/contracts/src/v0.8/ccip/ARM.sol
@@ -6,7 +6,7 @@ import {IARM} from "./interfaces/IARM.sol";
 
 import {OwnerIsCreator} from "./../shared/access/OwnerIsCreator.sol";
 
-/// @dev This contract is owned by RMN, if changes required, please notify RMN.
+/// @dev This contract is owned by RMN, if changing, please notify RMN.
 contract ARM is IARM, OwnerIsCreator, ITypeAndVersion {
   // STATIC CONFIG
   // solhint-disable-next-line chainlink-solidity/all-caps-constant-storage-variables

--- a/contracts/src/v0.8/ccip/ARM.sol
+++ b/contracts/src/v0.8/ccip/ARM.sol
@@ -6,7 +6,7 @@ import {IARM} from "./interfaces/IARM.sol";
 
 import {OwnerIsCreator} from "./../shared/access/OwnerIsCreator.sol";
 
-/// @dev This contract is owned by RMN, if changing, please notify RMN.
+/// @dev This contract is owned by RMN, if changing, please notify the RMN maintainers.
 contract ARM is IARM, OwnerIsCreator, ITypeAndVersion {
   // STATIC CONFIG
   // solhint-disable-next-line chainlink-solidity/all-caps-constant-storage-variables

--- a/contracts/src/v0.8/ccip/CommitStore.sol
+++ b/contracts/src/v0.8/ccip/CommitStore.sol
@@ -21,11 +21,13 @@ contract CommitStore is ICommitStore, ITypeAndVersion, OCR2Base {
 
   event Paused(address account);
   event Unpaused(address account);
+  /// @dev RMN depends on this event, if changing, please notify RMN.
   event ReportAccepted(CommitReport report);
   event ConfigSet(StaticConfig staticConfig, DynamicConfig dynamicConfig);
   event RootRemoved(bytes32 root);
 
   /// @notice Static commit store config
+  /// @dev RMN depends on this struct, if changing, please notify RMN.
   struct StaticConfig {
     uint64 chainSelector; // ───────╮  Destination chainSelector
     uint64 sourceChainSelector; // ─╯  Source chainSelector
@@ -45,6 +47,7 @@ contract CommitStore is ICommitStore, ITypeAndVersion, OCR2Base {
   }
 
   /// @notice Report that is committed by the observing DON at the committing phase
+  /// @dev RMN depends on this struct, if changing, please notify RMN.
   struct CommitReport {
     Internal.PriceUpdates priceUpdates;
     Interval interval;
@@ -222,6 +225,7 @@ contract CommitStore is ICommitStore, ITypeAndVersion, OCR2Base {
   // ================================================================
 
   /// @notice Returns the static commit store config.
+  /// @dev RMN depends on this function, if changing, please notify RMN.
   /// @return the configuration.
   function getStaticConfig() external view returns (StaticConfig memory) {
     return

--- a/contracts/src/v0.8/ccip/CommitStore.sol
+++ b/contracts/src/v0.8/ccip/CommitStore.sol
@@ -41,6 +41,7 @@ contract CommitStore is ICommitStore, ITypeAndVersion, OCR2Base {
   }
 
   /// @notice a sequenceNumber interval
+  /// @dev RMN depends on this struct, if changing, please notify RMN.
   struct Interval {
     uint64 min; // ───╮ Minimum sequence number, inclusive
     uint64 max; // ───╯ Maximum sequence number, inclusive

--- a/contracts/src/v0.8/ccip/CommitStore.sol
+++ b/contracts/src/v0.8/ccip/CommitStore.sol
@@ -21,13 +21,13 @@ contract CommitStore is ICommitStore, ITypeAndVersion, OCR2Base {
 
   event Paused(address account);
   event Unpaused(address account);
-  /// @dev RMN depends on this event, if changing, please notify RMN.
+  /// @dev RMN depends on this event, if changing, please notify the RMN maintainers.
   event ReportAccepted(CommitReport report);
   event ConfigSet(StaticConfig staticConfig, DynamicConfig dynamicConfig);
   event RootRemoved(bytes32 root);
 
   /// @notice Static commit store config
-  /// @dev RMN depends on this struct, if changing, please notify RMN.
+  /// @dev RMN depends on this struct, if changing, please notify the RMN maintainers.
   struct StaticConfig {
     uint64 chainSelector; // ───────╮  Destination chainSelector
     uint64 sourceChainSelector; // ─╯  Source chainSelector
@@ -41,14 +41,14 @@ contract CommitStore is ICommitStore, ITypeAndVersion, OCR2Base {
   }
 
   /// @notice a sequenceNumber interval
-  /// @dev RMN depends on this struct, if changing, please notify RMN.
+  /// @dev RMN depends on this struct, if changing, please notify the RMN maintainers.
   struct Interval {
     uint64 min; // ───╮ Minimum sequence number, inclusive
     uint64 max; // ───╯ Maximum sequence number, inclusive
   }
 
   /// @notice Report that is committed by the observing DON at the committing phase
-  /// @dev RMN depends on this struct, if changing, please notify RMN.
+  /// @dev RMN depends on this struct, if changing, please notify the RMN maintainers.
   struct CommitReport {
     Internal.PriceUpdates priceUpdates;
     Interval interval;
@@ -226,7 +226,7 @@ contract CommitStore is ICommitStore, ITypeAndVersion, OCR2Base {
   // ================================================================
 
   /// @notice Returns the static commit store config.
-  /// @dev RMN depends on this function, if changing, please notify RMN.
+  /// @dev RMN depends on this function, if changing, please notify the RMN maintainers.
   /// @return the configuration.
   function getStaticConfig() external view returns (StaticConfig memory) {
     return

--- a/contracts/src/v0.8/ccip/libraries/Client.sol
+++ b/contracts/src/v0.8/ccip/libraries/Client.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 // End consumer library.
 library Client {
-  /// @dev RMN depends on this struct, if changing, please notify RMN.
+  /// @dev RMN depends on this struct, if changing, please notify the RMN maintainers.
   struct EVMTokenAmount {
     address token; // token address on the local chain.
     uint256 amount; // Amount of tokens.

--- a/contracts/src/v0.8/ccip/libraries/Client.sol
+++ b/contracts/src/v0.8/ccip/libraries/Client.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 // End consumer library.
 library Client {
+  /// @dev RMN depends on this struct, if changing, please notify RMN.
   struct EVMTokenAmount {
     address token; // token address on the local chain.
     uint256 amount; // Amount of tokens.

--- a/contracts/src/v0.8/ccip/libraries/Internal.sol
+++ b/contracts/src/v0.8/ccip/libraries/Internal.sol
@@ -45,6 +45,8 @@ library Internal {
     address pool; // The token pool address
   }
 
+  /// @notice Report that is submitted by the execution DON at the execution phase.
+  /// @dev RMN depends on this struct, if changing, please notify RMN.
   struct ExecutionReport {
     EVM2EVMMessage[] messages;
     // Contains a bytes array for each message, each inner bytes array contains bytes per transferred token
@@ -53,7 +55,8 @@ library Internal {
     uint256 proofFlagBits;
   }
 
-  // @notice The cross chain message that gets committed to EVM chains
+  /// @notice The cross chain message that gets committed to EVM chains.
+  /// @dev RMN depends on this struct, if changing, please notify RMN.
   struct EVM2EVMMessage {
     uint64 sourceChainSelector; // ─────────╮ the chain selector of the source chain, note: not chainId
     address sender; // ─────────────────────╯ sender address on the source chain
@@ -129,6 +132,7 @@ library Internal {
   /// IN_PROGRESS currently being executed, used a replay protection
   /// SUCCESS successfully executed. End state
   /// FAILURE unsuccessfully executed, manual execution is now enabled.
+  /// @dev RMN depends on this enum, if changing, please notify RMN.
   enum MessageExecutionState {
     UNTOUCHED,
     IN_PROGRESS,

--- a/contracts/src/v0.8/ccip/libraries/Internal.sol
+++ b/contracts/src/v0.8/ccip/libraries/Internal.sol
@@ -16,21 +16,21 @@ library Internal {
   uint16 internal constant MAX_RET_BYTES = 4 + 4 * 32;
 
   /// @notice A collection of token price and gas price updates.
-  /// @dev RMN depends on this struct, if changing, please notify RMN.
+  /// @dev RMN depends on this struct, if changing, please notify the RMN maintainers.
   struct PriceUpdates {
     TokenPriceUpdate[] tokenPriceUpdates;
     GasPriceUpdate[] gasPriceUpdates;
   }
 
   /// @notice Token price in USD.
-  /// @dev RMN depends on this struct, if changing, please notify RMN.
+  /// @dev RMN depends on this struct, if changing, please notify the RMN maintainers.
   struct TokenPriceUpdate {
     address sourceToken; // Source token
     uint224 usdPerToken; // 1e18 USD per smallest unit of token
   }
 
   /// @notice Gas price for a given chain in USD, its value may contain tightly packed fields.
-  /// @dev RMN depends on this struct, if changing, please notify RMN.
+  /// @dev RMN depends on this struct, if changing, please notify the RMN maintainers.
   struct GasPriceUpdate {
     uint64 destChainSelector; // Destination chain selector
     uint224 usdPerUnitGas; // 1e18 USD per smallest unit (e.g. wei) of destination chain gas
@@ -53,7 +53,7 @@ library Internal {
   }
 
   /// @notice Report that is submitted by the execution DON at the execution phase.
-  /// @dev RMN depends on this struct, if changing, please notify RMN.
+  /// @dev RMN depends on this struct, if changing, please notify the RMN maintainers.
   struct ExecutionReport {
     EVM2EVMMessage[] messages;
     // Contains a bytes array for each message, each inner bytes array contains bytes per transferred token
@@ -63,7 +63,7 @@ library Internal {
   }
 
   /// @notice The cross chain message that gets committed to EVM chains.
-  /// @dev RMN depends on this struct, if changing, please notify RMN.
+  /// @dev RMN depends on this struct, if changing, please notify the RMN maintainers.
   struct EVM2EVMMessage {
     uint64 sourceChainSelector; // ─────────╮ the chain selector of the source chain, note: not chainId
     address sender; // ─────────────────────╯ sender address on the source chain
@@ -108,7 +108,7 @@ library Internal {
 
   function _hash(EVM2EVMMessage memory original, bytes32 metadataHash) internal pure returns (bytes32) {
     // Fixed-size message fields are included in nested hash to reduce stack pressure.
-    // This hashing scheme is also used by RMN. If changing it, please notify RMN.
+    // This hashing scheme is also used by RMN. If changing it, please notify the RMN maintainers.
     return
       keccak256(
         abi.encode(
@@ -139,7 +139,7 @@ library Internal {
   /// IN_PROGRESS currently being executed, used a replay protection
   /// SUCCESS successfully executed. End state
   /// FAILURE unsuccessfully executed, manual execution is now enabled.
-  /// @dev RMN depends on this enum, if changing, please notify RMN.
+  /// @dev RMN depends on this enum, if changing, please notify the RMN maintainers.
   enum MessageExecutionState {
     UNTOUCHED,
     IN_PROGRESS,

--- a/contracts/src/v0.8/ccip/libraries/Internal.sol
+++ b/contracts/src/v0.8/ccip/libraries/Internal.sol
@@ -15,21 +15,28 @@ library Internal {
   // repeated out-of-gas scenarios.
   uint16 internal constant MAX_RET_BYTES = 4 + 4 * 32;
 
+  /// @notice A collection of token price and gas price updates.
+  /// @dev RMN depends on this struct, if changing, please notify RMN.
   struct PriceUpdates {
     TokenPriceUpdate[] tokenPriceUpdates;
     GasPriceUpdate[] gasPriceUpdates;
   }
 
+  /// @notice Token price in USD.
+  /// @dev RMN depends on this struct, if changing, please notify RMN.
   struct TokenPriceUpdate {
     address sourceToken; // Source token
     uint224 usdPerToken; // 1e18 USD per smallest unit of token
   }
 
+  /// @notice Gas price for a given chain in USD, its value may contain tightly packed fields.
+  /// @dev RMN depends on this struct, if changing, please notify RMN.
   struct GasPriceUpdate {
     uint64 destChainSelector; // Destination chain selector
     uint224 usdPerUnitGas; // 1e18 USD per smallest unit (e.g. wei) of destination chain gas
   }
 
+  /// @notice A timestamped uint224 value that can contain several tightly packed fields.
   struct TimestampedPackedUint224 {
     uint224 value; // ───────╮ Value in uint224, packed.
     uint32 timestamp; // ────╯ Timestamp of the most recent price update.
@@ -37,7 +44,7 @@ library Internal {
 
   /// @dev Gas price is stored in 112-bit unsigned int. uint224 can pack 2 prices.
   /// When packing L1 and L2 gas prices, L1 gas price is left-shifted to the higher-order bits.
-  /// Using uint8, which is strictly lower than 1st shift operand, to avoid shift operand type warning.
+  /// Using uint8 type, which cannot be higher than other bit shift operands, to avoid shift operand type warning.
   uint8 public constant GAS_PRICE_BITS = 112;
 
   struct PoolUpdate {

--- a/contracts/src/v0.8/ccip/offRamp/EVM2EVMOffRamp.sol
+++ b/contracts/src/v0.8/ccip/offRamp/EVM2EVMOffRamp.sol
@@ -63,10 +63,11 @@ contract EVM2EVMOffRamp is IAny2EVMOffRamp, AggregateRateLimiter, ITypeAndVersio
 
   event PoolAdded(address token, address pool);
   event PoolRemoved(address token, address pool);
-  // this event is needed for Atlas; if their structs/signature changes, we must update the ABIs there
+  /// @dev Atlas depends on this event, if changing, please notify Atlas.
   event ConfigSet(StaticConfig staticConfig, DynamicConfig dynamicConfig);
   event SkippedIncorrectNonce(uint64 indexed nonce, address indexed sender);
   event SkippedSenderWithPreviousRampMessageInflight(uint64 indexed nonce, address indexed sender);
+  /// @dev RMN depends on this event, if changing, please notify RMN.
   event ExecutionStateChanged(
     uint64 indexed sequenceNumber,
     bytes32 indexed messageId,
@@ -75,6 +76,7 @@ contract EVM2EVMOffRamp is IAny2EVMOffRamp, AggregateRateLimiter, ITypeAndVersio
   );
 
   /// @notice Static offRamp config
+  /// @dev RMN depends on this struct, if changing, please notify RMN.
   struct StaticConfig {
     address commitStore; // ────────╮  CommitStore address on the destination chain
     uint64 chainSelector; // ───────╯  Destination chainSelector
@@ -449,6 +451,7 @@ contract EVM2EVMOffRamp is IAny2EVMOffRamp, AggregateRateLimiter, ITypeAndVersio
 
   /// @notice Returns the static config.
   /// @dev This function will always return the same struct as the contents is static and can never change.
+  /// RMN depends on this function, if changing, please notify RMN.
   function getStaticConfig() external view returns (StaticConfig memory) {
     return
       StaticConfig({

--- a/contracts/src/v0.8/ccip/offRamp/EVM2EVMOffRamp.sol
+++ b/contracts/src/v0.8/ccip/offRamp/EVM2EVMOffRamp.sol
@@ -67,7 +67,7 @@ contract EVM2EVMOffRamp is IAny2EVMOffRamp, AggregateRateLimiter, ITypeAndVersio
   event ConfigSet(StaticConfig staticConfig, DynamicConfig dynamicConfig);
   event SkippedIncorrectNonce(uint64 indexed nonce, address indexed sender);
   event SkippedSenderWithPreviousRampMessageInflight(uint64 indexed nonce, address indexed sender);
-  /// @dev RMN depends on this event, if changing, please notify RMN.
+  /// @dev RMN depends on this event, if changing, please notify the RMN maintainers.
   event ExecutionStateChanged(
     uint64 indexed sequenceNumber,
     bytes32 indexed messageId,
@@ -76,7 +76,7 @@ contract EVM2EVMOffRamp is IAny2EVMOffRamp, AggregateRateLimiter, ITypeAndVersio
   );
 
   /// @notice Static offRamp config
-  /// @dev RMN depends on this struct, if changing, please notify RMN.
+  /// @dev RMN depends on this struct, if changing, please notify the RMN maintainers.
   struct StaticConfig {
     address commitStore; // ────────╮  CommitStore address on the destination chain
     uint64 chainSelector; // ───────╯  Destination chainSelector
@@ -451,7 +451,7 @@ contract EVM2EVMOffRamp is IAny2EVMOffRamp, AggregateRateLimiter, ITypeAndVersio
 
   /// @notice Returns the static config.
   /// @dev This function will always return the same struct as the contents is static and can never change.
-  /// RMN depends on this function, if changing, please notify RMN.
+  /// RMN depends on this function, if changing, please notify the RMN maintainers.
   function getStaticConfig() external view returns (StaticConfig memory) {
     return
       StaticConfig({

--- a/contracts/src/v0.8/ccip/onRamp/EVM2EVMOnRamp.sol
+++ b/contracts/src/v0.8/ccip/onRamp/EVM2EVMOnRamp.sol
@@ -61,12 +61,14 @@ contract EVM2EVMOnRamp is IEVM2AnyOnRamp, ILinkAvailable, AggregateRateLimiter, 
   event NopPaid(address indexed nop, uint256 amount);
   event FeeConfigSet(FeeTokenConfigArgs[] feeConfig);
   event TokenTransferFeeConfigSet(TokenTransferFeeConfigArgs[] transferFeeConfig);
+  /// RMN depends on this event, if changing, please notify RMN.
   event CCIPSendRequested(Internal.EVM2EVMMessage message);
   event NopsSet(uint256 nopWeightsTotal, NopAndWeight[] nopsAndWeights);
   event PoolAdded(address token, address pool);
   event PoolRemoved(address token, address pool);
 
   /// @dev Struct that contains the static configuration
+  /// RMN depends on this struct, if changing, please notify RMN.
   struct StaticConfig {
     address linkToken; // ────────╮ Link token address
     uint64 chainSelector; // ─────╯ Source chainSelector
@@ -382,6 +384,7 @@ contract EVM2EVMOnRamp is IEVM2AnyOnRamp, ILinkAvailable, AggregateRateLimiter, 
   // ================================================================
 
   /// @notice Returns the static onRamp config.
+  /// @dev RMN depends on this function, if changing, please notify RMN.
   /// @return the configuration.
   function getStaticConfig() external view returns (StaticConfig memory) {
     return

--- a/contracts/src/v0.8/ccip/onRamp/EVM2EVMOnRamp.sol
+++ b/contracts/src/v0.8/ccip/onRamp/EVM2EVMOnRamp.sol
@@ -61,14 +61,14 @@ contract EVM2EVMOnRamp is IEVM2AnyOnRamp, ILinkAvailable, AggregateRateLimiter, 
   event NopPaid(address indexed nop, uint256 amount);
   event FeeConfigSet(FeeTokenConfigArgs[] feeConfig);
   event TokenTransferFeeConfigSet(TokenTransferFeeConfigArgs[] transferFeeConfig);
-  /// RMN depends on this event, if changing, please notify RMN.
+  /// RMN depends on this event, if changing, please notify the RMN maintainers.
   event CCIPSendRequested(Internal.EVM2EVMMessage message);
   event NopsSet(uint256 nopWeightsTotal, NopAndWeight[] nopsAndWeights);
   event PoolAdded(address token, address pool);
   event PoolRemoved(address token, address pool);
 
   /// @dev Struct that contains the static configuration
-  /// RMN depends on this struct, if changing, please notify RMN.
+  /// RMN depends on this struct, if changing, please notify the RMN maintainers.
   struct StaticConfig {
     address linkToken; // ────────╮ Link token address
     uint64 chainSelector; // ─────╯ Source chainSelector
@@ -384,7 +384,7 @@ contract EVM2EVMOnRamp is IEVM2AnyOnRamp, ILinkAvailable, AggregateRateLimiter, 
   // ================================================================
 
   /// @notice Returns the static onRamp config.
-  /// @dev RMN depends on this function, if changing, please notify RMN.
+  /// @dev RMN depends on this function, if changing, please notify the RMN maintainers.
   /// @return the configuration.
   function getStaticConfig() external view returns (StaticConfig memory) {
     return

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/commit_store_v1_2_0.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/commit_store_v1_2_0.go
@@ -193,6 +193,7 @@ func (c CommitOffchainConfigV1_2_0) Validate() error {
 	if c.InflightCacheExpiry.Duration() == 0 {
 		return errors.New("must set InflightCacheExpiry")
 	}
+	// DAGasPriceDeviationPPB is not validated because it can be 0 on non-rollups
 
 	return nil
 }

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/commit_store_v1_2_0.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/commit_store_v1_2_0.go
@@ -178,9 +178,6 @@ func (c CommitOffchainConfigV1_2_0) Validate() error {
 	if c.GasPriceHeartBeat.Duration() == 0 {
 		return errors.New("must set GasPriceHeartBeat")
 	}
-	if c.DAGasPriceDeviationPPB == 0 {
-		return errors.New("must set DAGasPriceDeviationPPB")
-	}
 	if c.ExecGasPriceDeviationPPB == 0 {
 		return errors.New("must set ExecGasPriceDeviationPPB")
 	}


### PR DESCRIPTION
## Motivation
1. Allow CommitStoreV1.2 to accept 0 `DAGasPriceDeviationPPB`.
2. Make it clear in code on what changes impact RMN to avoid surprises.