### PR TITLE
CCIP-1319 Fixing finality in Commit Plugin

### DIFF
--- a/core/services/ocr2/plugins/ccip/commit_reporting_plugin.go
+++ b/core/services/ocr2/plugins/ccip/commit_reporting_plugin.go
@@ -242,7 +242,7 @@ func (r *CommitReportingPlugin) calculateMinMaxSequenceNumbers(ctx context.Conte
 		return 0, 0, err
 	}
 
-	msgRequests, err := r.onRampReader.GetSendRequestsGteSeqNum(ctx, nextInflightMin, int(r.offchainConfig.SourceFinalityDepth))
+	msgRequests, err := r.onRampReader.GetFinalizedSendRequestsGteSeqNum(ctx, nextInflightMin)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/core/services/ocr2/plugins/ccip/commit_reporting_plugin.go
+++ b/core/services/ocr2/plugins/ccip/commit_reporting_plugin.go
@@ -242,7 +242,7 @@ func (r *CommitReportingPlugin) calculateMinMaxSequenceNumbers(ctx context.Conte
 		return 0, 0, err
 	}
 
-	msgRequests, err := r.onRampReader.GetFinalizedSendRequestsGteSeqNum(ctx, nextInflightMin)
+	msgRequests, err := r.onRampReader.GetSendRequestsGteSeqNum(ctx, nextInflightMin)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -699,12 +699,7 @@ func (r *CommitReportingPlugin) buildReport(ctx context.Context, lggr logger.Log
 
 	// Logs are guaranteed to be in order of seq num, since these are finalized logs only
 	// and the contract's seq num is auto-incrementing.
-	sendRequests, err := r.onRampReader.GetSendRequestsBetweenSeqNums(
-		ctx,
-		interval.Min,
-		interval.Max,
-		int(r.offchainConfig.SourceFinalityDepth),
-	)
+	sendRequests, err := r.onRampReader.GetSendRequestsBetweenSeqNums(ctx, interval.Min, interval.Max)
 	if err != nil {
 		return ccipdata.CommitStoreReport{}, err
 	}

--- a/core/services/ocr2/plugins/ccip/commit_reporting_plugin_test.go
+++ b/core/services/ocr2/plugins/ccip/commit_reporting_plugin_test.go
@@ -105,7 +105,7 @@ func TestCommitReportingPlugin_Observation(t *testing.T) {
 
 			onRampReader := ccipdatamocks.NewOnRampReader(t)
 			if len(tc.sendReqs) > 0 {
-				onRampReader.On("GetSendRequestsGteSeqNum", ctx, tc.commitStoreSeqNum, sourceFinalityDepth).
+				onRampReader.On("GetFinalizedSendRequestsGteSeqNum", ctx, tc.commitStoreSeqNum, sourceFinalityDepth).
 					Return(tc.sendReqs, nil)
 			}
 
@@ -1322,7 +1322,7 @@ func TestCommitReportingPlugin_calculateMinMaxSequenceNumbers(t *testing.T) {
 					},
 				})
 			}
-			onRampReader.On("GetSendRequestsGteSeqNum", ctx, tc.expQueryMin, 0).Return(sendReqs, nil)
+			onRampReader.On("GetFinalizedSendRequestsGteSeqNum", ctx, tc.expQueryMin, 0).Return(sendReqs, nil)
 			p.onRampReader = onRampReader
 
 			minSeqNum, maxSeqNum, err := p.calculateMinMaxSequenceNumbers(ctx, lggr)

