### PR TITLE
Skip typechain in hardhat compile

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -13,7 +13,7 @@
     "size": "hardhat size-contracts",
     "clean": "hardhat clean",
     "compile:native": "./scripts/native_solc_compile_all",
-    "compile": "hardhat compile",
+    "compile": "hardhat compile --no-typechain",
     "coverage": "hardhat coverage",
     "prepublishOnly": "pnpm compile && ./scripts/prepublish_generate_abi_folder",
     "publish-beta": "pnpm publish --tag beta",


### PR DESCRIPTION
## Motivation
https://github.com/smartcontractkit/ccip/actions/runs/7118245183/job/19380952166#step:5:1564
```
event ConfigSet(StaticConfig staticConfig, DynamicConfig dynamicConfig);
```
this particular `ConfigSet` signature in CommitStore, OffRamp, OnRamp triggers a Typescript bug in the new repo during hardhat compile, and for some reason doesn't in the old repo, even when I make all the dependencies identical. Interestingly, this issue exists in the new repo since the very first compilable commit. I looked into every diff between that 1st compilable commit and old repo, didn't find anything meaningful.

## Solution
We do not include Typechain in the release anyway. Typechain should be considered legacy, we can skip it in Hardhat compile.
