### PR TITLE
Better bytes of bytes encoding

### DIFF
--- a/core/services/ocr2/plugins/ccip/internal/hashlib/common_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/hashlib/common_test.go
@@ -38,3 +38,52 @@ func TestBytesOfBytesKeccak(t *testing.T) {
 	})
 
 }
+
+func TestBytesOfBytesEncoding(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    [][]byte
+		expected []byte
+	}{
+		{
+			name:  "0 sub array, empty slice",
+			input: [][]byte{},
+			expected: []byte{
+				0, 0, 0, 0, 0, 0, 0, 0,
+			},
+		},
+		{
+			name: "1 sub array",
+			input: [][]byte{
+				{0, 1, 2, 3},
+			},
+			expected: []byte{
+				0, 0, 0, 0, 0, 0, 0, 1,
+				0, 0, 0, 0, 0, 0, 0, 4, 0, 1, 2, 3,
+			},
+		},
+		{
+			name: "3 sub array",
+			input: [][]byte{
+				{0, 1, 2, 3},
+				{0, 0, 0},
+				{7, 8},
+			},
+			expected: []byte{
+				0, 0, 0, 0, 0, 0, 0, 3,
+				0, 0, 0, 0, 0, 0, 0, 4, 0, 1, 2, 3,
+				0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 2, 7, 8,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encoded, err := encodeBytesOfBytes(tt.input)
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.expected, encoded)
+		})
+	}
+}


### PR DESCRIPTION
## Motivation
The previous encoding used variable-length length prefixes. It is not immune to collisions and cannot be reliably decoded.

## Solution
Switching to the common fixed-length length prefixes for unique encodings and decodings.