### PR TITLE
offchain - decouple exec plugin from evm specific details

### DIFF
--- a/core/services/ocr2/plugins/ccip/execution_plugin.go
+++ b/core/services/ocr2/plugins/ccip/execution_plugin.go
@@ -125,7 +125,6 @@ func jobSpecToExecPluginConfig(lggr logger.Logger, jb job.Job, chainSet evm.Lega
 			sourceLP:                 sourceChain.LogPoller(),
 			destLP:                   destChain.LogPoller(),
 			onRampReader:             onRampReader,
-			destReader:               ccipdata.NewLogPollerReader(destChain.LogPoller(), execLggr, destChain.Client()),
 			commitStoreReader:        commitStoreReader,
 			offRampReader:            offRampReader,
 			sourcePriceRegistry:      sourcePriceRegistry,

--- a/core/services/ocr2/plugins/ccip/execution_reporting_plugin.go
+++ b/core/services/ocr2/plugins/ccip/execution_reporting_plugin.go
@@ -65,17 +65,26 @@ type ExecutionPluginStaticConfig struct {
 }
 
 type ExecutionReportingPlugin struct {
-	config ExecutionPluginStaticConfig
-
-	F                 int
-	lggr              logger.Logger
-	inflightReports   *inflightExecReportsContainer
-	snoozedRoots      cache.SnoozedRoots
+	// Misc
+	F                  int
+	lggr               logger.Logger
+	offchainConfig     ccipdata.ExecOffchainConfig
+	tokenDataProviders map[common.Address]tokendata.Reader
+	// Source
+	gasPriceEstimator        prices.GasPriceEstimatorExec
+	sourcePriceRegistry      ccipdata.PriceRegistryReader
+	sourceWrappedNativeToken common.Address
+	onRampReader             ccipdata.OnRampReader
+	// Dest
+	commitStoreReader ccipdata.CommitStoreReader
 	destPriceRegistry ccipdata.PriceRegistryReader
 	destWrappedNative common.Address
 	onchainConfig     ccipdata.ExecOnchainConfig
-	offchainConfig    ccipdata.ExecOffchainConfig
-	gasPriceEstimator prices.GasPriceEstimatorExec
+	offRampReader     ccipdata.OffRampReader
+	destReader        ccipdata.Reader // todo: remove
+	// State
+	inflightReports *inflightExecReportsContainer
+	snoozedRoots    cache.SnoozedRoots
 }
 
 type ExecutionReportingPluginFactory struct {
@@ -138,16 +147,22 @@ func (rf *ExecutionReportingPluginFactory) NewReportingPlugin(config types.Repor
 	offchainConfig := rf.config.offRampReader.OffchainConfig()
 
 	return &ExecutionReportingPlugin{
-			config:            rf.config,
-			F:                 config.F,
-			lggr:              rf.config.lggr.Named("ExecutionReportingPlugin"),
-			snoozedRoots:      cache.NewSnoozedRoots(rf.config.offRampReader.OnchainConfig().PermissionLessExecutionThresholdSeconds, offchainConfig.RootSnoozeTime.Duration()),
-			inflightReports:   newInflightExecReportsContainer(offchainConfig.InflightCacheExpiry.Duration()),
-			destPriceRegistry: rf.destPriceRegReader,
-			destWrappedNative: destWrappedNative,
-			onchainConfig:     rf.config.offRampReader.OnchainConfig(),
-			offchainConfig:    offchainConfig,
-			gasPriceEstimator: rf.config.offRampReader.GasPriceEstimator(),
+			F:                        config.F,
+			lggr:                     rf.config.lggr.Named("ExecutionReportingPlugin"),
+			offchainConfig:           offchainConfig,
+			tokenDataProviders:       rf.config.tokenDataProviders,
+			gasPriceEstimator:        rf.config.offRampReader.GasPriceEstimator(),
+			sourcePriceRegistry:      rf.config.sourcePriceRegistry,
+			sourceWrappedNativeToken: rf.config.sourceWrappedNativeToken,
+			onRampReader:             rf.config.onRampReader,
+			commitStoreReader:        rf.config.commitStoreReader,
+			destPriceRegistry:        rf.destPriceRegReader,
+			destWrappedNative:        destWrappedNative,
+			onchainConfig:            rf.config.offRampReader.OnchainConfig(),
+			offRampReader:            rf.config.offRampReader,
+			destReader:               rf.config.destReader,
+			inflightReports:          newInflightExecReportsContainer(offchainConfig.InflightCacheExpiry.Duration()),
+			snoozedRoots:             cache.NewSnoozedRoots(rf.config.offRampReader.OnchainConfig().PermissionLessExecutionThresholdSeconds, offchainConfig.RootSnoozeTime.Duration()),
 		}, types.ReportingPluginInfo{
 			Name: "CCIPExecution",
 			// Setting this to false saves on calldata since OffRamp doesn't require agreement between NOPs
@@ -166,7 +181,7 @@ func (r *ExecutionReportingPlugin) Query(context.Context, types.ReportTimestamp)
 
 func (r *ExecutionReportingPlugin) Observation(ctx context.Context, timestamp types.ReportTimestamp, query types.Query) (types.Observation, error) {
 	lggr := r.lggr.Named("ExecutionObservation")
-	down, err := r.config.commitStoreReader.IsDown(ctx)
+	down, err := r.commitStoreReader.IsDown(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "isDown check errored")
 	}
@@ -206,7 +221,7 @@ func (r *ExecutionReportingPlugin) Observation(ctx context.Context, timestamp ty
 func (r *ExecutionReportingPlugin) getExecutableObservations(ctx context.Context, lggr logger.Logger, timestamp types.ReportTimestamp, inflight []InflightInternalExecutionReport) ([]ObservedMessage, error) {
 	unexpiredReports, err := r.getUnexpiredCommitReports(
 		ctx,
-		r.config.commitStoreReader,
+		r.commitStoreReader,
 		r.onchainConfig.PermissionLessExecutionThresholdSeconds,
 		lggr,
 	)
@@ -228,27 +243,27 @@ func (r *ExecutionReportingPlugin) getExecutableObservations(ctx context.Context
 		// always be the lower bound of what would be available on chain
 		// since we already account for inflight txs.
 		getAllowedTokenAmount := cache.LazyFetch(func() (evm_2_evm_offramp.RateLimiterTokenBucket, error) {
-			return r.config.offRampReader.CurrentRateLimiterState(ctx)
+			return r.offRampReader.CurrentRateLimiterState(ctx)
 		})
 
 		getSourceTokensPrices := cache.LazyFetch(func() (map[common.Address]*big.Int, error) {
-			sourceFeeTokens, err := r.config.sourcePriceRegistry.GetFeeTokens(ctx)
+			sourceFeeTokens, err := r.sourcePriceRegistry.GetFeeTokens(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("get source fee tokens: %w", err)
 			}
 			return getTokensPrices(
 				ctx,
-				r.config.sourcePriceRegistry,
-				append([]common.Address{r.config.sourceWrappedNativeToken}, sourceFeeTokens...),
+				r.sourcePriceRegistry,
+				append([]common.Address{r.sourceWrappedNativeToken}, sourceFeeTokens...),
 			)
 		})
 
 		getSourceToDestTokens := cache.LazyFetch(func() (map[common.Address]common.Address, error) {
-			return r.config.offRampReader.GetSourceToDestTokensMapping(ctx)
+			return r.offRampReader.GetSourceToDestTokensMapping(ctx)
 		})
 
 		getDestTokensPrices := cache.LazyFetch(func() (map[common.Address]*big.Int, error) {
-			destFeeTokens, destBridgedTokens, err := ccipcommon.GetDestinationTokens(ctx, r.config.offRampReader, r.destPriceRegistry)
+			destFeeTokens, destBridgedTokens, err := ccipcommon.GetDestinationTokens(ctx, r.offRampReader, r.destPriceRegistry)
 			if err != nil {
 				return nil, fmt.Errorf("get destination tokens: %w", err)
 			}
@@ -307,7 +322,7 @@ func (r *ExecutionReportingPlugin) getExecutableObservations(ctx context.Context
 				continue
 			}
 
-			blessed, err := r.config.commitStoreReader.IsBlessed(ctx, merkleRoot)
+			blessed, err := r.commitStoreReader.IsBlessed(ctx, merkleRoot)
 			if err != nil {
 				return nil, err
 			}
@@ -366,7 +381,7 @@ func (r *ExecutionReportingPlugin) getExecutableObservations(ctx context.Context
 // destPoolRateLimits returns a map that consists of the rate limits of each destination token of the provided reports.
 // If a token is missing from the returned map it either means that token was not found or token pool is disabled for this token.
 func (r *ExecutionReportingPlugin) destPoolRateLimits(ctx context.Context, commitReports []commitReportWithSendRequests, sourceToDestToken map[common.Address]common.Address) (map[common.Address]*big.Int, error) {
-	tokenPools, err := r.config.offRampReader.GetDestinationTokenPools(ctx)
+	tokenPools, err := r.offRampReader.GetDestinationTokenPools(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("get cached token pools: %w", err)
 	}
@@ -406,7 +421,7 @@ func (r *ExecutionReportingPlugin) destPoolRateLimits(ctx context.Context, commi
 		}
 	}
 
-	rateLimits, err := r.config.offRampReader.GetTokenPoolsRateLimits(ctx, dstPools)
+	rateLimits, err := r.offRampReader.GetTokenPoolsRateLimits(ctx, dstPools)
 	if err != nil {
 		return nil, fmt.Errorf("fetch pool rate limits: %w", err)
 	}
@@ -432,7 +447,7 @@ func (r *ExecutionReportingPlugin) destPoolRateLimits(ctx context.Context, commi
 // before. It doesn't matter if the executed succeeded, since we don't retry previous
 // attempts even if they failed. Value in the map indicates whether the log is finalized or not.
 func (r *ExecutionReportingPlugin) getExecutedSeqNrsInRange(ctx context.Context, min, max uint64, latestBlock int64) (map[uint64]bool, error) {
-	stateChanges, err := r.config.offRampReader.GetExecutionStateChangesBetweenSeqNums(
+	stateChanges, err := r.offRampReader.GetExecutionStateChangesBetweenSeqNums(
 		ctx,
 		min,
 		max,
@@ -492,7 +507,7 @@ func (r *ExecutionReportingPlugin) buildBatch(
 			} else {
 				// Nothing inflight take from chain.
 				// Chain holds existing nonce.
-				nonce, err := r.config.offRampReader.GetSenderNonce(ctx, msg.Sender)
+				nonce, err := r.offRampReader.GetSenderNonce(ctx, msg.Sender)
 				if err != nil {
 					lggr.Errorw("unable to get sender nonce", "err", err, "seqNr", msg.SequenceNumber)
 					continue
@@ -523,7 +538,7 @@ func (r *ExecutionReportingPlugin) buildBatch(
 			continue
 		}
 
-		tokenData, err2 := getTokenData(ctx, msgLggr, msg, r.config.tokenDataProviders, skipTokenWithData)
+		tokenData, err2 := getTokenData(ctx, msgLggr, msg, r.tokenDataProviders, skipTokenWithData)
 		if err2 != nil {
 			// When fetching token data, 3rd party API could hang or rate limit or fail due to any reason.
 			// If this happens, we skip all remaining msgs that require token data in this batch.
@@ -767,7 +782,7 @@ func (r *ExecutionReportingPlugin) getReportsWithSendRequests(
 	var sendRequests []ccipdata.Event[internal.EVM2EVMMessage]
 	eg.Go(func() error {
 		// We don't need to double-check if logs are finalized because we already checked that in the Commit phase.
-		sendReqs, err := r.config.onRampReader.GetSendRequestsBetweenSeqNums(ctx, intervalMin, intervalMax, false)
+		sendReqs, err := r.onRampReader.GetSendRequestsBetweenSeqNums(ctx, intervalMin, intervalMax, false)
 		if err != nil {
 			return err
 		}
@@ -777,7 +792,7 @@ func (r *ExecutionReportingPlugin) getReportsWithSendRequests(
 
 	var executedSeqNums map[uint64]bool
 	eg.Go(func() error {
-		latestBlock, err := r.config.destReader.LatestBlock(ctx)
+		latestBlock, err := r.destReader.LatestBlock(ctx)
 		if err != nil {
 			return err
 		}
@@ -843,16 +858,16 @@ func aggregateTokenValue(destTokenPricesUSD map[common.Address]*big.Int, sourceT
 // Assumes non-empty report. Messages to execute can span more than one report, but are assumed to be in order of increasing
 // sequence number.
 func (r *ExecutionReportingPlugin) buildReport(ctx context.Context, lggr logger.Logger, observedMessages []ObservedMessage) ([]byte, error) {
-	if err := validateSeqNumbers(ctx, r.config.commitStoreReader, observedMessages); err != nil {
+	if err := validateSeqNumbers(ctx, r.commitStoreReader, observedMessages); err != nil {
 		return nil, err
 	}
-	commitReport, err := getCommitReportForSeqNum(ctx, r.config.commitStoreReader, observedMessages[0].SeqNr)
+	commitReport, err := getCommitReportForSeqNum(ctx, r.commitStoreReader, observedMessages[0].SeqNr)
 	if err != nil {
 		return nil, err
 	}
 	lggr.Infow("Building execution report", "observations", observedMessages, "merkleRoot", hexutil.Encode(commitReport.MerkleRoot[:]), "report", commitReport)
 
-	sendReqsInRoot, leaves, tree, err := getProofData(ctx, r.config.onRampReader, commitReport.Interval)
+	sendReqsInRoot, leaves, tree, err := getProofData(ctx, r.onRampReader, commitReport.Interval)
 	if err != nil {
 		return nil, err
 	}
@@ -865,7 +880,7 @@ func (r *ExecutionReportingPlugin) buildReport(ctx context.Context, lggr logger.
 			return false
 		}
 
-		encoded, err2 := r.config.offRampReader.EncodeExecutionReport(report)
+		encoded, err2 := r.offRampReader.EncodeExecutionReport(report)
 		if err2 != nil {
 			// false makes Search keep looking to the right, always including any "erroring" ObservedMessage and allowing us to detect in the bottom
 			return false
@@ -881,7 +896,7 @@ func (r *ExecutionReportingPlugin) buildReport(ctx context.Context, lggr logger.
 		return nil, err
 	}
 
-	encodedReport, err := r.config.offRampReader.EncodeExecutionReport(execReport)
+	encodedReport, err := r.offRampReader.EncodeExecutionReport(execReport)
 	if err != nil {
 		return nil, err
 	}
@@ -893,7 +908,7 @@ func (r *ExecutionReportingPlugin) buildReport(ctx context.Context, lggr logger.
 		)
 	}
 	// Double check this verifies before sending.
-	valid, err := r.config.commitStoreReader.VerifyExecutionReport(ctx, execReport)
+	valid, err := r.commitStoreReader.VerifyExecutionReport(ctx, execReport)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to verify")
 	}
@@ -990,7 +1005,7 @@ func calculateObservedMessagesConsensus(observations []ExecutionObservation, f i
 
 func (r *ExecutionReportingPlugin) ShouldAcceptFinalizedReport(ctx context.Context, timestamp types.ReportTimestamp, report types.Report) (bool, error) {
 	lggr := r.lggr.Named("ShouldAcceptFinalizedReport")
-	execReport, err := r.config.offRampReader.DecodeExecutionReport(report)
+	execReport, err := r.offRampReader.DecodeExecutionReport(report)
 	if err != nil {
 		lggr.Errorw("Unable to decode report", "err", err)
 		return false, err
@@ -1016,7 +1031,7 @@ func (r *ExecutionReportingPlugin) ShouldAcceptFinalizedReport(ctx context.Conte
 
 func (r *ExecutionReportingPlugin) ShouldTransmitAcceptedReport(ctx context.Context, timestamp types.ReportTimestamp, report types.Report) (bool, error) {
 	lggr := r.lggr.Named("ShouldTransmitAcceptedReport")
-	execReport, err := r.config.offRampReader.DecodeExecutionReport(report)
+	execReport, err := r.offRampReader.DecodeExecutionReport(report)
 	if err != nil {
 		lggr.Errorw("Unable to decode report", "err", err)
 		return false, nil
@@ -1047,7 +1062,7 @@ func (r *ExecutionReportingPlugin) isStaleReport(ctx context.Context, messages [
 	// If the first message is executed already, this execution report is stale.
 	// Note the default execution state, including for arbitrary seq number not yet committed
 	// is ExecutionStateUntouched.
-	msgState, err := r.config.offRampReader.GetExecutionState(ctx, messages[0].SequenceNumber)
+	msgState, err := r.offRampReader.GetExecutionState(ctx, messages[0].SequenceNumber)
 	if err != nil {
 		return true, err
 	}

--- a/core/services/ocr2/plugins/ccip/execution_reporting_plugin_test.go
+++ b/core/services/ocr2/plugins/ccip/execution_reporting_plugin_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
 	lpMocks "github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal"
@@ -108,10 +107,6 @@ func TestExecutionReportingPlugin_Observation(t *testing.T) {
 			commitStoreReader.On("GetAcceptedCommitReportsGteTimestamp", ctx, mock.Anything, 0).
 				Return(tc.unexpiredReports, nil).Maybe()
 			p.commitStoreReader = commitStoreReader
-
-			destReader := ccipdatamocks.NewReader(t)
-			destReader.On("LatestBlock", ctx).Return(logpoller.LogPollerBlock{BlockNumber: 1234}, nil).Maybe()
-			p.destReader = destReader
 
 			var executionEvents []ccipdata.Event[ccipdata.ExecutionStateChanged]
 			for _, seqNum := range tc.executedSeqNums {
@@ -910,7 +905,6 @@ func TestExecutionReportingPlugin_getReportsWithSendRequests(t *testing.T) {
 		expQueryMin         uint64 // expected min/max used in the query to get ccipevents
 		expQueryMax         uint64
 		onchainEvents       []ccipdata.Event[internal.EVM2EVMMessage]
-		destLatestBlock     int64
 		destExecutedSeqNums []uint64
 
 		expReports []commitReportWithSendRequests
@@ -941,7 +935,6 @@ func TestExecutionReportingPlugin_getReportsWithSendRequests(t *testing.T) {
 				{Data: internal.EVM2EVMMessage{SequenceNumber: 2}},
 				{Data: internal.EVM2EVMMessage{SequenceNumber: 3}},
 			},
-			destLatestBlock:     10_000,
 			destExecutedSeqNums: []uint64{1},
 			expReports: []commitReportWithSendRequests{
 				{
@@ -995,17 +988,23 @@ func TestExecutionReportingPlugin_getReportsWithSendRequests(t *testing.T) {
 				Return(tc.onchainEvents, nil).Maybe()
 			p.onRampReader = sourceReader
 
-			destReader := ccipdatamocks.NewReader(t)
-			destReader.On("LatestBlock", ctx).Return(logpoller.LogPollerBlock{BlockNumber: tc.destLatestBlock}, nil).Maybe()
+			finalized := make(map[uint64]bool)
+			for _, r := range tc.expReports {
+				for _, s := range r.sendRequestsWithMeta {
+					finalized[s.SequenceNumber] = s.Finalized
+				}
+			}
+
 			var executedEvents []ccipdata.Event[ccipdata.ExecutionStateChanged]
 			for _, executedSeqNum := range tc.destExecutedSeqNums {
 				executedEvents = append(executedEvents, ccipdata.Event[ccipdata.ExecutionStateChanged]{
-					Data: ccipdata.ExecutionStateChanged{SequenceNumber: executedSeqNum},
-					Meta: ccipdata.Meta{BlockNumber: tc.destLatestBlock - 10},
+					Data: ccipdata.ExecutionStateChanged{
+						SequenceNumber: executedSeqNum,
+						Finalized:      finalized[executedSeqNum],
+					},
 				})
 			}
 			offRampReader.On("GetExecutionStateChangesBetweenSeqNums", ctx, tc.expQueryMin, tc.expQueryMax, 0).Return(executedEvents, nil).Maybe()
-			p.destReader = destReader
 
 			populatedReports, err := p.getReportsWithSendRequests(ctx, tc.reports)
 			if tc.expErr {
@@ -1025,116 +1024,6 @@ func TestExecutionReportingPlugin_getReportsWithSendRequests(t *testing.T) {
 		})
 	}
 }
-
-/*
-func TestExecutionReportingPluginFactory_UpdateLogPollerFilters(t *testing.T) {
-	const numFilters = 10
-	filters := make([]logpoller.Filter, numFilters)
-	for i := range filters {
-		filters[i] = logpoller.Filter{
-			Name:      fmt.Sprintf("filter-%d", i),
-			EventSigs: []common.Hash{common.HexToHash(fmt.Sprintf("%d", i))},
-			Addresses: []common.Address{common.HexToAddress(fmt.Sprintf("%d", i))},
-			Retention: time.Duration(i) * time.Second,
-		}
-	}
-
-	destLP := lpMocks.NewLogPoller(t)
-	sourceLP := lpMocks.NewLogPoller(t)
-
-	onRamp, _ := testhelpers.NewFakeOnRamp(t)
-	sourcePriceRegistry, _ := testhelpers.NewFakePriceRegistry(t)
-	commitStoreReader, _ := testhelpers.NewFakeCommitStore(t, 1)
-	offRamp, _ := testhelpers.NewFakeOffRamp(t)
-
-	destPriceRegistryAddr := utils.RandomAddress()
-
-	tokenDataProviders := make(map[common.Address]tokendata.Reader)
-
-	rf := &ExecutionReportingPluginFactory{
-		filtersMu:          &sync.Mutex{},
-		sourceChainFilters: filters[:5],
-		destChainFilters:   filters[5:10],
-		config: ExecutionPluginStaticConfig{
-			destLP:              destLP,
-			sourceLP:            sourceLP,
-			onRamp:              onRamp,
-			commitStoreReader:         commitStoreReader,
-			offRamp:             offRamp,
-			sourcePriceRegistry: sourcePriceRegistry,
-			tokenDataProviders:  tokenDataProviders,
-		},
-	}
-
-	for _, f := range getExecutionPluginSourceLpChainFilters(sourcePriceRegistry.Address()) {
-		sourceLP.On("RegisterFilter", f).Return(nil)
-	}
-	for _, f := range getExecutionPluginDestLpChainFilters(commitStoreReader.Address(), offRamp.Address(), destPriceRegistryAddr) {
-		destLP.On("RegisterFilter", f).Return(nil)
-	}
-	for _, f := range rf.sourceChainFilters[1:] { // zero address is skipped
-		sourceLP.On("UnregisterFilter", f.Name, mock.Anything).Return(nil)
-	}
-	for _, f := range rf.destChainFilters {
-		destLP.On("UnregisterFilter", f.Name, mock.Anything).Return(nil)
-	}
-
-	err := rf.UpdateLogPollerFilters(destPriceRegistryAddr)
-	assert.NoError(t, err)
-}
-*/
-
-/*
-func TestExecutionReportToEthTxMeta(t *testing.T) {
-	t.Run("happy flow", func(t *testing.T) {
-		executionReport := generateExecutionReport(t, 10, 3, 1000)
-		encExecReport, err := ccipdata.EncodeExecutionReport(executionReport)
-		assert.NoError(t, err)
-		txMeta, err := ExecutionReportToEthTxMeta(encExecReport)
-		assert.NoError(t, err)
-		assert.Len(t, txMeta.MessageIDs, len(executionReport.Messages))
-	})
-
-	t.Run("invalid report", func(t *testing.T) {
-		_, err := ExecutionReportToEthTxMeta([]byte("whatever"))
-		assert.Error(t, err)
-	})
-}
-*/
-
-/* this is a test related to the cache, should not be here
-func TestUpdateSourceToDestTokenMapping(t *testing.T) {
-	expectedNewBlockNumber := int64(10000)
-	logs := []logpoller.Log{{BlockNumber: expectedNewBlockNumber}}
-	mockDestLP := &lpMocks.LogPoller{}
-
-	mockDestLP.On("LatestLogEventSigsAddrsWithConfs", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(logs, nil)
-	mockDestLP.On("LatestBlock", mock.Anything).Return(expectedNewBlockNumber, nil)
-
-	sourceToken, destToken := common.HexToAddress("111111"), common.HexToAddress("222222")
-
-	mockOffRamp := ccipdata.NewMockOffRampReader(t)
-	mockOffRamp.On("Address").Return(common.HexToAddress("0x01"))
-	mockOffRamp.On("GetSupportedTokens", mock.Anything).Return([]common.Address{sourceToken}, nil)
-	mockOffRamp.On("GetDestinationToken", mock.Anything, sourceToken).Return(destToken, nil)
-
-	mockPriceRegistry := ccipdata.NewMockPriceRegistryReader(t)
-	mockPriceRegistry.On("Address").Return(common.HexToAddress("0x02"))
-	mockPriceRegistry.On("GetFeeTokens", mock.Anything).Return([]common.Address{}, nil)
-
-	plugin := ExecutionReportingPlugin{
-		config: ExecutionPluginStaticConfig{
-			destLP:        mockDestLP,
-			offRampReader: mockOffRamp,
-		},
-		cachedDestTokens: cache.NewCachedSupportedTokens(mockDestLP, mockOffRamp, mockPriceRegistry, 0),
-	}
-
-	value, err := plugin.cachedDestTokens.Get(context.Background())
-	require.NoError(t, err)
-	require.Equal(t, destToken, value.SupportedTokens[sourceToken])
-}
-*/
 
 func Test_calculateObservedMessagesConsensus(t *testing.T) {
 	type args struct {

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/logpoller.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/logpoller.go
@@ -16,8 +16,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/pg"
 )
 
-var _ Reader = &LogPollerReader{}
-
 // LogPollerReader implements the Reader interface by using a logPoller instance to fetch the events.
 type LogPollerReader struct {
 	lp     logpoller.LogPoller

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/offramp_reader.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/offramp_reader.go
@@ -85,6 +85,7 @@ func (c ExecOnchainConfig) Validate() error {
 
 type ExecutionStateChanged struct {
 	SequenceNumber uint64
+	Finalized      bool
 }
 
 type ExecReport struct {

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/reader.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/reader.go
@@ -1,12 +1,10 @@
 package ccipdata
 
 import (
-	"context"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pg"
 )
 
@@ -31,12 +29,4 @@ const (
 
 type Closer interface {
 	Close(qopts ...pg.QOpt) error
-}
-
-// Client can be used to fetch CCIP related parsed on-chain data.
-//
-//go:generate mockery --quiet --name Reader --filename reader_mock.go --case=underscore
-type Reader interface {
-	// LatestBlock returns the latest known/parsed block of the underlying implementation.
-	LatestBlock(ctx context.Context) (logpoller.LogPollerBlock, error)
 }


### PR DESCRIPTION
base
- remove Reader interface that had only one method `LatestBlock` and use finalized tag instead for fetching the block num
- remove all the evm specific details from exec plugin `(lp, ethClient, ..)`
- group fields similar to commit plugin

extras
- delete commented out tests