--- a/core/services/ocr2/plugins/ccip/commit_reporting_plugin_test.go
+++ b/core/services/ocr2/plugins/ccip/commit_reporting_plugin_test.go
@@ -95,8 +95,6 @@ func TestCommitReportingPlugin_Observation(t *testing.T) {
 	ctx := testutils.Context(t)
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			sourceFinalityDepth := 10
-
 			commitStoreReader := ccipdatamocks.NewCommitStoreReader(t)
 			commitStoreReader.On("IsDown", ctx).Return(tc.commitStoreIsPaused, nil)
 			if !tc.commitStoreIsPaused {
@@ -105,7 +103,7 @@ func TestCommitReportingPlugin_Observation(t *testing.T) {
 
 			onRampReader := ccipdatamocks.NewOnRampReader(t)
 			if len(tc.sendReqs) > 0 {
-				onRampReader.On("GetFinalizedSendRequestsGteSeqNum", ctx, tc.commitStoreSeqNum, sourceFinalityDepth).
+				onRampReader.On("GetSendRequestsGteSeqNum", ctx, tc.commitStoreSeqNum).
 					Return(tc.sendReqs, nil)
 			}
 
@@ -135,7 +133,6 @@ func TestCommitReportingPlugin_Observation(t *testing.T) {
 			p.lggr = logger.TestLogger(t)
 			p.inflightReports = newInflightCommitReportsContainer(time.Hour)
 			p.commitStoreReader = commitStoreReader
-			p.offchainConfig.SourceFinalityDepth = uint32(sourceFinalityDepth)
 			p.onRampReader = onRampReader
 			p.tokenDecimalsCache = tokenDecimalsCache
 			p.priceGetter = priceGet
@@ -227,7 +224,7 @@ func TestCommitReportingPlugin_Report(t *testing.T) {
 				MerkleRoot:  [32]byte{},
 				Interval:    ccipdata.CommitStoreInterval{Min: 1, Max: 1},
 				TokenPrices: nil,
-				GasPrices:   []ccipdata.GasPrice{{DestChainSelector: uint64(sourceChainSelector), Value: gasPrice}},
+				GasPrices:   []ccipdata.GasPrice{{DestChainSelector: sourceChainSelector, Value: gasPrice}},
 			},
 			expErr: false,
 		},
@@ -272,7 +269,7 @@ func TestCommitReportingPlugin_Report(t *testing.T) {
 
 			onRampReader := ccipdatamocks.NewOnRampReader(t)
 			if len(tc.sendRequests) > 0 {
-				onRampReader.On("GetSendRequestsBetweenSeqNums", ctx, tc.expSeqNumRange.Min, tc.expSeqNumRange.Max, 0).Return(tc.sendRequests, nil)
+				onRampReader.On("GetSendRequestsBetweenSeqNums", ctx, tc.expSeqNumRange.Min, tc.expSeqNumRange.Max).Return(tc.sendRequests, nil)
 			}
 
 			gasPriceEstimator := prices.NewMockGasPriceEstimatorCommit(t)
@@ -1322,7 +1319,7 @@ func TestCommitReportingPlugin_calculateMinMaxSequenceNumbers(t *testing.T) {
 					},
 				})
 			}
-			onRampReader.On("GetFinalizedSendRequestsGteSeqNum", ctx, tc.expQueryMin, 0).Return(sendReqs, nil)
+			onRampReader.On("GetSendRequestsGteSeqNum", ctx, tc.expQueryMin).Return(sendReqs, nil)
 			p.onRampReader = onRampReader
 
 			minSeqNum, maxSeqNum, err := p.calculateMinMaxSequenceNumbers(ctx, lggr)

--- a/core/services/ocr2/plugins/ccip/execution_batch_building.go
+++ b/core/services/ocr2/plugins/ccip/execution_batch_building.go
@@ -17,12 +17,7 @@ func getProofData(
 	sourceReader ccipdata.OnRampReader,
 	interval ccipdata.CommitStoreInterval,
 ) (sendReqsInRoot []ccipdata.Event[internal.EVM2EVMMessage], leaves [][32]byte, tree *merklemulti.Tree[[32]byte], err error) {
-	sendReqs, err := sourceReader.GetSendRequestsBetweenSeqNums(
-		ctx,
-		interval.Min,
-		interval.Max,
-		0, // no need for confirmations, commitReport was already confirmed and we need all msgs in it
-	)
+	sendReqs, err := sourceReader.GetSendRequestsBetweenSeqNums(ctx, interval.Min, interval.Max)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/core/services/ocr2/plugins/ccip/execution_reporting_plugin.go
+++ b/core/services/ocr2/plugins/ccip/execution_reporting_plugin.go
@@ -767,12 +767,7 @@ func (r *ExecutionReportingPlugin) getReportsWithSendRequests(
 
 	var sendRequests []ccipdata.Event[internal.EVM2EVMMessage]
 	eg.Go(func() error {
-		sendReqs, err := r.config.onRampReader.GetSendRequestsBetweenSeqNums(
-			ctx,
-			intervalMin,
-			intervalMax,
-			int(r.offchainConfig.SourceFinalityDepth),
-		)
+		sendReqs, err := r.config.onRampReader.GetSendRequestsBetweenSeqNums(ctx, intervalMin, intervalMax)
 		if err != nil {
 			return err
 		}

--- a/core/services/ocr2/plugins/ccip/execution_reporting_plugin_test.go
+++ b/core/services/ocr2/plugins/ccip/execution_reporting_plugin_test.go
@@ -133,7 +133,7 @@ func TestExecutionReportingPlugin_Observation(t *testing.T) {
 			p.config.offRampReader = mockOffRampReader
 
 			mockOnRampReader := ccipdatamocks.NewOnRampReader(t)
-			mockOnRampReader.On("GetSendRequestsBetweenSeqNums", ctx, mock.Anything, mock.Anything, 0).
+			mockOnRampReader.On("GetSendRequestsBetweenSeqNums", ctx, mock.Anything, mock.Anything).
 				Return(tc.sendRequests, nil).Maybe()
 			p.config.onRampReader = mockOnRampReader
 
@@ -396,7 +396,7 @@ func TestExecutionReportingPlugin_buildReport(t *testing.T) {
 		sendReqs[i] = ccipdata.Event[internal.EVM2EVMMessage]{Data: msg}
 	}
 	sourceReader.On("GetSendRequestsBetweenSeqNums",
-		ctx, observations[0].SeqNr, observations[len(observations)-1].SeqNr, 0).Return(sendReqs, nil)
+		ctx, observations[0].SeqNr, observations[len(observations)-1].SeqNr).Return(sendReqs, nil)
 	p.config.onRampReader = sourceReader
 
 	execReport, err := p.buildReport(ctx, p.lggr, observations)
@@ -1010,7 +1010,7 @@ func TestExecutionReportingPlugin_getReportsWithSendRequests(t *testing.T) {
 			p.config.offRampReader = offRampReader
 
 			sourceReader := ccipdatamocks.NewOnRampReader(t)
-			sourceReader.On("GetSendRequestsBetweenSeqNums", ctx, tc.expQueryMin, tc.expQueryMax, 0).
+			sourceReader.On("GetSendRequestsBetweenSeqNums", ctx, tc.expQueryMin, tc.expQueryMax).
 				Return(tc.onchainEvents, nil).Maybe()
 			p.config.onRampReader = sourceReader
 

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/mocks/onramp_reader_mock.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/mocks/onramp_reader_mock.go
@@ -90,8 +90,34 @@ func (_m *OnRampReader) GetDynamicConfig() (ccipdata.OnRampDynamicConfig, error)
 	return r0, r1
 }
 
-// GetFinalizedSendRequestsGteSeqNum provides a mock function with given fields: ctx, seqNum
-func (_m *OnRampReader) GetFinalizedSendRequestsGteSeqNum(ctx context.Context, seqNum uint64) ([]ccipdata.Event[internal.EVM2EVMMessage], error) {
+// GetSendRequestsBetweenSeqNums provides a mock function with given fields: ctx, seqNumMin, seqNumMax
+func (_m *OnRampReader) GetSendRequestsBetweenSeqNums(ctx context.Context, seqNumMin uint64, seqNumMax uint64) ([]ccipdata.Event[internal.EVM2EVMMessage], error) {
+	ret := _m.Called(ctx, seqNumMin, seqNumMax)
+
+	var r0 []ccipdata.Event[internal.EVM2EVMMessage]
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, uint64) ([]ccipdata.Event[internal.EVM2EVMMessage], error)); ok {
+		return rf(ctx, seqNumMin, seqNumMax)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, uint64, uint64) []ccipdata.Event[internal.EVM2EVMMessage]); ok {
+		r0 = rf(ctx, seqNumMin, seqNumMax)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]ccipdata.Event[internal.EVM2EVMMessage])
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, uint64, uint64) error); ok {
+		r1 = rf(ctx, seqNumMin, seqNumMax)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetSendRequestsGteSeqNum provides a mock function with given fields: ctx, seqNum
+func (_m *OnRampReader) GetSendRequestsGteSeqNum(ctx context.Context, seqNum uint64) ([]ccipdata.Event[internal.EVM2EVMMessage], error) {
 	ret := _m.Called(ctx, seqNum)
 
 	var r0 []ccipdata.Event[internal.EVM2EVMMessage]
@@ -109,32 +135,6 @@ func (_m *OnRampReader) GetFinalizedSendRequestsGteSeqNum(ctx context.Context, s
 
 	if rf, ok := ret.Get(1).(func(context.Context, uint64) error); ok {
 		r1 = rf(ctx, seqNum)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// GetSendRequestsBetweenSeqNums provides a mock function with given fields: ctx, seqNumMin, seqNumMax, confs
-func (_m *OnRampReader) GetSendRequestsBetweenSeqNums(ctx context.Context, seqNumMin uint64, seqNumMax uint64, confs int) ([]ccipdata.Event[internal.EVM2EVMMessage], error) {
-	ret := _m.Called(ctx, seqNumMin, seqNumMax, confs)
-
-	var r0 []ccipdata.Event[internal.EVM2EVMMessage]
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, uint64, uint64, int) ([]ccipdata.Event[internal.EVM2EVMMessage], error)); ok {
-		return rf(ctx, seqNumMin, seqNumMax, confs)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, uint64, uint64, int) []ccipdata.Event[internal.EVM2EVMMessage]); ok {
-		r0 = rf(ctx, seqNumMin, seqNumMax, confs)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]ccipdata.Event[internal.EVM2EVMMessage])
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, uint64, uint64, int) error); ok {
-		r1 = rf(ctx, seqNumMin, seqNumMax, confs)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/mocks/onramp_reader_mock.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/mocks/onramp_reader_mock.go
@@ -90,6 +90,32 @@ func (_m *OnRampReader) GetDynamicConfig() (ccipdata.OnRampDynamicConfig, error)
 	return r0, r1
 }
 
