### PR TITLE
CCIP-1231 Plugin metrics

### DIFF
--- a/core/services/ocr2/plugins/ccip/commit_reporting_plugin.go
+++ b/core/services/ocr2/plugins/ccip/commit_reporting_plugin.go
@@ -223,6 +223,8 @@ func (r *CommitReportingPlugin) Observation(ctx context.Context, epochAndRound t
 		"sourceGasPriceUSD", sourceGasPriceUSD,
 		"tokenPricesUSD", tokenPricesUSD,
 		"epochAndRound", epochAndRound)
+	(&PluginMetricsCollector{}).NumberOfMessagesBasedOnInterval(Observation, min, max)
+
 	// Even if all values are empty we still want to communicate our observation
 	// with the other nodes, therefore, we always return the observed values.
 	return CommitObservation{
@@ -495,6 +497,9 @@ func (r *CommitReportingPlugin) Report(ctx context.Context, epochAndRound types.
 	if err != nil {
 		return false, nil, err
 	}
+
+	(&PluginMetricsCollector{}).NumberOfMessagesBasedOnInterval(Report, report.Interval.Min, report.Interval.Max)
+
 	lggr.Infow("Report",
 		"merkleRoot", hex.EncodeToString(report.MerkleRoot[:]),
 		"minSeqNr", report.Interval.Min,
@@ -755,6 +760,8 @@ func (r *CommitReportingPlugin) ShouldAcceptFinalizedReport(ctx context.Context,
 	if err := r.inflightReports.add(lggr, parsedReport, epochAndRound); err != nil {
 		return false, err
 	}
+	(&PluginMetricsCollector{}).SequenceNumber(parsedReport.Interval.Max)
+
 	lggr.Infow("Accepting finalized report", "merkleRoot", hexutil.Encode(parsedReport.MerkleRoot[:]))
 	return true, nil
 }

--- a/core/services/ocr2/plugins/ccip/commit_reporting_plugin.go
+++ b/core/services/ocr2/plugins/ccip/commit_reporting_plugin.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
+	chainselectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	evmclient "github.com/smartcontractkit/chainlink/v2/core/chains/evm/client"
@@ -85,7 +86,8 @@ type CommitReportingPlugin struct {
 	// Offchain
 	priceGetter pricegetter.PriceGetter
 	// State
-	inflightReports *inflightCommitReportsContainer
+	inflightReports  *inflightCommitReportsContainer
+	metricsCollector PluginMetricsCollector
 }
 
 type CommitReportingPluginFactory struct {
@@ -147,6 +149,7 @@ func (rf *CommitReportingPluginFactory) NewReportingPlugin(config types.Reportin
 		return nil, types.ReportingPluginInfo{}, err
 	}
 
+	sourceChainId, err := chainselectors.ChainIdFromSelector(rf.config.sourceChainSelector)
 	if err != nil {
 		return nil, types.ReportingPluginInfo{}, err
 	}
@@ -166,6 +169,7 @@ func (rf *CommitReportingPluginFactory) NewReportingPlugin(config types.Reportin
 			offRampReader:           rf.config.offRamp,
 			gasPriceEstimator:       rf.config.commitStore.GasPriceEstimator(),
 			offchainConfig:          pluginOffChainConfig,
+			metricsCollector:  NewPluginMetricsCollector(ExecPluginLabel, big.NewInt(int64(sourceChainId)), rf.config.destClient.ConfiguredChainID()),
 		},
 		types.ReportingPluginInfo{
 			Name:          "CCIPCommit",
@@ -223,7 +227,7 @@ func (r *CommitReportingPlugin) Observation(ctx context.Context, epochAndRound t
 		"sourceGasPriceUSD", sourceGasPriceUSD,
 		"tokenPricesUSD", tokenPricesUSD,
 		"epochAndRound", epochAndRound)
-	(&PluginMetricsCollector{}).NumberOfMessagesBasedOnInterval(Observation, min, max)
+	r.metricsCollector.NumberOfMessagesBasedOnInterval(Observation, min, max)
 
 	// Even if all values are empty we still want to communicate our observation
 	// with the other nodes, therefore, we always return the observed values.
@@ -498,8 +502,7 @@ func (r *CommitReportingPlugin) Report(ctx context.Context, epochAndRound types.
 		return false, nil, err
 	}
 
-	(&PluginMetricsCollector{}).NumberOfMessagesBasedOnInterval(Report, report.Interval.Min, report.Interval.Max)
-
+	r.metricsCollector.NumberOfMessagesBasedOnInterval(Report, report.Interval.Min, report.Interval.Max)
 	lggr.Infow("Report",
 		"merkleRoot", hex.EncodeToString(report.MerkleRoot[:]),
 		"minSeqNr", report.Interval.Min,
@@ -760,7 +763,7 @@ func (r *CommitReportingPlugin) ShouldAcceptFinalizedReport(ctx context.Context,
 	if err := r.inflightReports.add(lggr, parsedReport, epochAndRound); err != nil {
 		return false, err
 	}
-	(&PluginMetricsCollector{}).SequenceNumber(parsedReport.Interval.Max)
+	r.metricsCollector.SequenceNumber(parsedReport.Interval.Max)
 
 	lggr.Infow("Accepting finalized report", "merkleRoot", hexutil.Encode(parsedReport.MerkleRoot[:]))
 	return true, nil

--- a/core/services/ocr2/plugins/ccip/commit_reporting_plugin_test.go
+++ b/core/services/ocr2/plugins/ccip/commit_reporting_plugin_test.go
@@ -353,6 +353,7 @@ func TestCommitReportingPlugin_ShouldAcceptFinalizedReport(t *testing.T) {
 		p := &CommitReportingPlugin{}
 		p.lggr = logger.TestLogger(t)
 		p.inflightReports = newInflightCommitReportsContainer(time.Minute)
+		p.metricsCollector = NoopMetricsCollector
 		return p
 	}
 

--- a/core/services/ocr2/plugins/ccip/commit_reporting_plugin_test.go
+++ b/core/services/ocr2/plugins/ccip/commit_reporting_plugin_test.go
@@ -147,6 +147,7 @@ func TestCommitReportingPlugin_Observation(t *testing.T) {
 			p.priceGetter = priceGet
 			p.sourceNative = sourceNativeTokenAddr
 			p.gasPriceEstimator = gasPriceEstimator
+			p.metricsCollector = NoopMetricsCollector
 
 			obs, err := p.Observation(ctx, tc.epochAndRound, types.Query{})
 
@@ -317,6 +318,7 @@ func TestCommitReportingPlugin_Report(t *testing.T) {
 			p.gasPriceEstimator = gasPriceEstimator
 			p.offchainConfig.GasPriceHeartBeat = gasPriceHeartBeat.Duration()
 			p.commitStoreReader = commitStoreReader
+			p.metricsCollector = NoopMetricsCollector
 			p.F = tc.f
 
 			aos := make([]types.AttributedObservation, 0, len(tc.observations))

--- a/core/services/ocr2/plugins/ccip/execution_reporting_plugin.go
+++ b/core/services/ocr2/plugins/ccip/execution_reporting_plugin.go
@@ -373,7 +373,7 @@ func (r *ExecutionReportingPlugin) getExecutableObservations(ctx context.Context
 }
 
 // destPoolRateLimits returns a map that consists of the rate limits of each destination token of the provided reports.
-// If a token is missing from the returned map it either means that token was not found or token pool is noop for this token.
+// If a token is missing from the returned map it either means that token was not found or token pool is disabled for this token.
 func (r *ExecutionReportingPlugin) destPoolRateLimits(ctx context.Context, commitReports []commitReportWithSendRequests, sourceToDestToken map[common.Address]common.Address) (map[common.Address]*big.Int, error) {
 	tokenPools, err := r.offRampReader.GetDestinationTokenPools(ctx)
 	if err != nil {
@@ -422,7 +422,7 @@ func (r *ExecutionReportingPlugin) destPoolRateLimits(ctx context.Context, commi
 
 	res := make(map[common.Address]*big.Int, len(dstTokenToPool))
 	for i, rateLimit := range rateLimits {
-		// if the rate limit is noop for this token pool then we omit it from the result
+		// if the rate limit is disabled for this token pool then we omit it from the result
 		if !rateLimit.IsEnabled {
 			continue
 		}

--- a/core/services/ocr2/plugins/ccip/execution_reporting_plugin_test.go
+++ b/core/services/ocr2/plugins/ccip/execution_reporting_plugin_test.go
@@ -150,6 +150,7 @@ func TestExecutionReportingPlugin_Observation(t *testing.T) {
 			p.sourcePriceRegistry = sourcePriceRegReader
 
 			p.snoozedRoots = cache.NewSnoozedRoots(time.Minute, time.Minute)
+			p.metricsCollector = NoopMetricsCollector
 
 			_, err := p.Observation(ctx, types.ReportTimestamp{}, types.Query{})
 			if tc.expErr {
@@ -332,6 +333,7 @@ func TestExecutionReportingPlugin_buildReport(t *testing.T) {
 	// ensure that buildReport should cap the built report to fit in MaxExecutionReportLength
 	p := &ExecutionReportingPlugin{}
 	p.lggr = logger.TestLogger(t)
+	p.metricsCollector = NoopMetricsCollector
 
 	commitStore := ccipdatamocks.NewCommitStoreReader(t)
 	commitStore.On("VerifyExecutionReport", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
@@ -797,7 +799,7 @@ func TestExecutionReportingPlugin_destPoolRateLimits(t *testing.T) {
 			expErr: false,
 		},
 		{
-			name: "pool is disabled",
+			name: "pool is noop",
 			tokenAmounts: []internal.TokenAmount{
 				{Token: tk1},
 				{Token: tk2},

--- a/core/services/ocr2/plugins/ccip/execution_reporting_plugin_test.go
+++ b/core/services/ocr2/plugins/ccip/execution_reporting_plugin_test.go
@@ -799,7 +799,7 @@ func TestExecutionReportingPlugin_destPoolRateLimits(t *testing.T) {
 			expErr: false,
 		},
 		{
-			name: "pool is noop",
+			name: "pool is disabled",
 			tokenAmounts: []internal.TokenAmount{
 				{Token: tk1},
 				{Token: tk2},

--- a/core/services/ocr2/plugins/ccip/internal/observability/commit_store.go
+++ b/core/services/ocr2/plugins/ccip/internal/observability/commit_store.go
@@ -61,18 +61,6 @@ func (o *ObservedCommitStoreReader) IsBlessed(ctx context.Context, root [32]byte
 	})
 }
 
-func (o *ObservedCommitStoreReader) EncodeCommitReport(report ccipdata.CommitStoreReport) ([]byte, error) {
-	return withObservedInteraction(o.metric, "EncodeCommitReport", func() ([]byte, error) {
-		return o.CommitStoreReader.EncodeCommitReport(report)
-	})
-}
-
-func (o *ObservedCommitStoreReader) DecodeCommitReport(report []byte) (ccipdata.CommitStoreReport, error) {
-	return withObservedInteraction(o.metric, "DecodeCommitReport", func() (ccipdata.CommitStoreReport, error) {
-		return o.CommitStoreReader.DecodeCommitReport(report)
-	})
-}
-
 func (o *ObservedCommitStoreReader) VerifyExecutionReport(ctx context.Context, report ccipdata.ExecReport) (bool, error) {
 	return withObservedInteraction(o.metric, "VerifyExecutionReport", func() (bool, error) {
 		return o.CommitStoreReader.VerifyExecutionReport(ctx, report)

--- a/core/services/ocr2/plugins/ccip/internal/observability/metrics.go
+++ b/core/services/ocr2/plugins/ccip/internal/observability/metrics.go
@@ -15,11 +15,15 @@ var (
 		float64(50 * time.Millisecond),
 		float64(75 * time.Millisecond),
 		float64(100 * time.Millisecond),
-		float64(250 * time.Millisecond),
+		float64(200 * time.Millisecond),
+		float64(300 * time.Millisecond),
+		float64(400 * time.Millisecond),
 		float64(500 * time.Millisecond),
 		float64(750 * time.Millisecond),
 		float64(1 * time.Second),
 		float64(2 * time.Second),
+		float64(3 * time.Second),
+		float64(4 * time.Second),
 	}
 	labels          = []string{"evmChainID", "plugin", "reader", "function", "success"}
 	readerHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{

--- a/core/services/ocr2/plugins/ccip/internal/observability/offramp.go
+++ b/core/services/ocr2/plugins/ccip/internal/observability/offramp.go
@@ -27,18 +27,6 @@ func NewObservedOffRampReader(origin ccipdata.OffRampReader, chainID int64, plug
 	}
 }
 
-func (o *ObservedOffRampReader) EncodeExecutionReport(report ccipdata.ExecReport) ([]byte, error) {
-	return withObservedInteraction(o.metric, "EncodeExecutionReport", func() ([]byte, error) {
-		return o.OffRampReader.EncodeExecutionReport(report)
-	})
-}
-
-func (o *ObservedOffRampReader) DecodeExecutionReport(report []byte) (ccipdata.ExecReport, error) {
-	return withObservedInteraction(o.metric, "DecodeExecutionReport", func() (ccipdata.ExecReport, error) {
-		return o.OffRampReader.DecodeExecutionReport(report)
-	})
-}
-
 func (o *ObservedOffRampReader) GetExecutionStateChangesBetweenSeqNums(ctx context.Context, seqNumMin, seqNumMax uint64, confs int) ([]ccipdata.Event[ccipdata.ExecutionStateChanged], error) {
 	return withObservedInteraction(o.metric, "GetExecutionStateChangesBetweenSeqNums", func() ([]ccipdata.Event[ccipdata.ExecutionStateChanged], error) {
 		return o.OffRampReader.GetExecutionStateChangesBetweenSeqNums(ctx, seqNumMin, seqNumMax, confs)

--- a/core/services/ocr2/plugins/ccip/internal/observability/onramp.go
+++ b/core/services/ocr2/plugins/ccip/internal/observability/onramp.go
@@ -39,12 +39,6 @@ func (o ObservedOnRampReader) RouterAddress() (common.Address, error) {
 	})
 }
 
-func (o ObservedOnRampReader) Address() (common.Address, error) {
-	return withObservedInteraction(o.metric, "Address", func() (common.Address, error) {
-		return o.OnRampReader.Address()
-	})
-}
-
 func (o ObservedOnRampReader) GetDynamicConfig() (ccipdata.OnRampDynamicConfig, error) {
 	return withObservedInteraction(o.metric, "GetDynamicConfig", func() (ccipdata.OnRampDynamicConfig, error) {
 		return o.OnRampReader.GetDynamicConfig()

--- a/core/services/ocr2/plugins/ccip/metrics.go
+++ b/core/services/ocr2/plugins/ccip/metrics.go
@@ -30,7 +30,7 @@ var (
 	messagesProcessed = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "ccip_number_of_messages_processed",
 		Help: "Number of messages processed by the plugin during different OCR phases",
-	}, []string{"plugin", "source", "dest", "ocr_phase"})
+	}, []string{"plugin", "source", "dest", "ocrPhase"})
 	sequenceNumberCounter = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "ccip_sequence_number_counter",
 		Help: "Sequence number of the last message processed by the plugin",

--- a/core/services/ocr2/plugins/ccip/metrics_test.go
+++ b/core/services/ocr2/plugins/ccip/metrics_test.go
@@ -1,0 +1,20 @@
+package ccip
+
+var (
+	// NoopMetricsCollector is a no-op implementation of PluginMetricsCollector
+	NoopMetricsCollector PluginMetricsCollector = noop{}
+)
+
+type noop struct{}
+
+func (d noop) NumberOfMessagesProcessed(ocrPhase, int) {
+}
+
+func (d noop) NumberOfMessagesBasedOnInterval(ocrPhase, uint64, uint64) {
+}
+
+func (d noop) UnexpiredCommitRoots(int) {
+}
+
+func (d noop) SequenceNumber(uint64) {
+}


### PR DESCRIPTION
# To be tested on real deployment first

## Solution

* Removing observability layers from pure functions in Reader (e.g. encodeReport)
* Removing unused metrics from the Exec plugin (at this moment, most of the durations are covered by the OCR2 metrics)
* Adding Gauge metrics for number of messages processed within a single round 

Some of these overlap with the OCR2 telemetry. This is intentional because the cost of adding/removing prom metrics is very low, and they will give me many insights during tests. However, OCR2 telemetry is not ready yet. 