### PR TITLE
Guard USDC API hanging and rate limits

### DIFF
--- a/core/services/ocr2/plugins/ccip/config/config.go
+++ b/core/services/ocr2/plugins/ccip/config/config.go
@@ -28,11 +28,15 @@ type USDCConfig struct {
 	SourceTokenAddress              common.Address
 	SourceMessageTransmitterAddress common.Address
 	AttestationAPI                  string
+	AttestationAPITimeoutSeconds    int
 }
 
 func (uc *USDCConfig) ValidateUSDCConfig() error {
 	if uc.AttestationAPI == "" {
 		return errors.New("AttestationAPI is required")
+	}
+	if uc.AttestationAPITimeoutSeconds < 0 {
+		return errors.New("AttestationAPITimeoutSeconds must be non-negative")
 	}
 	if uc.SourceTokenAddress == utils.ZeroAddress {
 		return errors.New("SourceTokenAddress is required")

--- a/core/services/ocr2/plugins/ccip/execution_plugin.go
+++ b/core/services/ocr2/plugins/ccip/execution_plugin.go
@@ -196,6 +196,7 @@ func getTokenDataProviders(lggr logger.Logger, pluginConfig ccipconfig.Execution
 				lggr,
 				usdcReader,
 				attestationURI,
+				pluginConfig.USDCConfig.AttestationAPITimeoutSeconds,
 			),
 		)
 	}

--- a/core/services/ocr2/plugins/ccip/execution_reporting_plugin.go
+++ b/core/services/ocr2/plugins/ccip/execution_reporting_plugin.go
@@ -526,21 +526,15 @@ func (r *ExecutionReportingPlugin) buildBatch(
 			continue
 		}
 
-		tokenData, skipData, ready, err2 := getTokenData(ctx, msgLggr, msg, r.config.tokenDataProviders, skipTokenWithData)
+		tokenData, err2 := getTokenData(ctx, msgLggr, msg, r.config.tokenDataProviders, skipTokenWithData)
 		if err2 != nil {
-			msgLggr.Errorw("Skipping message unable to check token data", "err", err2)
-			continue
-		}
-		if skipData {
-			// When fetching token data, 3rd party API could hang or rate limit.
-			// If this happens, we should skip all remaining messages that require token data to avoid calling the API again in this batch.
-			// If API issues does not resolve, eventually the root will only contain messages that should be skipped, and be snoozed.
+			// When fetching token data, 3rd party API could hang or rate limit or fail due to any reason.
+			// If this happens, we skip all remaining msgs that require token data in this batch.
+			// If the issue is transient, then it is likely for other nodes in the DON to succeed and execute the msg anyway.
+			// If the issue is API outage or rate limit, then we should indeed avoid calling the API.
+			// If API issues do not resolve, eventually the root will only contain msg that should be skipped, and be snoozed.
 			skipTokenWithData = true
-			msgLggr.Warnw("Skipping message due to failing to fetch data from token API")
-			continue
-		}
-		if !ready {
-			msgLggr.Warnw("Skipping message attestation not ready")
+			msgLggr.Errorw("Skipping message unable to get token data", "err", err2)
 			continue
 		}
 
@@ -630,7 +624,7 @@ func (r *ExecutionReportingPlugin) buildBatch(
 	return executableMessages
 }
 