+// GetFinalizedSendRequestsGteSeqNum provides a mock function with given fields: ctx, seqNum
+func (_m *OnRampReader) GetFinalizedSendRequestsGteSeqNum(ctx context.Context, seqNum uint64) ([]ccipdata.Event[internal.EVM2EVMMessage], error) {
+	ret := _m.Called(ctx, seqNum)
+
+	var r0 []ccipdata.Event[internal.EVM2EVMMessage]
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, uint64) ([]ccipdata.Event[internal.EVM2EVMMessage], error)); ok {
+		return rf(ctx, seqNum)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, uint64) []ccipdata.Event[internal.EVM2EVMMessage]); ok {
+		r0 = rf(ctx, seqNum)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]ccipdata.Event[internal.EVM2EVMMessage])
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, uint64) error); ok {
+		r1 = rf(ctx, seqNum)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetSendRequestsBetweenSeqNums provides a mock function with given fields: ctx, seqNumMin, seqNumMax, confs
 func (_m *OnRampReader) GetSendRequestsBetweenSeqNums(ctx context.Context, seqNumMin uint64, seqNumMax uint64, confs int) ([]ccipdata.Event[internal.EVM2EVMMessage], error) {
 	ret := _m.Called(ctx, seqNumMin, seqNumMax, confs)
@@ -109,32 +135,6 @@ func (_m *OnRampReader) GetSendRequestsBetweenSeqNums(ctx context.Context, seqNu
 
 	if rf, ok := ret.Get(1).(func(context.Context, uint64, uint64, int) error); ok {
 		r1 = rf(ctx, seqNumMin, seqNumMax, confs)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// GetSendRequestsGteSeqNum provides a mock function with given fields: ctx, seqNum, confs
-func (_m *OnRampReader) GetSendRequestsGteSeqNum(ctx context.Context, seqNum uint64, confs int) ([]ccipdata.Event[internal.EVM2EVMMessage], error) {
-	ret := _m.Called(ctx, seqNum, confs)
-
-	var r0 []ccipdata.Event[internal.EVM2EVMMessage]
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, uint64, int) ([]ccipdata.Event[internal.EVM2EVMMessage], error)); ok {
-		return rf(ctx, seqNum, confs)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, uint64, int) []ccipdata.Event[internal.EVM2EVMMessage]); ok {
-		r0 = rf(ctx, seqNum, confs)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]ccipdata.Event[internal.EVM2EVMMessage])
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, uint64, int) error); ok {
-		r1 = rf(ctx, seqNum, confs)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/onramp_reader.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/onramp_reader.go
@@ -40,10 +40,10 @@ type OnRampDynamicConfig struct {
 //go:generate mockery --quiet --name OnRampReader --filename onramp_reader_mock.go --case=underscore
 type OnRampReader interface {
 	Closer
-	// GetFinalizedSendRequestsGteSeqNum returns all the finalized message send requests with sequence number greater than or equal to the provided.
-	GetFinalizedSendRequestsGteSeqNum(ctx context.Context, seqNum uint64) ([]Event[internal.EVM2EVMMessage], error)
-	// GetSendRequestsBetweenSeqNums returns all the message send requests in the provided sequence numbers range (inclusive).
-	GetSendRequestsBetweenSeqNums(ctx context.Context, seqNumMin, seqNumMax uint64, confs int) ([]Event[internal.EVM2EVMMessage], error)
+	// GetSendRequestsGteSeqNum returns all the finalized message send requests with sequence number greater than or equal to the provided.
+	GetSendRequestsGteSeqNum(ctx context.Context, seqNum uint64) ([]Event[internal.EVM2EVMMessage], error)
+	// GetSendRequestsBetweenSeqNums returns all the finalized message send requests in the provided sequence numbers range (inclusive).
+	GetSendRequestsBetweenSeqNums(ctx context.Context, seqNumMin, seqNumMax uint64) ([]Event[internal.EVM2EVMMessage], error)
 	// Get router configured in the onRamp
 	RouterAddress() (common.Address, error)
 	Address() (common.Address, error)

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/onramp_reader.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/onramp_reader.go
@@ -40,9 +40,8 @@ type OnRampDynamicConfig struct {
 //go:generate mockery --quiet --name OnRampReader --filename onramp_reader_mock.go --case=underscore
 type OnRampReader interface {
 	Closer
-	// GetSendRequestsGteSeqNum returns all the message send requests with sequence number greater than or equal to the provided.
-	// If checkFinalityTags is set to true then confs param is ignored, the latest finalized block is used in the query.
-	GetSendRequestsGteSeqNum(ctx context.Context, seqNum uint64, confs int) ([]Event[internal.EVM2EVMMessage], error)
+	// GetFinalizedSendRequestsGteSeqNum returns all the finalized message send requests with sequence number greater than or equal to the provided.
+	GetFinalizedSendRequestsGteSeqNum(ctx context.Context, seqNum uint64) ([]Event[internal.EVM2EVMMessage], error)
 	// GetSendRequestsBetweenSeqNums returns all the message send requests in the provided sequence numbers range (inclusive).
 	GetSendRequestsBetweenSeqNums(ctx context.Context, seqNumMin, seqNumMax uint64, confs int) ([]Event[internal.EVM2EVMMessage], error)
 	// Get router configured in the onRamp

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/onramp_reader_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/onramp_reader_test.go
@@ -330,7 +330,7 @@ func testOnRampReader(t *testing.T, th onRampReaderTH, expectedRouterAddress com
 	require.NoError(t, err)
 	require.Equal(t, expectedRouterAddress, res)
 
-	msg, err := th.reader.GetSendRequestsGteSeqNum(ctx, 0, 0)
+	msg, err := th.reader.GetFinalizedSendRequestsGteSeqNum(ctx, 0)
 	require.NoError(t, err)
 	require.NotNil(t, msg)
 	require.Equal(t, []ccipdata.Event[internal.EVM2EVMMessage]{}, msg)

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/onramp_reader_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/onramp_reader_test.go
@@ -330,12 +330,12 @@ func testOnRampReader(t *testing.T, th onRampReaderTH, expectedRouterAddress com
 	require.NoError(t, err)
 	require.Equal(t, expectedRouterAddress, res)
 
-	msg, err := th.reader.GetFinalizedSendRequestsGteSeqNum(ctx, 0)
+	msg, err := th.reader.GetSendRequestsGteSeqNum(ctx, 0)
 	require.NoError(t, err)
 	require.NotNil(t, msg)
 	require.Equal(t, []ccipdata.Event[internal.EVM2EVMMessage]{}, msg)
 
-	msg, err = th.reader.GetSendRequestsBetweenSeqNums(ctx, 0, 10, 0)
+	msg, err = th.reader.GetSendRequestsBetweenSeqNums(ctx, 0, 10)
 	require.NoError(t, err)
 	require.NotNil(t, msg)
 	require.Equal(t, []ccipdata.Event[internal.EVM2EVMMessage]{}, msg)

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/onramp_v1_0_0.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/onramp_v1_0_0.go
@@ -202,17 +202,17 @@ func (o *OnRampV1_0_0) logToMessage(log types.Log) (*internal.EVM2EVMMessage, er
 	}, nil
 }
 
-func (o *OnRampV1_0_0) GetSendRequestsGteSeqNum(ctx context.Context, seqNum uint64, confs int) ([]Event[internal.EVM2EVMMessage], error) {
-	logs, err2 := o.lp.LogsDataWordGreaterThan(
+func (o *OnRampV1_0_0) GetFinalizedSendRequestsGteSeqNum(ctx context.Context, seqNum uint64) ([]Event[internal.EVM2EVMMessage], error) {
+	logs, err := o.lp.LogsDataWordGreaterThan(
 		o.sendRequestedEventSig,
 		o.address,
 		o.sendRequestedSeqNumberWord,
 		abihelpers.EvmWord(seqNum),
-		logpoller.Confirmations(confs),
+		logpoller.Finalized,
 		pg.WithParentCtx(ctx),
 	)
-	if err2 != nil {
-		return nil, fmt.Errorf("logs data word greater than: %w", err2)
+	if err != nil {
+		return nil, fmt.Errorf("logs data word greater than: %w", err)
 	}
 	return parseLogs[internal.EVM2EVMMessage](logs, o.lggr, o.logToMessage)
 }

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/onramp_v1_0_0.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/onramp_v1_0_0.go
@@ -202,7 +202,7 @@ func (o *OnRampV1_0_0) logToMessage(log types.Log) (*internal.EVM2EVMMessage, er
 	}, nil
 }
 
-func (o *OnRampV1_0_0) GetFinalizedSendRequestsGteSeqNum(ctx context.Context, seqNum uint64) ([]Event[internal.EVM2EVMMessage], error) {
+func (o *OnRampV1_0_0) GetSendRequestsGteSeqNum(ctx context.Context, seqNum uint64) ([]Event[internal.EVM2EVMMessage], error) {
 	logs, err := o.lp.LogsDataWordGreaterThan(
 		o.sendRequestedEventSig,
 		o.address,
@@ -225,14 +225,14 @@ func (o *OnRampV1_0_0) RouterAddress() (common.Address, error) {
 	return config.Router, nil
 }
 
-func (o *OnRampV1_0_0) GetSendRequestsBetweenSeqNums(ctx context.Context, seqNumMin, seqNumMax uint64, confs int) ([]Event[internal.EVM2EVMMessage], error) {
+func (o *OnRampV1_0_0) GetSendRequestsBetweenSeqNums(ctx context.Context, seqNumMin, seqNumMax uint64) ([]Event[internal.EVM2EVMMessage], error) {
 	logs, err := o.lp.LogsDataWordRange(
 		o.sendRequestedEventSig,
 		o.address,
 		o.sendRequestedSeqNumberWord,
 		logpoller.EvmWord(seqNumMin),
 		logpoller.EvmWord(seqNumMax),
-		logpoller.Confirmations(confs),
+		logpoller.Finalized,
 		pg.WithParentCtx(ctx))
 	if err != nil {
 		return nil, err

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/onramp_v1_2_0.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/onramp_v1_2_0.go
@@ -269,7 +269,7 @@ func (o *OnRampV1_2_0) logToMessage(log types.Log) (*internal.EVM2EVMMessage, er
 	}, nil
 }
 
-func (o *OnRampV1_2_0) GetFinalizedSendRequestsGteSeqNum(ctx context.Context, seqNum uint64) ([]Event[internal.EVM2EVMMessage], error) {
+func (o *OnRampV1_2_0) GetSendRequestsGteSeqNum(ctx context.Context, seqNum uint64) ([]Event[internal.EVM2EVMMessage], error) {
 	logs, err := o.lp.LogsDataWordGreaterThan(
 		o.sendRequestedEventSig,
 		o.address,
@@ -284,14 +284,14 @@ func (o *OnRampV1_2_0) GetFinalizedSendRequestsGteSeqNum(ctx context.Context, se
 	return parseLogs[internal.EVM2EVMMessage](logs, o.lggr, o.logToMessage)
 }
 
-func (o *OnRampV1_2_0) GetSendRequestsBetweenSeqNums(ctx context.Context, seqNumMin, seqNumMax uint64, confs int) ([]Event[internal.EVM2EVMMessage], error) {
+func (o *OnRampV1_2_0) GetSendRequestsBetweenSeqNums(ctx context.Context, seqNumMin, seqNumMax uint64) ([]Event[internal.EVM2EVMMessage], error) {
 	logs, err := o.lp.LogsDataWordRange(
 		o.sendRequestedEventSig,
 		o.address,
 		o.sendRequestedSeqNumberWord,
 		logpoller.EvmWord(seqNumMin),
 		logpoller.EvmWord(seqNumMax),
-		logpoller.Confirmations(confs),
+		logpoller.Finalized,
 		pg.WithParentCtx(ctx))
 	if err != nil {
 		return nil, err

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/onramp_v1_2_0.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/onramp_v1_2_0.go
@@ -269,17 +269,17 @@ func (o *OnRampV1_2_0) logToMessage(log types.Log) (*internal.EVM2EVMMessage, er
 	}, nil
 }
 
-func (o *OnRampV1_2_0) GetSendRequestsGteSeqNum(ctx context.Context, seqNum uint64, confs int) ([]Event[internal.EVM2EVMMessage], error) {
-	logs, err2 := o.lp.LogsDataWordGreaterThan(
+func (o *OnRampV1_2_0) GetFinalizedSendRequestsGteSeqNum(ctx context.Context, seqNum uint64) ([]Event[internal.EVM2EVMMessage], error) {
+	logs, err := o.lp.LogsDataWordGreaterThan(
 		o.sendRequestedEventSig,
 		o.address,
 		o.sendRequestedSeqNumberWord,
 		abihelpers.EvmWord(seqNum),
-		logpoller.Confirmations(confs),
+		logpoller.Finalized,
 		pg.WithParentCtx(ctx),
 	)
-	if err2 != nil {
-		return nil, fmt.Errorf("logs data word greater than: %w", err2)
+	if err != nil {
+		return nil, fmt.Errorf("logs data word greater than: %w", err)
 	}
 	return parseLogs[internal.EVM2EVMMessage](logs, o.lggr, o.logToMessage)
 }

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/onramp_v1_2_0_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/onramp_v1_2_0_test.go
@@ -102,11 +102,7 @@ func TestLogPollerClient_GetSendRequestsGteSeqNum(t *testing.T) {
 		mock.Anything,
 	).Return([]logpoller.Log{}, nil)
 
-	events, err := onRampV2.GetSendRequestsGteSeqNum(
-		context.Background(),
-		seqNum,
-		confs,
-	)
+	events, err := onRampV2.GetFinalizedSendRequestsGteSeqNum(context.Background(), seqNum)
 	assert.NoError(t, err)
 	assert.Empty(t, events)
 	lp.AssertExpectations(t)

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/onramp_v1_2_0_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/onramp_v1_2_0_test.go
@@ -86,7 +86,6 @@ func TestHasherV1_2_0(t *testing.T) {
 func TestLogPollerClient_GetSendRequestsGteSeqNum(t *testing.T) {
 	onRampAddr := utils.RandomAddress()
 	seqNum := uint64(100)
-	confs := 4
 	lggr := logger.TestLogger(t)
 
 	lp := mocks.NewLogPoller(t)
@@ -98,11 +97,11 @@ func TestLogPollerClient_GetSendRequestsGteSeqNum(t *testing.T) {
 		onRampAddr,
 		onRampV2.sendRequestedSeqNumberWord,
 		abihelpers.EvmWord(seqNum),
-		logpoller.Confirmations(confs),
+		logpoller.Finalized,
 		mock.Anything,
 	).Return([]logpoller.Log{}, nil)
 
-	events, err := onRampV2.GetFinalizedSendRequestsGteSeqNum(context.Background(), seqNum)
+	events, err := onRampV2.GetSendRequestsGteSeqNum(context.Background(), seqNum)
 	assert.NoError(t, err)
 	assert.Empty(t, events)
 	lp.AssertExpectations(t)

--- a/core/services/ocr2/plugins/ccip/internal/observability/onramp.go
+++ b/core/services/ocr2/plugins/ccip/internal/observability/onramp.go
@@ -27,9 +27,9 @@ func NewObservedOnRampReader(origin ccipdata.OnRampReader, chainID int64, plugin
 	}
 }
 
-func (o ObservedOnRampReader) GetSendRequestsGteSeqNum(ctx context.Context, seqNum uint64, confs int) ([]ccipdata.Event[internal.EVM2EVMMessage], error) {
-	return withObservedInteractionAndResults(o.metric, "GetSendRequestsGteSeqNum", func() ([]ccipdata.Event[internal.EVM2EVMMessage], error) {
-		return o.OnRampReader.GetSendRequestsGteSeqNum(ctx, seqNum, confs)
+func (o ObservedOnRampReader) GetFinalizedSendRequestsGteSeqNum(ctx context.Context, seqNum uint64) ([]ccipdata.Event[internal.EVM2EVMMessage], error) {
+	return withObservedInteractionAndResults(o.metric, "GetFinalizedSendRequestsGteSeqNum", func() ([]ccipdata.Event[internal.EVM2EVMMessage], error) {
+		return o.OnRampReader.GetFinalizedSendRequestsGteSeqNum(ctx, seqNum)
 	})
 }
 

--- a/core/services/ocr2/plugins/ccip/internal/observability/onramp.go
+++ b/core/services/ocr2/plugins/ccip/internal/observability/onramp.go
@@ -27,15 +27,15 @@ func NewObservedOnRampReader(origin ccipdata.OnRampReader, chainID int64, plugin
 	}
 }
 
-func (o ObservedOnRampReader) GetFinalizedSendRequestsGteSeqNum(ctx context.Context, seqNum uint64) ([]ccipdata.Event[internal.EVM2EVMMessage], error) {
-	return withObservedInteractionAndResults(o.metric, "GetFinalizedSendRequestsGteSeqNum", func() ([]ccipdata.Event[internal.EVM2EVMMessage], error) {
-		return o.OnRampReader.GetFinalizedSendRequestsGteSeqNum(ctx, seqNum)
+func (o ObservedOnRampReader) GetSendRequestsGteSeqNum(ctx context.Context, seqNum uint64) ([]ccipdata.Event[internal.EVM2EVMMessage], error) {
+	return withObservedInteractionAndResults(o.metric, "GetSendRequestsGteSeqNum", func() ([]ccipdata.Event[internal.EVM2EVMMessage], error) {
+		return o.OnRampReader.GetSendRequestsGteSeqNum(ctx, seqNum)
 	})
 }
 
-func (o ObservedOnRampReader) GetSendRequestsBetweenSeqNums(ctx context.Context, seqNumMin, seqNumMax uint64, confs int) ([]ccipdata.Event[internal.EVM2EVMMessage], error) {
+func (o ObservedOnRampReader) GetSendRequestsBetweenSeqNums(ctx context.Context, seqNumMin, seqNumMax uint64) ([]ccipdata.Event[internal.EVM2EVMMessage], error) {
 	return withObservedInteractionAndResults(o.metric, "GetSendRequestsBetweenSeqNums", func() ([]ccipdata.Event[internal.EVM2EVMMessage], error) {
-		return o.OnRampReader.GetSendRequestsBetweenSeqNums(ctx, seqNumMin, seqNumMax, confs)
+		return o.OnRampReader.GetSendRequestsBetweenSeqNums(ctx, seqNumMin, seqNumMax)
 	})
 }
 


### PR DESCRIPTION
Issue was introduced here https://github.com/smartcontractkit/ccip/pull/269/commits/24cb822b362011acfbbc0e40880179d1273a6cc5#diff-945401ccd299f224b7a8955a8a81ebe81471950490fa0024ade5d5fe0408f5f2L247

Switching from SourceFinalityDepth to the chain values
* toml finalityDepth when `finalityTags = false`
* chain finality when `finalityTags = true`