### PR TITLE
CCIP-1311 Reporting number of results returned from Contract Readers

### DIFF
--- a/core/services/ocr2/plugins/ccip/internal/observability/commit_store.go
+++ b/core/services/ocr2/plugins/ccip/internal/observability/commit_store.go
@@ -16,69 +16,71 @@ func NewObservedCommitStoreReader(origin ccipdata.CommitStoreReader, chainID int
 	return &ObservedCommitStoreReader{
 		CommitStoreReader: origin,
 		metric: metricDetails{
-			histogram:  commitStoreHistogram,
-			pluginName: pluginName,
-			chainId:    chainID,
+			interactionDuration: readerHistogram,
+			resultSetSize:       readerDatasetSize,
+			pluginName:          pluginName,
+			readerName:          "CommitStoreReader",
+			chainId:             chainID,
 		},
 	}
 }
 
 func (o *ObservedCommitStoreReader) GetExpectedNextSequenceNumber(context context.Context) (uint64, error) {
-	return withObservedContract(o.metric, "GetExpectedNextSequenceNumber", func() (uint64, error) {
+	return withObservedInteraction(o.metric, "GetExpectedNextSequenceNumber", func() (uint64, error) {
 		return o.CommitStoreReader.GetExpectedNextSequenceNumber(context)
 	})
 }
 
 func (o *ObservedCommitStoreReader) GetLatestPriceEpochAndRound(context context.Context) (uint64, error) {
-	return withObservedContract(o.metric, "GetLatestPriceEpochAndRound", func() (uint64, error) {
+	return withObservedInteraction(o.metric, "GetLatestPriceEpochAndRound", func() (uint64, error) {
 		return o.CommitStoreReader.GetLatestPriceEpochAndRound(context)
 	})
 }
 
 func (o *ObservedCommitStoreReader) GetAcceptedCommitReportsGteSeqNum(ctx context.Context, seqNum uint64, confs int) ([]ccipdata.Event[ccipdata.CommitStoreReport], error) {
-	return withObservedContract(o.metric, "GetAcceptedCommitReportsGteSeqNum", func() ([]ccipdata.Event[ccipdata.CommitStoreReport], error) {
+	return withObservedInteractionAndResults(o.metric, "GetAcceptedCommitReportsGteSeqNum", func() ([]ccipdata.Event[ccipdata.CommitStoreReport], error) {
 		return o.CommitStoreReader.GetAcceptedCommitReportsGteSeqNum(ctx, seqNum, confs)
 	})
 }
 
 func (o *ObservedCommitStoreReader) GetAcceptedCommitReportsGteTimestamp(ctx context.Context, ts time.Time, confs int) ([]ccipdata.Event[ccipdata.CommitStoreReport], error) {
-	return withObservedContract(o.metric, "GetAcceptedCommitReportsGteTimestamp", func() ([]ccipdata.Event[ccipdata.CommitStoreReport], error) {
+	return withObservedInteractionAndResults(o.metric, "GetAcceptedCommitReportsGteTimestamp", func() ([]ccipdata.Event[ccipdata.CommitStoreReport], error) {
 		return o.CommitStoreReader.GetAcceptedCommitReportsGteTimestamp(ctx, ts, confs)
 	})
 }
 
 func (o *ObservedCommitStoreReader) IsDown(ctx context.Context) (bool, error) {
-	return withObservedContract(o.metric, "IsDown", func() (bool, error) {
+	return withObservedInteraction(o.metric, "IsDown", func() (bool, error) {
 		return o.CommitStoreReader.IsDown(ctx)
 	})
 }
 
 func (o *ObservedCommitStoreReader) IsBlessed(ctx context.Context, root [32]byte) (bool, error) {
-	return withObservedContract(o.metric, "IsBlessed", func() (bool, error) {
+	return withObservedInteraction(o.metric, "IsBlessed", func() (bool, error) {
 		return o.CommitStoreReader.IsBlessed(ctx, root)
 	})
 }
 
 func (o *ObservedCommitStoreReader) EncodeCommitReport(report ccipdata.CommitStoreReport) ([]byte, error) {
-	return withObservedContract(o.metric, "EncodeCommitReport", func() ([]byte, error) {
+	return withObservedInteraction(o.metric, "EncodeCommitReport", func() ([]byte, error) {
 		return o.CommitStoreReader.EncodeCommitReport(report)
 	})
 }
 
 func (o *ObservedCommitStoreReader) DecodeCommitReport(report []byte) (ccipdata.CommitStoreReport, error) {
-	return withObservedContract(o.metric, "DecodeCommitReport", func() (ccipdata.CommitStoreReport, error) {
+	return withObservedInteraction(o.metric, "DecodeCommitReport", func() (ccipdata.CommitStoreReport, error) {
 		return o.CommitStoreReader.DecodeCommitReport(report)
 	})
 }
 
 func (o *ObservedCommitStoreReader) VerifyExecutionReport(ctx context.Context, report ccipdata.ExecReport) (bool, error) {
-	return withObservedContract(o.metric, "VerifyExecutionReport", func() (bool, error) {
+	return withObservedInteraction(o.metric, "VerifyExecutionReport", func() (bool, error) {
 		return o.CommitStoreReader.VerifyExecutionReport(ctx, report)
 	})
 }
 
 func (o *ObservedCommitStoreReader) GetCommitStoreStaticConfig(ctx context.Context) (ccipdata.CommitStoreStaticConfig, error) {
-	return withObservedContract(o.metric, "GetCommitStoreStaticConfig", func() (ccipdata.CommitStoreStaticConfig, error) {
+	return withObservedInteraction(o.metric, "GetCommitStoreStaticConfig", func() (ccipdata.CommitStoreStaticConfig, error) {
 		return o.CommitStoreReader.GetCommitStoreStaticConfig(ctx)
 	})
 }

--- a/core/services/ocr2/plugins/ccip/internal/observability/metrics_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/observability/metrics_test.go
@@ -15,31 +15,32 @@ import (
 )
 
 func TestProperLabelsArePassed(t *testing.T) {
-	histogram := offRampHistogram
+	histogram := readerHistogram
 	successCounter := 10
 	failedCounter := 5
 
 	details := metricDetails{
-		histogram:  histogram,
-		pluginName: "plugin",
-		chainId:    123,
+		interactionDuration: histogram,
+		pluginName:          "plugin",
+		readerName:          "reader",
+		chainId:             123,
 	}
 
 	for i := 0; i < successCounter; i++ {
-		_, err := withObservedContract[string](details, "successFun", successfulContract)
+		_, err := withObservedInteraction[string](details, "successFun", successfulContract)
 		require.NoError(t, err)
 	}
 
 	for i := 0; i < failedCounter; i++ {
-		_, err := withObservedContract[string](details, "failedFun", failedContract)
+		_, err := withObservedInteraction[string](details, "failedFun", failedContract)
 		require.Error(t, err)
 	}
 
-	assert.Equal(t, successCounter, counterFromHistogramByLabels(t, histogram, "123", "plugin", "successFun", "true"))
-	assert.Equal(t, failedCounter, counterFromHistogramByLabels(t, histogram, "123", "plugin", "failedFun", "false"))
+	assert.Equal(t, successCounter, counterFromHistogramByLabels(t, histogram, "123", "plugin", "reader", "successFun", "true"))
+	assert.Equal(t, failedCounter, counterFromHistogramByLabels(t, histogram, "123", "plugin", "reader", "failedFun", "false"))
 
-	assert.Equal(t, 0, counterFromHistogramByLabels(t, histogram, "123", "plugin", "failedFun", "true"))
-	assert.Equal(t, 0, counterFromHistogramByLabels(t, histogram, "123", "plugin", "successFun", "false"))
+	assert.Equal(t, 0, counterFromHistogramByLabels(t, histogram, "123", "plugin", "reader", "failedFun", "true"))
+	assert.Equal(t, 0, counterFromHistogramByLabels(t, histogram, "123", "plugin", "reader", "successFun", "false"))
 }
 
 func TestMetricsSendFromContractDirectly(t *testing.T) {
@@ -58,10 +59,10 @@ func TestMetricsSendFromContractDirectly(t *testing.T) {
 		_, _ = observedOfframp.GetDestinationTokens(ctx)
 	}
 
-	assert.Equal(t, expectedCounter, counterFromHistogramByLabels(t, observedOfframp.metric.histogram, "420", "plugin", "GetSupportedTokens", "true"))
-	assert.Equal(t, expectedCounter, counterFromHistogramByLabels(t, observedOfframp.metric.histogram, "420", "plugin", "GetDestinationTokens", "false"))
-	assert.Equal(t, 0, counterFromHistogramByLabels(t, observedOfframp.metric.histogram, "420", "plugin", "GetPoolByDestToken", "false"))
-	assert.Equal(t, 0, counterFromHistogramByLabels(t, observedOfframp.metric.histogram, "420", "plugin", "GetPoolByDestToken", "true"))
+	assert.Equal(t, expectedCounter, counterFromHistogramByLabels(t, observedOfframp.metric.interactionDuration, "420", "plugin", "OffRampReader", "GetSupportedTokens", "true"))
+	assert.Equal(t, expectedCounter, counterFromHistogramByLabels(t, observedOfframp.metric.interactionDuration, "420", "plugin", "OffRampReader", "GetDestinationTokens", "false"))
+	assert.Equal(t, 0, counterFromHistogramByLabels(t, observedOfframp.metric.interactionDuration, "420", "plugin", "OffRampReader", "GetPoolByDestToken", "false"))
+	assert.Equal(t, 0, counterFromHistogramByLabels(t, observedOfframp.metric.interactionDuration, "420", "plugin", "OffRampReader", "GetPoolByDestToken", "true"))
 }
 
 func counterFromHistogramByLabels(t *testing.T, histogramVec *prometheus.HistogramVec, labels ...string) int {

--- a/core/services/ocr2/plugins/ccip/internal/observability/offramp.go
+++ b/core/services/ocr2/plugins/ccip/internal/observability/offramp.go
@@ -18,75 +18,77 @@ func NewObservedOffRampReader(origin ccipdata.OffRampReader, chainID int64, plug
 	return &ObservedOffRampReader{
 		OffRampReader: origin,
 		metric: metricDetails{
-			histogram:  offRampHistogram,
-			pluginName: pluginName,
-			chainId:    chainID,
+			interactionDuration: readerHistogram,
+			resultSetSize:       readerDatasetSize,
+			pluginName:          pluginName,
+			readerName:          "OffRampReader",
+			chainId:             chainID,
 		},
 	}
 }
 
 func (o *ObservedOffRampReader) EncodeExecutionReport(report ccipdata.ExecReport) ([]byte, error) {
-	return withObservedContract(o.metric, "EncodeExecutionReport", func() ([]byte, error) {
+	return withObservedInteraction(o.metric, "EncodeExecutionReport", func() ([]byte, error) {
 		return o.OffRampReader.EncodeExecutionReport(report)
 	})
 }
 
 func (o *ObservedOffRampReader) DecodeExecutionReport(report []byte) (ccipdata.ExecReport, error) {
-	return withObservedContract(o.metric, "DecodeExecutionReport", func() (ccipdata.ExecReport, error) {
+	return withObservedInteraction(o.metric, "DecodeExecutionReport", func() (ccipdata.ExecReport, error) {
 		return o.OffRampReader.DecodeExecutionReport(report)
 	})
 }
 
-func (o *ObservedOffRampReader) GetExecutionStateChangesBetweenSeqNums(ctx context.Context, seqNumMin, seqNumMax uint64, confs int) ([]ccipdata.Event[ccipdata.ExecutionStateChanged], error) {
-	return withObservedContract(o.metric, "GetExecutionStateChangesBetweenSeqNums", func() ([]ccipdata.Event[ccipdata.ExecutionStateChanged], error) {
+func (o *ObservedOffRampReader) withObservedInteractionAndResults(ctx context.Context, seqNumMin, seqNumMax uint64, confs int) ([]ccipdata.Event[ccipdata.ExecutionStateChanged], error) {
+	return withObservedInteraction(o.metric, "GetExecutionStateChangesBetweenSeqNums", func() ([]ccipdata.Event[ccipdata.ExecutionStateChanged], error) {
 		return o.OffRampReader.GetExecutionStateChangesBetweenSeqNums(ctx, seqNumMin, seqNumMax, confs)
 	})
 }
 
 func (o *ObservedOffRampReader) GetDestinationTokens(ctx context.Context) ([]common.Address, error) {
-	return withObservedContract(o.metric, "GetDestinationTokens", func() ([]common.Address, error) {
+	return withObservedInteractionAndResults(o.metric, "GetDestinationTokens", func() ([]common.Address, error) {
 		return o.OffRampReader.GetDestinationTokens(ctx)
 	})
 }
 
 func (o *ObservedOffRampReader) GetPoolByDestToken(ctx context.Context, address common.Address) (common.Address, error) {
-	return withObservedContract(o.metric, "GetPoolByDestToken", func() (common.Address, error) {
+	return withObservedInteraction(o.metric, "GetPoolByDestToken", func() (common.Address, error) {
 		return o.OffRampReader.GetPoolByDestToken(ctx, address)
 	})
 }
 
 func (o *ObservedOffRampReader) GetDestinationTokensFromSourceTokens(ctx context.Context, tokenAddresses []common.Address) ([]common.Address, error) {
-	return withObservedContract(o.metric, "GetDestinationTokensFromSourceTokens", func() ([]common.Address, error) {
+	return withObservedInteractionAndResults(o.metric, "GetDestinationTokensFromSourceTokens", func() ([]common.Address, error) {
 		return o.OffRampReader.GetDestinationTokensFromSourceTokens(ctx, tokenAddresses)
 	})
 }
 
 func (o *ObservedOffRampReader) GetSupportedTokens(ctx context.Context) ([]common.Address, error) {
-	return withObservedContract(o.metric, "GetSupportedTokens", func() ([]common.Address, error) {
+	return withObservedInteractionAndResults(o.metric, "GetSupportedTokens", func() ([]common.Address, error) {
 		return o.OffRampReader.GetSupportedTokens(ctx)
 	})
 }
 
 func (o *ObservedOffRampReader) GetSenderNonce(ctx context.Context, sender common.Address) (uint64, error) {
-	return withObservedContract(o.metric, "GetSenderNonce", func() (uint64, error) {
+	return withObservedInteraction(o.metric, "GetSenderNonce", func() (uint64, error) {
 		return o.OffRampReader.GetSenderNonce(ctx, sender)
 	})
 }
 
 func (o *ObservedOffRampReader) CurrentRateLimiterState(ctx context.Context) (evm_2_evm_offramp.RateLimiterTokenBucket, error) {
-	return withObservedContract(o.metric, "CurrentRateLimiterState", func() (evm_2_evm_offramp.RateLimiterTokenBucket, error) {
+	return withObservedInteraction(o.metric, "CurrentRateLimiterState", func() (evm_2_evm_offramp.RateLimiterTokenBucket, error) {
 		return o.OffRampReader.CurrentRateLimiterState(ctx)
 	})
 }
 
 func (o *ObservedOffRampReader) GetExecutionState(ctx context.Context, sequenceNumber uint64) (uint8, error) {
-	return withObservedContract(o.metric, "GetExecutionState", func() (uint8, error) {
+	return withObservedInteraction(o.metric, "GetExecutionState", func() (uint8, error) {
 		return o.OffRampReader.GetExecutionState(ctx, sequenceNumber)
 	})
 }
 
 func (o *ObservedOffRampReader) GetStaticConfig(ctx context.Context) (ccipdata.OffRampStaticConfig, error) {
-	return withObservedContract(o.metric, "GetStaticConfig", func() (ccipdata.OffRampStaticConfig, error) {
+	return withObservedInteraction(o.metric, "GetStaticConfig", func() (ccipdata.OffRampStaticConfig, error) {
 		return o.OffRampReader.GetStaticConfig(ctx)
 	})
 }

--- a/core/services/ocr2/plugins/ccip/internal/observability/onramp.go
+++ b/core/services/ocr2/plugins/ccip/internal/observability/onramp.go
@@ -18,39 +18,41 @@ func NewObservedOnRampReader(origin ccipdata.OnRampReader, chainID int64, plugin
 	return &ObservedOnRampReader{
 		OnRampReader: origin,
 		metric: metricDetails{
-			histogram:  onRampHistogram,
-			pluginName: pluginName,
-			chainId:    chainID,
+			interactionDuration: readerHistogram,
+			resultSetSize:       readerDatasetSize,
+			pluginName:          pluginName,
+			readerName:          "OnRampReader",
+			chainId:             chainID,
 		},
 	}
 }
 
 func (o ObservedOnRampReader) GetSendRequestsGteSeqNum(ctx context.Context, seqNum uint64, confs int) ([]ccipdata.Event[internal.EVM2EVMMessage], error) {
-	return withObservedContract(o.metric, "GetSendRequestsGteSeqNum", func() ([]ccipdata.Event[internal.EVM2EVMMessage], error) {
+	return withObservedInteractionAndResults(o.metric, "GetSendRequestsGteSeqNum", func() ([]ccipdata.Event[internal.EVM2EVMMessage], error) {
 		return o.OnRampReader.GetSendRequestsGteSeqNum(ctx, seqNum, confs)
 	})
 }
 
 func (o ObservedOnRampReader) GetSendRequestsBetweenSeqNums(ctx context.Context, seqNumMin, seqNumMax uint64, confs int) ([]ccipdata.Event[internal.EVM2EVMMessage], error) {
-	return withObservedContract(o.metric, "GetSendRequestsBetweenSeqNums", func() ([]ccipdata.Event[internal.EVM2EVMMessage], error) {
+	return withObservedInteractionAndResults(o.metric, "GetSendRequestsBetweenSeqNums", func() ([]ccipdata.Event[internal.EVM2EVMMessage], error) {
 		return o.OnRampReader.GetSendRequestsBetweenSeqNums(ctx, seqNumMin, seqNumMax, confs)
 	})
 }
 
 func (o ObservedOnRampReader) RouterAddress() (common.Address, error) {
-	return withObservedContract(o.metric, "RouterAddress", func() (common.Address, error) {
+	return withObservedInteraction(o.metric, "RouterAddress", func() (common.Address, error) {
 		return o.OnRampReader.RouterAddress()
 	})
 }
 
 func (o ObservedOnRampReader) Address() (common.Address, error) {
-	return withObservedContract(o.metric, "Address", func() (common.Address, error) {
+	return withObservedInteraction(o.metric, "Address", func() (common.Address, error) {
 		return o.OnRampReader.Address()
 	})
 }
 
 func (o ObservedOnRampReader) GetDynamicConfig() (ccipdata.OnRampDynamicConfig, error) {
-	return withObservedContract(o.metric, "GetDynamicConfig", func() (ccipdata.OnRampDynamicConfig, error) {
+	return withObservedInteraction(o.metric, "GetDynamicConfig", func() (ccipdata.OnRampDynamicConfig, error) {
 		return o.OnRampReader.GetDynamicConfig()
 	})
 }

--- a/core/services/ocr2/plugins/ccip/internal/observability/price_registry.go
+++ b/core/services/ocr2/plugins/ccip/internal/observability/price_registry.go
@@ -18,33 +18,35 @@ func NewPriceRegistryReader(origin ccipdata.PriceRegistryReader, chainID int64, 
 	return &ObservedPriceRegistryReader{
 		PriceRegistryReader: origin,
 		metric: metricDetails{
-			histogram:  priceRegistryHistogram,
-			pluginName: pluginName,
-			chainId:    chainID,
+			interactionDuration: readerHistogram,
+			resultSetSize:       readerDatasetSize,
+			pluginName:          pluginName,
+			readerName:          "PriceRegistryReader",
+			chainId:             chainID,
 		},
 	}
 }
 
 func (o *ObservedPriceRegistryReader) GetTokenPriceUpdatesCreatedAfter(ctx context.Context, ts time.Time, confs int) ([]ccipdata.Event[ccipdata.TokenPriceUpdate], error) {
-	return withObservedContract(o.metric, "GetTokenPriceUpdatesCreatedAfter", func() ([]ccipdata.Event[ccipdata.TokenPriceUpdate], error) {
+	return withObservedInteractionAndResults(o.metric, "GetTokenPriceUpdatesCreatedAfter", func() ([]ccipdata.Event[ccipdata.TokenPriceUpdate], error) {
 		return o.PriceRegistryReader.GetTokenPriceUpdatesCreatedAfter(ctx, ts, confs)
 	})
 }
 
 func (o *ObservedPriceRegistryReader) GetGasPriceUpdatesCreatedAfter(ctx context.Context, chainSelector uint64, ts time.Time, confs int) ([]ccipdata.Event[ccipdata.GasPriceUpdate], error) {
-	return withObservedContract(o.metric, "GetGasPriceUpdatesCreatedAfter", func() ([]ccipdata.Event[ccipdata.GasPriceUpdate], error) {
+	return withObservedInteractionAndResults(o.metric, "GetGasPriceUpdatesCreatedAfter", func() ([]ccipdata.Event[ccipdata.GasPriceUpdate], error) {
 		return o.PriceRegistryReader.GetGasPriceUpdatesCreatedAfter(ctx, chainSelector, ts, confs)
 	})
 }
 
 func (o *ObservedPriceRegistryReader) GetFeeTokens(ctx context.Context) ([]common.Address, error) {
-	return withObservedContract(o.metric, "GetFeeTokens", func() ([]common.Address, error) {
+	return withObservedInteraction(o.metric, "GetFeeTokens", func() ([]common.Address, error) {
 		return o.PriceRegistryReader.GetFeeTokens(ctx)
 	})
 }
 
 func (o *ObservedPriceRegistryReader) GetTokenPrices(ctx context.Context, wantedTokens []common.Address) ([]ccipdata.TokenPriceUpdate, error) {
-	return withObservedContract(o.metric, "GetTokenPrices", func() ([]ccipdata.TokenPriceUpdate, error) {
+	return withObservedInteractionAndResults(o.metric, "GetTokenPrices", func() ([]ccipdata.TokenPriceUpdate, error) {
 		return o.PriceRegistryReader.GetTokenPrices(ctx, wantedTokens)
 	})
 }


### PR DESCRIPTION
## Motivation

LogPoller metrics can't contain information about the plugin used to execute specific queries. Some of the `Reader` methods are proxies for LogPoller, so tracking the number of records returned here could help us identify which part of the code hits LogPoller. 

## Solution

Combine all existing metrics with latencies into a single one (it would be simpler). And introduce another one to track the number of records returned. This is very similar to what we already have for LP.