-func getTokenData(ctx context.Context, lggr logger.Logger, msg internal.EVM2EVMOnRampCCIPSendRequestedWithMeta, tokenDataProviders map[common.Address]tokendata.Reader, skipTokenWithData bool) (tokenData [][]byte, skipData bool, allReady bool, err error) {
+func getTokenData(ctx context.Context, lggr logger.Logger, msg internal.EVM2EVMOnRampCCIPSendRequestedWithMeta, tokenDataProviders map[common.Address]tokendata.Reader, skipTokenWithData bool) (tokenData [][]byte, err error) {
 	for _, token := range msg.TokenAmounts {
 		offchainTokenDataProvider, ok := tokenDataProviders[token.Token]
 		if !ok {
@@ -640,26 +634,18 @@ func getTokenData(ctx context.Context, lggr logger.Logger, msg internal.EVM2EVMO
 		}
 		if skipTokenWithData {
 			// If token data is required but should be skipped, exit without calling the API
-			return [][]byte{}, true, false, nil
+			return [][]byte{}, errors.New("token requiring data is flagged to be skipped")
 		}
 		lggr.Infow("Fetching token data", "token", token.Token.Hex())
 		tknData, err2 := offchainTokenDataProvider.ReadTokenData(ctx, msg)
 		if err2 != nil {
-			if errors.Is(err2, tokendata.ErrRateLimit) || errors.Is(err2, tokendata.ErrTimeout) {
-				lggr.Infow(err2.Error(), "token", token.Token.Hex())
-				return [][]byte{}, true, false, nil
-			}
-			if errors.Is(err2, tokendata.ErrNotReady) {
-				lggr.Infow("Token data not ready yet", "token", token.Token.Hex())
-				return [][]byte{}, false, false, nil
-			}
-			return [][]byte{}, false, false, err2
+			return [][]byte{}, err2
 		}
 
 		lggr.Infow("Token data retrieved", "token", token.Token.Hex())
 		tokenData = append(tokenData, tknData)
 	}
-	return tokenData, false, true, nil
+	return tokenData, nil
 }
 
 func (r *ExecutionReportingPlugin) isRateLimitEnoughForTokenPool(

--- a/core/services/ocr2/plugins/ccip/tokendata/reader.go
+++ b/core/services/ocr2/plugins/ccip/tokendata/reader.go
@@ -9,7 +9,8 @@ import (
 )
 
 var (
-	ErrNotReady = errors.New("token data not ready")
+	ErrNotReady  = errors.New("token data not ready")
+	ErrRateLimit = errors.New("token data API is being rate limited")
 )
 
 // Reader is an interface for fetching offchain token data

--- a/core/services/ocr2/plugins/ccip/tokendata/reader.go
+++ b/core/services/ocr2/plugins/ccip/tokendata/reader.go
@@ -11,6 +11,7 @@ import (
 var (
 	ErrNotReady  = errors.New("token data not ready")
 	ErrRateLimit = errors.New("token data API is being rate limited")
+	ErrTimeout   = errors.New("token data API timed out")
 )
 
 // Reader is an interface for fetching offchain token data

--- a/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc.go
+++ b/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc.go
@@ -149,6 +149,9 @@ func (s *TokenDataReader) callAttestationApi(ctx context.Context, usdcMessageHas
 	req.Header.Add("accept", "application/json")
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return attestationResponse{}, tokendata.ErrTimeout
+		}
 		return attestationResponse{}, err
 	}
 	defer res.Body.Close()

--- a/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc.go
+++ b/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc.go
@@ -152,6 +152,12 @@ func (s *TokenDataReader) callAttestationApi(ctx context.Context, usdcMessageHas
 		return attestationResponse{}, err
 	}
 	defer res.Body.Close()
+
+	// Explicitly signal if the API is being rate limited
+	if res.StatusCode == http.StatusTooManyRequests {
+		return attestationResponse{}, tokendata.ErrRateLimit
+	}
+
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return attestationResponse{}, err

--- a/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc_blackbox_test.go
+++ b/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc_blackbox_test.go
@@ -64,7 +64,7 @@ func TestUSDCReader_ReadTokenData(t *testing.T) {
 	attestationURI, err := url.ParseRequestURI(ts.URL)
 	require.NoError(t, err)
 
-	usdcService := usdc.NewUSDCTokenDataReader(lggr, &usdcReader, attestationURI)
+	usdcService := usdc.NewUSDCTokenDataReader(lggr, &usdcReader, attestationURI, 0)
 	msgAndAttestation, err := usdcService.ReadTokenData(context.Background(), internal.EVM2EVMOnRampCCIPSendRequestedWithMeta{
 		EVM2EVMMessage: internal.EVM2EVMMessage{
 			SequenceNumber: seqNum,


### PR DESCRIPTION
## Motivation
If Circle API consistently hangs, exec plugin buildBatch will always timeout in the observation phase and make no progress, add a 5second timeout to API call so the plugin gets a chance to progress.