### PR TITLE
CCIP-1306 Using proper query for fetching single CommitReport from the LP

### DIFF
--- a/core/chains/evm/logpoller/disabled.go
+++ b/core/chains/evm/logpoller/disabled.go
@@ -106,3 +106,7 @@ func (d disabled) IndexedLogsCreatedAfter(eventSig common.Hash, address common.A
 func (d disabled) LatestBlockByEventSigsAddrsWithConfs(fromBlock int64, eventSigs []common.Hash, addresses []common.Address, confs Confirmations, qopts ...pg.QOpt) (int64, error) {
 	return 0, ErrDisabled
 }
+
+func (d disabled) LogsDataWordBetween(eventSig common.Hash, address common.Address, wordIndexMin, wordIndexMax int, wordValue common.Hash, confs Confirmations, qopts ...pg.QOpt) ([]Log, error) {
+	return nil, ErrDisabled
+}

--- a/core/chains/evm/logpoller/log_poller.go
+++ b/core/chains/evm/logpoller/log_poller.go
@@ -58,6 +58,7 @@ type LogPoller interface {
 	IndexedLogsWithSigsExcluding(address common.Address, eventSigA, eventSigB common.Hash, topicIndex int, fromBlock, toBlock int64, confs Confirmations, qopts ...pg.QOpt) ([]Log, error)
 	LogsDataWordRange(eventSig common.Hash, address common.Address, wordIndex int, wordValueMin, wordValueMax common.Hash, confs Confirmations, qopts ...pg.QOpt) ([]Log, error)
 	LogsDataWordGreaterThan(eventSig common.Hash, address common.Address, wordIndex int, wordValueMin common.Hash, confs Confirmations, qopts ...pg.QOpt) ([]Log, error)
+	LogsDataWordBetween(eventSig common.Hash, address common.Address, wordIndexMin, wordIndexMax int, wordValue common.Hash, confs Confirmations, qopts ...pg.QOpt) ([]Log, error)
 }
 
 type Confirmations int
@@ -1017,6 +1018,10 @@ func (lp *logPoller) LatestLogEventSigsAddrsWithConfs(fromBlock int64, eventSigs
 
 func (lp *logPoller) LatestBlockByEventSigsAddrsWithConfs(fromBlock int64, eventSigs []common.Hash, addresses []common.Address, confs Confirmations, qopts ...pg.QOpt) (int64, error) {
 	return lp.orm.SelectLatestBlockByEventSigsAddrsWithConfs(fromBlock, eventSigs, addresses, confs, qopts...)
+}
+
+func (lp *logPoller) LogsDataWordBetween(eventSig common.Hash, address common.Address, wordIndexMin, wordIndexMax int, wordValue common.Hash, confs Confirmations, qopts ...pg.QOpt) ([]Log, error) {
+	return lp.orm.SelectLogsDataWordBetween(address, eventSig, wordIndexMin, wordIndexMax, wordValue, confs, qopts...)
 }
 
 // GetBlocksRange tries to get the specified block numbers from the log pollers

--- a/core/chains/evm/logpoller/mocks/log_poller.go
+++ b/core/chains/evm/logpoller/mocks/log_poller.go
@@ -522,6 +522,39 @@ func (_m *LogPoller) LogsCreatedAfter(eventSig common.Hash, address common.Addre
 	return r0, r1
 }
 
+// LogsDataWordBetween provides a mock function with given fields: eventSig, address, wordIndexMin, wordIndexMax, wordValue, confs, qopts
+func (_m *LogPoller) LogsDataWordBetween(eventSig common.Hash, address common.Address, wordIndexMin int, wordIndexMax int, wordValue common.Hash, confs logpoller.Confirmations, qopts ...pg.QOpt) ([]logpoller.Log, error) {
+	_va := make([]interface{}, len(qopts))
+	for _i := range qopts {
+		_va[_i] = qopts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, eventSig, address, wordIndexMin, wordIndexMax, wordValue, confs)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 []logpoller.Log
+	var r1 error
+	if rf, ok := ret.Get(0).(func(common.Hash, common.Address, int, int, common.Hash, logpoller.Confirmations, ...pg.QOpt) ([]logpoller.Log, error)); ok {
+		return rf(eventSig, address, wordIndexMin, wordIndexMax, wordValue, confs, qopts...)
+	}
+	if rf, ok := ret.Get(0).(func(common.Hash, common.Address, int, int, common.Hash, logpoller.Confirmations, ...pg.QOpt) []logpoller.Log); ok {
+		r0 = rf(eventSig, address, wordIndexMin, wordIndexMax, wordValue, confs, qopts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]logpoller.Log)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(common.Hash, common.Address, int, int, common.Hash, logpoller.Confirmations, ...pg.QOpt) error); ok {
+		r1 = rf(eventSig, address, wordIndexMin, wordIndexMax, wordValue, confs, qopts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // LogsDataWordGreaterThan provides a mock function with given fields: eventSig, address, wordIndex, wordValueMin, confs, qopts
 func (_m *LogPoller) LogsDataWordGreaterThan(eventSig common.Hash, address common.Address, wordIndex int, wordValueMin common.Hash, confs logpoller.Confirmations, qopts ...pg.QOpt) ([]logpoller.Log, error) {
 	_va := make([]interface{}, len(qopts))

--- a/core/chains/evm/logpoller/observability.go
+++ b/core/chains/evm/logpoller/observability.go
@@ -212,6 +212,12 @@ func (o *ObservedORM) SelectLogsDataWordGreaterThan(address common.Address, even
 	})
 }
 
+func (o *ObservedORM) SelectLogsDataWordBetween(address common.Address, eventSIg common.Hash, wordIndexMin int, wordIndexMax int, wordValue common.Hash, confs Confirmations, qopts ...pg.QOpt) ([]Log, error) {
+	return withObservedQueryAndResults(o, "SelectLogsDataWordBetween", func() ([]Log, error) {
+		return o.ORM.SelectLogsDataWordBetween(address, eventSIg, wordIndexMin, wordIndexMax, wordValue, confs, qopts...)
+	})
+}
+
 func (o *ObservedORM) SelectIndexedLogsTopicGreaterThan(address common.Address, eventSig common.Hash, topicIndex int, topicValueMin common.Hash, confs Confirmations, qopts ...pg.QOpt) ([]Log, error) {
 	return withObservedQueryAndResults(o, "SelectIndexedLogsTopicGreaterThan", func() ([]Log, error) {
 		return o.ORM.SelectIndexedLogsTopicGreaterThan(address, eventSig, topicIndex, topicValueMin, confs, qopts...)

--- a/core/chains/evm/logpoller/orm_test.go
+++ b/core/chains/evm/logpoller/orm_test.go
@@ -1493,7 +1493,7 @@ func TestSelectLogsDataWordBetween(t *testing.T) {
 			expectedLogs: []int64{1, 2},
 		},
 		{
-			name:         "returns no logs if word value is outside of the rang",
+			name:         "returns no logs if word value is outside of the range",
 			wordValue:    21,
 			expectedLogs: []int64{},
 		},

--- a/core/chains/evm/logpoller/query.go
+++ b/core/chains/evm/logpoller/query.go
@@ -74,6 +74,18 @@ func (q *queryArgs) withWordIndex(wordIndex int) *queryArgs {
 	return q.withCustomArg("word_index", wordIndex)
 }
 
+func (q *queryArgs) withWordIndexMin(wordIndex int) *queryArgs {
+	return q.withCustomArg("word_index_min", wordIndex)
+}
+
+func (q *queryArgs) withWordIndexMax(wordIndex int) *queryArgs {
+	return q.withCustomArg("word_index_max", wordIndex)
+}
+
+func (q *queryArgs) withWordValue(wordValue common.Hash) *queryArgs {
+	return q.withCustomHashArg("word_value", wordValue)
+}
+
 func (q *queryArgs) withWordValueMin(wordValueMin common.Hash) *queryArgs {
 	return q.withCustomHashArg("word_value_min", wordValueMin)
 }

--- a/core/services/ocr2/plugins/ccip/execution_batch_building.go
+++ b/core/services/ocr2/plugins/ccip/execution_batch_building.go
@@ -95,7 +95,7 @@ func getCommitReportForSeqNum(ctx context.Context, commitStoreReader ccipdata.Co
 		return ccipdata.CommitStoreReport{}, err
 	}
 
-	if len(acceptedReports) < 1 {
+	if len(acceptedReports) == 0 {
 		return ccipdata.CommitStoreReport{}, errors.Errorf("seq number not committed")
 	}
 

--- a/core/services/ocr2/plugins/ccip/execution_batch_building.go
+++ b/core/services/ocr2/plugins/ccip/execution_batch_building.go
@@ -90,7 +90,7 @@ func validateSeqNumbers(serviceCtx context.Context, commitStore ccipdata.CommitS
 
 // Gets the commit report from the saved logs for a given sequence number.
 func getCommitReportForSeqNum(ctx context.Context, commitStoreReader ccipdata.CommitStoreReader, seqNum uint64) (ccipdata.CommitStoreReport, error) {
-	acceptedReports, err := commitStoreReader.GetAcceptedCommitReportsGteSeqNum(ctx, seqNum, 0)
+	acceptedReports, err := commitStoreReader.GetCommitReportMatchingSeqNum(ctx, seqNum, 0)
 	if err != nil {
 		return ccipdata.CommitStoreReport{}, err
 	}

--- a/core/services/ocr2/plugins/ccip/execution_batch_building.go
+++ b/core/services/ocr2/plugins/ccip/execution_batch_building.go
@@ -95,12 +95,9 @@ func getCommitReportForSeqNum(ctx context.Context, commitStoreReader ccipdata.Co
 		return ccipdata.CommitStoreReport{}, err
 	}
 
-	for _, acceptedReport := range acceptedReports {
-		reportInterval := acceptedReport.Data.Interval
-		if reportInterval.Min <= seqNum && seqNum <= reportInterval.Max {
-			return acceptedReport.Data, nil
-		}
+	if len(acceptedReports) < 1 {
+		return ccipdata.CommitStoreReport{}, errors.Errorf("seq number not committed")
 	}
 
-	return ccipdata.CommitStoreReport{}, errors.Errorf("seq number not committed")
+	return acceptedReports[0].Data, nil
 }

--- a/core/services/ocr2/plugins/ccip/execution_reporting_plugin_test.go
+++ b/core/services/ocr2/plugins/ccip/execution_reporting_plugin_test.go
@@ -357,7 +357,7 @@ func TestExecutionReportingPlugin_buildReport(t *testing.T) {
 	commitStore.On("VerifyExecutionReport", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
 	commitStore.On("GetExpectedNextSequenceNumber", mock.Anything).
 		Return(executionReport.Messages[len(executionReport.Messages)-1].SequenceNumber+1, nil)
-	commitStore.On("GetAcceptedCommitReportsGteSeqNum", ctx, observations[0].SeqNr, 0).
+	commitStore.On("GetCommitReportMatchingSeqNum", ctx, observations[0].SeqNr, 0).
 		Return([]ccipdata.Event[ccipdata.CommitStoreReport]{
 			{
 				Data: ccipdata.CommitStoreReport{

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/commit_store_reader.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/commit_store_reader.go
@@ -96,8 +96,8 @@ type CommitStoreReader interface {
 	Closer
 	GetExpectedNextSequenceNumber(context context.Context) (uint64, error)
 	GetLatestPriceEpochAndRound(context context.Context) (uint64, error)
-	// GetAcceptedCommitReportsGteSeqNum returns all the accepted commit reports that have max sequence number greater than or equal to the provided.
-	GetAcceptedCommitReportsGteSeqNum(ctx context.Context, seqNum uint64, confs int) ([]Event[CommitStoreReport], error)
+	// GetCommitReportMatchingSeqNum returns all the accepted commit reports that have max sequence number greater than or equal to the provided.
+	GetCommitReportMatchingSeqNum(ctx context.Context, seqNum uint64, confs int) ([]Event[CommitStoreReport], error)
 	// GetAcceptedCommitReportsGteTimestamp returns all the commit reports with timestamp greater than or equal to the provided.
 	// Returned Commit Reports have to be sorted by Interval.Min/Interval.Max in ascending order.
 	GetAcceptedCommitReportsGteTimestamp(ctx context.Context, ts time.Time, confs int) ([]Event[CommitStoreReport], error)

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/commit_store_reader.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/commit_store_reader.go
@@ -96,7 +96,7 @@ type CommitStoreReader interface {
 	Closer
 	GetExpectedNextSequenceNumber(context context.Context) (uint64, error)
 	GetLatestPriceEpochAndRound(context context.Context) (uint64, error)
-	// GetCommitReportMatchingSeqNum returns all the accepted commit reports that have max sequence number greater than or equal to the provided.
+	// GetCommitReportMatchingSeqNum returns accepted commit report that satisfies Interval.Min <= seqNum <= Interval.Max. Returned slice should be empty or have exactly one element
 	GetCommitReportMatchingSeqNum(ctx context.Context, seqNum uint64, confs int) ([]Event[CommitStoreReport], error)
 	// GetAcceptedCommitReportsGteTimestamp returns all the commit reports with timestamp greater than or equal to the provided.
 	// Returned Commit Reports have to be sorted by Interval.Min/Interval.Max in ascending order.

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/commit_store_reader_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/commit_store_reader_test.go
@@ -343,19 +343,23 @@ func TestCommitStoreReaders(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, rep.Interval.Max+1, seqNr)
 
-			reps, err := cr.GetAcceptedCommitReportsGteSeqNum(context.Background(), rep.Interval.Max+1, 0)
+			reps, err := cr.GetCommitReportMatchingSeqNum(context.Background(), rep.Interval.Max+1, 0)
 			require.NoError(t, err)
 			assert.Len(t, reps, 0)
 
-			reps, err = cr.GetAcceptedCommitReportsGteSeqNum(context.Background(), rep.Interval.Max, 0)
+			reps, err = cr.GetCommitReportMatchingSeqNum(context.Background(), rep.Interval.Max, 0)
 			require.NoError(t, err)
 			require.Len(t, reps, 1)
 			assert.Equal(t, reps[0].Data, rep)
 
-			reps, err = cr.GetAcceptedCommitReportsGteSeqNum(context.Background(), rep.Interval.Min-1, 0)
+			reps, err = cr.GetCommitReportMatchingSeqNum(context.Background(), rep.Interval.Min, 0)
 			require.NoError(t, err)
 			require.Len(t, reps, 1)
 			assert.Equal(t, reps[0].Data, rep)
+
+			reps, err = cr.GetCommitReportMatchingSeqNum(context.Background(), rep.Interval.Min-1, 0)
+			require.NoError(t, err)
+			require.Len(t, reps, 0)
 
 			// Sanity
 			reps, err = cr.GetAcceptedCommitReportsGteTimestamp(context.Background(), time.Unix(0, 0), 0)

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/commit_store_v1_0_0.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/commit_store_v1_0_0.go
@@ -275,11 +275,20 @@ func (c *CommitStoreV1_0_0) GetCommitReportMatchingSeqNum(ctx context.Context, s
 		return nil, err
 	}
 
-	return parseLogs[CommitStoreReport](
+	parsedLogs, err := parseLogs[CommitStoreReport](
 		logs,
 		c.lggr,
 		c.parseReport,
 	)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(parsedLogs) > 1 {
+		c.lggr.Errorw("More than one report found for seqNum", "seqNum", seqNum, "commitReports", parsedLogs)
+		return parsedLogs[:1], nil
+	}
+	return parsedLogs, nil
 }
 
 func (c *CommitStoreV1_0_0) GetAcceptedCommitReportsGteTimestamp(ctx context.Context, ts time.Time, confs int) ([]Event[CommitStoreReport], error) {

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/commit_store_v1_0_0.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/commit_store_v1_0_0.go
@@ -261,10 +261,11 @@ func (c *CommitStoreV1_0_0) parseReport(log types.Log) (*CommitStoreReport, erro
 	}, nil
 }
 
-func (c *CommitStoreV1_0_0) GetAcceptedCommitReportsGteSeqNum(ctx context.Context, seqNum uint64, confs int) ([]Event[CommitStoreReport], error) {
-	logs, err := c.lp.LogsDataWordGreaterThan(
+func (c *CommitStoreV1_0_0) GetCommitReportMatchingSeqNum(ctx context.Context, seqNum uint64, confs int) ([]Event[CommitStoreReport], error) {
+	logs, err := c.lp.LogsDataWordBetween(
 		c.reportAcceptedSig,
 		c.address,
+		c.reportAcceptedMaxSeqIndex-1,
 		c.reportAcceptedMaxSeqIndex,
 		logpoller.EvmWord(seqNum),
 		logpoller.Confirmations(confs),

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/commit_store_v1_2_0.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/commit_store_v1_2_0.go
@@ -281,10 +281,11 @@ func (c *CommitStoreV1_2_0) parseReport(log types.Log) (*CommitStoreReport, erro
 	}, nil
 }
 
-func (c *CommitStoreV1_2_0) GetAcceptedCommitReportsGteSeqNum(ctx context.Context, seqNum uint64, confs int) ([]Event[CommitStoreReport], error) {
-	logs, err := c.lp.LogsDataWordGreaterThan(
+func (c *CommitStoreV1_2_0) GetCommitReportMatchingSeqNum(ctx context.Context, seqNum uint64, confs int) ([]Event[CommitStoreReport], error) {
+	logs, err := c.lp.LogsDataWordBetween(
 		c.reportAcceptedSig,
 		c.address,
+		c.reportAcceptedMaxSeqIndex-1,
 		c.reportAcceptedMaxSeqIndex,
 		logpoller.EvmWord(seqNum),
 		logpoller.Confirmations(confs),

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/commit_store_v1_2_0.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/commit_store_v1_2_0.go
@@ -295,11 +295,20 @@ func (c *CommitStoreV1_2_0) GetCommitReportMatchingSeqNum(ctx context.Context, s
 		return nil, err
 	}
 
-	return parseLogs[CommitStoreReport](
+	parsedLogs, err := parseLogs[CommitStoreReport](
 		logs,
 		c.lggr,
 		c.parseReport,
 	)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(parsedLogs) > 1 {
+		c.lggr.Errorw("More than one report found for seqNum", "seqNum", seqNum, "commitReports", parsedLogs)
+		return parsedLogs[:1], nil
+	}
+	return parsedLogs, nil
 }
 
 func (c *CommitStoreV1_2_0) GetAcceptedCommitReportsGteTimestamp(ctx context.Context, ts time.Time, confs int) ([]Event[CommitStoreReport], error) {

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/mocks/commit_store_reader_mock.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/mocks/commit_store_reader_mock.go
@@ -134,32 +134,6 @@ func (_m *CommitStoreReader) GasPriceEstimator() prices.GasPriceEstimatorCommit 
 	return r0
 }
 
-// GetAcceptedCommitReportsGteSeqNum provides a mock function with given fields: ctx, seqNum, confs
-func (_m *CommitStoreReader) GetAcceptedCommitReportsGteSeqNum(ctx context.Context, seqNum uint64, confs int) ([]ccipdata.Event[ccipdata.CommitStoreReport], error) {
-	ret := _m.Called(ctx, seqNum, confs)
-
-	var r0 []ccipdata.Event[ccipdata.CommitStoreReport]
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, uint64, int) ([]ccipdata.Event[ccipdata.CommitStoreReport], error)); ok {
-		return rf(ctx, seqNum, confs)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, uint64, int) []ccipdata.Event[ccipdata.CommitStoreReport]); ok {
-		r0 = rf(ctx, seqNum, confs)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]ccipdata.Event[ccipdata.CommitStoreReport])
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, uint64, int) error); ok {
-		r1 = rf(ctx, seqNum, confs)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // GetAcceptedCommitReportsGteTimestamp provides a mock function with given fields: ctx, ts, confs
 func (_m *CommitStoreReader) GetAcceptedCommitReportsGteTimestamp(ctx context.Context, ts time.Time, confs int) ([]ccipdata.Event[ccipdata.CommitStoreReport], error) {
 	ret := _m.Called(ctx, ts, confs)
@@ -179,6 +153,32 @@ func (_m *CommitStoreReader) GetAcceptedCommitReportsGteTimestamp(ctx context.Co
 
 	if rf, ok := ret.Get(1).(func(context.Context, time.Time, int) error); ok {
 		r1 = rf(ctx, ts, confs)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetCommitReportMatchingSeqNum provides a mock function with given fields: ctx, seqNum, confs
+func (_m *CommitStoreReader) GetCommitReportMatchingSeqNum(ctx context.Context, seqNum uint64, confs int) ([]ccipdata.Event[ccipdata.CommitStoreReport], error) {
+	ret := _m.Called(ctx, seqNum, confs)
+
+	var r0 []ccipdata.Event[ccipdata.CommitStoreReport]
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, int) ([]ccipdata.Event[ccipdata.CommitStoreReport], error)); ok {
+		return rf(ctx, seqNum, confs)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, int) []ccipdata.Event[ccipdata.CommitStoreReport]); ok {
+		r0 = rf(ctx, seqNum, confs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]ccipdata.Event[ccipdata.CommitStoreReport])
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, uint64, int) error); ok {
+		r1 = rf(ctx, seqNum, confs)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/core/services/ocr2/plugins/ccip/internal/observability/commit_store.go
+++ b/core/services/ocr2/plugins/ccip/internal/observability/commit_store.go
@@ -37,9 +37,9 @@ func (o *ObservedCommitStoreReader) GetLatestPriceEpochAndRound(context context.
 	})
 }
 
-func (o *ObservedCommitStoreReader) GetAcceptedCommitReportsGteSeqNum(ctx context.Context, seqNum uint64, confs int) ([]ccipdata.Event[ccipdata.CommitStoreReport], error) {
-	return withObservedInteractionAndResults(o.metric, "GetAcceptedCommitReportsGteSeqNum", func() ([]ccipdata.Event[ccipdata.CommitStoreReport], error) {
-		return o.CommitStoreReader.GetAcceptedCommitReportsGteSeqNum(ctx, seqNum, confs)
+func (o *ObservedCommitStoreReader) GetCommitReportMatchingSeqNum(ctx context.Context, seqNum uint64, confs int) ([]ccipdata.Event[ccipdata.CommitStoreReport], error) {
+	return withObservedInteractionAndResults(o.metric, "GetCommitReportMatchingSeqNum", func() ([]ccipdata.Event[ccipdata.CommitStoreReport], error) {
+		return o.CommitStoreReader.GetCommitReportMatchingSeqNum(ctx, seqNum, confs)
 	})
 }
 


### PR DESCRIPTION
## Motivation

The current approach to fetching CommitReport based on `seqNr` is suboptimal. We can have query with better filters that pick exactly one report that we need instead of fetching all Commit Reports greater or equal passed sequence number. Under higher load it becomes a bottleneck 

## Solution

Use a dedicated query `LogsDataWordBetween` that applies lower and upper bound filters in the SQL query 