### PR TITLE
rename BigIntMedian to BitIntSortedMiddle

### DIFF
--- a/core/services/ocr2/plugins/ccip/commit_reporting_plugin.go
+++ b/core/services/ocr2/plugins/ccip/commit_reporting_plugin.go
@@ -635,7 +635,7 @@ func (r *CommitReportingPlugin) calculatePriceUpdates(observations []CommitObser
 
 	var tokenPriceUpdates []ccipdata.TokenPrice
 	for token, tokenPriceObservations := range priceObservations {
-		medianPrice := ccipcalc.BigIntMedian(tokenPriceObservations)
+		medianPrice := ccipcalc.BigIntSortedMiddle(tokenPriceObservations)
 
 		latestTokenPrice, exists := latestTokenPrices[token]
 		if exists {

--- a/core/services/ocr2/plugins/ccip/internal/ccipcalc/calc.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipcalc/calc.go
@@ -29,8 +29,10 @@ func CalculateUsdPerUnitGas(sourceGasPrice *big.Int, usdPerFeeCoin *big.Int) *bi
 	return tmp.Div(tmp, big.NewInt(1e18))
 }
 
-// BigIntMedian returns the median of the provided numbers. nil is returned if the provided slice is empty.
-func BigIntMedian(vals []*big.Int) *big.Int {
+// BigIntSortedMiddle returns the middle number after sorting the provided numbers. nil is returned if the provided slice is empty.
+// If length of the provided slice is even, the right-hand-side value of the middle 2 numbers is returned.
+// The objective of this function is to always pick within the range of values reported by honest nodes when we have 2f+1 values.
+func BigIntSortedMiddle(vals []*big.Int) *big.Int {
 	if len(vals) == 0 {
 		return nil
 	}

--- a/core/services/ocr2/plugins/ccip/internal/ccipcalc/calc_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipcalc/calc_test.go
@@ -101,7 +101,7 @@ func TestCalculateUsdPerUnitGas(t *testing.T) {
 	}
 }
 
-func TestBigIntMedian(t *testing.T) {
+func TestBigIntSortedMiddle(t *testing.T) {
 	tests := []struct {
 		name string
 		vals []*big.Int
@@ -130,7 +130,7 @@ func TestBigIntMedian(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, BigIntMedian(tt.vals), "BigIntMedian(%v)", tt.vals)
+			assert.Equalf(t, tt.want, BigIntSortedMiddle(tt.vals), "BigIntSortedMiddle(%v)", tt.vals)
 		})
 	}
 }

--- a/core/services/ocr2/plugins/ccip/prices/da_price_estimator.go
+++ b/core/services/ocr2/plugins/ccip/prices/da_price_estimator.go
@@ -100,8 +100,8 @@ func (g DAGasPriceEstimator) Median(gasPrices []GasPrice) (GasPrice, error) {
 		execPrices[i] = execGasPrice
 	}
 
-	daMedian := ccipcalc.BigIntMedian(daPrices)
-	execMedian := ccipcalc.BigIntMedian(execPrices)
+	daMedian := ccipcalc.BigIntSortedMiddle(daPrices)
+	execMedian := ccipcalc.BigIntSortedMiddle(execPrices)
 
 	daMedian = new(big.Int).Lsh(daMedian, g.priceEncodingLength)
 	return new(big.Int).Add(daMedian, execMedian), nil

--- a/core/services/ocr2/plugins/ccip/prices/exec_price_estimator.go
+++ b/core/services/ocr2/plugins/ccip/prices/exec_price_estimator.go
@@ -52,7 +52,7 @@ func (g ExecGasPriceEstimator) Median(gasPrices []GasPrice) (GasPrice, error) {
 		prices = append(prices, p)
 	}
 
-	return ccipcalc.BigIntMedian(prices), nil
+	return ccipcalc.BigIntSortedMiddle(prices), nil
 }
 
 func (g ExecGasPriceEstimator) Deviates(p1 GasPrice, p2 GasPrice) (bool, error) {


### PR DESCRIPTION
## Motivation
Median can be confusing when slice length is even, renaming to SortedMiddle to be explicit per priori discussion.