### PR TITLE
[Test2] add 10s delay to USDC call

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,7 +53,7 @@ jobs:
           tags: |
             type=sha,enable={{is_default_branch}}
             type=sha,format=long,enable={{is_default_branch}}
-            type=ref,event=push
+            type=ref,event=branch
       - name: Fetch operator-ui
         shell: bash
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,6 +98,7 @@ jobs:
         uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25 # v1.6.0
         with:
           version: latest
+          tags: laggy-usdc
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - ccip-develop
       - deployment-test
+      - feature/laggy-usdc
 
 jobs:
   build-and-publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,6 +53,7 @@ jobs:
           tags: |
             type=sha,enable={{is_default_branch}}
             type=sha,format=long,enable={{is_default_branch}}
+            type=ref,event=push
       - name: Fetch operator-ui
         shell: bash
         env:
@@ -98,7 +99,6 @@ jobs:
         uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25 # v1.6.0
         with:
           version: latest
-          tags: laggy-usdc
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - ccip-develop
       - deployment-test
-      - feature/laggy-usdc
+      - feature/laggy-usdc-2
 
 jobs:
   build-and-publish:

--- a/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc.go
+++ b/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc.go
@@ -100,6 +100,9 @@ func (s *TokenDataReader) ReadTokenData(ctx context.Context, msg internal.EVM2EV
 
 	s.lggr.Infow("Calling attestation API", "messageBodyHash", hexutil.Encode(messageBody[:]), "messageID", hexutil.Encode(msg.MessageId[:]))
 
+	// sleep for 10 seconds for each API call
+	time.Sleep(10 * time.Second)
+
 	// The attestation API expects the hash of the message body
 	attestationResp, err := s.callAttestationApi(ctx, utils.Keccak256Fixed(messageBody))
 	if err != nil {


### PR DESCRIPTION
## Motivation
In order to test the scenario where exec plugin times out while building USDC batch, add a 10 second delay to each USDC API call.
At observation timeout threshold of 35 seconds, this caps USDC throughput to 3 messages per round. Since the API responses are cached, the plugin should eventually make enough calls to execute the root.
E.g if a root has 10 messages, it should take 4 rounds to execute the root.