### PR TITLE
offchain - chain agnostic plugin ocr2 factories

### DIFF
--- a/core/services/ocr2/plugins/ccip/commit_plugin.go
+++ b/core/services/ocr2/plugins/ccip/commit_plugin.go
@@ -3,6 +3,7 @@ package ccip
 import (
 	"context"
 	"encoding/json"
+	"math/big"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
@@ -110,6 +111,7 @@ func jobSpecToCommitPluginConfig(lggr logger.Logger, jb job.Job, pr pipeline.Run
 			priceGetter:           pipelinePriceGetter,
 			sourceNative:          sourceNative,
 			sourceChainSelector:   staticConfig.SourceChainSelector,
+			destChainSelector:     staticConfig.ChainSelector,
 			commitStore:           commitStoreReader,
 			priceRegistryProvider: ccipdataprovider.NewEvmPriceRegistry(destChain.LogPoller(), destChain.Client(), commitLggr, CommitPluginLabel),
 		}, &BackfillArgs{
@@ -139,7 +141,7 @@ func NewCommitServices(lggr logger.Logger, jb job.Job, chainSet evm.LegacyChainC
 		return nil, err1
 	}
 
-	argsNoPlugin.ReportingPluginFactory = promwrapper.NewPromFactory(wrappedPluginFactory, "CCIPCommit", jb.OCR2OracleSpec.Relay, pluginConfig.destChainEVMID)
+	argsNoPlugin.ReportingPluginFactory = promwrapper.NewPromFactory(wrappedPluginFactory, "CCIPCommit", jb.OCR2OracleSpec.Relay, big.NewInt(0).SetUint64(pluginConfig.destChainSelector))
 	argsNoPlugin.Logger = relaylogger.NewOCRWrapper(pluginConfig.lggr, true, logError)
 	oracle, err := libocr2.NewOracle(argsNoPlugin)
 	if err != nil {

--- a/core/services/ocr2/plugins/ccip/commit_plugin.go
+++ b/core/services/ocr2/plugins/ccip/commit_plugin.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
+	chainselectors "github.com/smartcontractkit/chain-selectors"
 	libocr2 "github.com/smartcontractkit/libocr/offchainreporting2plus"
 
 	relaylogger "github.com/smartcontractkit/chainlink-relay/pkg/logger"
@@ -141,7 +142,11 @@ func NewCommitServices(lggr logger.Logger, jb job.Job, chainSet evm.LegacyChainC
 		return nil, err1
 	}
 
-	argsNoPlugin.ReportingPluginFactory = promwrapper.NewPromFactory(wrappedPluginFactory, "CCIPCommit", jb.OCR2OracleSpec.Relay, big.NewInt(0).SetUint64(pluginConfig.destChainSelector))
+	destChainID, err := chainselectors.ChainIdFromSelector(pluginConfig.destChainSelector)
+	if err != nil {
+		return nil, err
+	}
+	argsNoPlugin.ReportingPluginFactory = promwrapper.NewPromFactory(wrappedPluginFactory, "CCIPCommit", jb.OCR2OracleSpec.Relay, big.NewInt(0).SetUint64(destChainID))
 	argsNoPlugin.Logger = relaylogger.NewOCRWrapper(pluginConfig.lggr, true, logError)
 	oracle, err := libocr2.NewOracle(argsNoPlugin)
 	if err != nil {

--- a/core/services/ocr2/plugins/ccip/commit_reporting_plugin.go
+++ b/core/services/ocr2/plugins/ccip/commit_reporting_plugin.go
@@ -20,6 +20,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipcalc"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipcommon"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipdata"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipdata/ccipdataprovider"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/pricegetter"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/prices"
 	"github.com/smartcontractkit/chainlink/v2/core/utils/mathutil"
@@ -50,10 +51,6 @@ type update struct {
 	value     *big.Int
 }
 
-type PriceRegistryProvider interface {
-	NewPriceRegistryReader(ctx context.Context, addr common.Address) (ccipdata.PriceRegistryReader, error)
-}
-
 type CommitPluginStaticConfig struct {
 	lggr logger.Logger
 	// Source
@@ -64,7 +61,7 @@ type CommitPluginStaticConfig struct {
 	offRamp               ccipdata.OffRampReader
 	commitStore           ccipdata.CommitStoreReader
 	destChainEVMID        *big.Int // todo: this field is not initialized
-	priceRegistryProvider PriceRegistryProvider
+	priceRegistryProvider ccipdataprovider.PriceRegistry
 	// Offchain
 	priceGetter pricegetter.PriceGetter
 }

--- a/core/services/ocr2/plugins/ccip/commit_reporting_plugin.go
+++ b/core/services/ocr2/plugins/ccip/commit_reporting_plugin.go
@@ -60,7 +60,7 @@ type CommitPluginStaticConfig struct {
 	// Dest
 	offRamp               ccipdata.OffRampReader
 	commitStore           ccipdata.CommitStoreReader
-	destChainEVMID        *big.Int // todo: this field is not initialized
+	destChainSelector     uint64
 	priceRegistryProvider ccipdataprovider.PriceRegistry
 	// Offchain
 	priceGetter pricegetter.PriceGetter

--- a/core/services/ocr2/plugins/ccip/execution_plugin.go
+++ b/core/services/ocr2/plugins/ccip/execution_plugin.go
@@ -163,7 +163,11 @@ func NewExecutionServices(lggr logger.Logger, jb job.Job, chainSet evm.LegacyCha
 		return nil, err1
 	}
 
-	argsNoPlugin.ReportingPluginFactory = promwrapper.NewPromFactory(wrappedPluginFactory, "CCIPExecution", jb.OCR2OracleSpec.Relay, big.NewInt(0).SetUint64(execPluginConfig.destChainSelector))
+	destChainID, err := chainselectors.ChainIdFromSelector(execPluginConfig.destChainSelector)
+	if err != nil {
+		return nil, err
+	}
+	argsNoPlugin.ReportingPluginFactory = promwrapper.NewPromFactory(wrappedPluginFactory, "CCIPExecution", jb.OCR2OracleSpec.Relay, big.NewInt(0).SetUint64(destChainID))
 	argsNoPlugin.Logger = relaylogger.NewOCRWrapper(execPluginConfig.lggr, true, logError)
 	oracle, err := libocr2.NewOracle(argsNoPlugin)
 	if err != nil {

--- a/core/services/ocr2/plugins/ccip/execution_plugin.go
+++ b/core/services/ocr2/plugins/ccip/execution_plugin.go
@@ -135,7 +135,6 @@ func jobSpecToExecPluginConfig(lggr logger.Logger, jb job.Job, chainSet evm.Lega
 			offRampReader:            offRampReader,
 			sourcePriceRegistry:      sourcePriceRegistry,
 			sourceWrappedNativeToken: sourceWrappedNative,
-			destGasEstimator:         destChain.GasEstimator(),
 			destChainSelector:        destChainSelector,
 			tokenDataProviders:       tokenDataProviders,
 			priceRegistryProvider:    ccipdataprovider.NewEvmPriceRegistry(destChain.LogPoller(), destChain.Client(), execLggr, ExecPluginLabel),

--- a/core/services/ocr2/plugins/ccip/execution_plugin.go
+++ b/core/services/ocr2/plugins/ccip/execution_plugin.go
@@ -15,6 +15,7 @@ import (
 	libocr2 "github.com/smartcontractkit/libocr/offchainreporting2plus"
 
 	relaylogger "github.com/smartcontractkit/chainlink-relay/pkg/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipdata/ccipdataprovider"
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
@@ -122,17 +123,15 @@ func jobSpecToExecPluginConfig(lggr logger.Logger, jb job.Job, chainSet evm.Lega
 		"sourceRouter", sourceRouter.Address())
 	return &ExecutionPluginStaticConfig{
 			lggr:                     execLggr,
-			sourceLP:                 sourceChain.LogPoller(),
-			destLP:                   destChain.LogPoller(),
 			onRampReader:             onRampReader,
 			commitStoreReader:        commitStoreReader,
 			offRampReader:            offRampReader,
 			sourcePriceRegistry:      sourcePriceRegistry,
 			sourceWrappedNativeToken: sourceWrappedNative,
-			destClient:               destChain.Client(),
 			destGasEstimator:         destChain.GasEstimator(),
 			destChainEVMID:           destChain.ID(),
 			tokenDataProviders:       tokenDataProviders,
+			priceRegistryProvider:    ccipdataprovider.NewEvmPriceRegistry(destChain.LogPoller(), destChain.Client(), execLggr, ExecPluginLabel),
 		}, &BackfillArgs{
 			sourceLP:         sourceChain.LogPoller(),
 			destLP:           destChain.LogPoller(),

--- a/core/services/ocr2/plugins/ccip/execution_reporting_plugin.go
+++ b/core/services/ocr2/plugins/ccip/execution_reporting_plugin.go
@@ -18,17 +18,15 @@ import (
 
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
-	evmclient "github.com/smartcontractkit/chainlink/v2/core/chains/evm/client"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/gas"
-	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/evm_2_evm_offramp"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/cache"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipcommon"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipdata"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipdata/ccipdataprovider"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/hashlib"
-	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/observability"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/prices"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/tokendata"
 )
@@ -50,16 +48,15 @@ var (
 
 type ExecutionPluginStaticConfig struct {
 	lggr                     logger.Logger
-	sourceLP, destLP         logpoller.LogPoller
 	onRampReader             ccipdata.OnRampReader
 	offRampReader            ccipdata.OffRampReader
 	commitStoreReader        ccipdata.CommitStoreReader
 	sourcePriceRegistry      ccipdata.PriceRegistryReader
 	sourceWrappedNativeToken common.Address
-	destClient               evmclient.Client
 	destChainEVMID           *big.Int
 	destGasEstimator         gas.EvmFeeEstimator
 	tokenDataProviders       map[common.Address]tokendata.Reader
+	priceRegistryProvider    ccipdataprovider.PriceRegistry
 }
 
 type ExecutionReportingPlugin struct {
@@ -120,11 +117,11 @@ func (rf *ExecutionReportingPluginFactory) UpdateDynamicReaders(newPriceRegAddr 
 			return err
 		}
 	}
-	destPriceRegistryReader, err := ccipdata.NewPriceRegistryReader(rf.config.lggr, newPriceRegAddr, rf.config.destLP, rf.config.destClient)
+
+	destPriceRegistryReader, err := rf.config.priceRegistryProvider.NewPriceRegistryReader(context.Background(), newPriceRegAddr)
 	if err != nil {
 		return err
 	}
-	destPriceRegistryReader = observability.NewPriceRegistryReader(destPriceRegistryReader, rf.config.destClient.ConfiguredChainID().Int64(), ExecPluginLabel)
 	rf.destPriceRegReader = destPriceRegistryReader
 	rf.destPriceRegAddr = newPriceRegAddr
 	return nil

--- a/core/services/ocr2/plugins/ccip/execution_reporting_plugin.go
+++ b/core/services/ocr2/plugins/ccip/execution_reporting_plugin.go
@@ -53,8 +53,8 @@ type ExecutionPluginStaticConfig struct {
 	commitStoreReader        ccipdata.CommitStoreReader
 	sourcePriceRegistry      ccipdata.PriceRegistryReader
 	sourceWrappedNativeToken common.Address
-	destChainEVMID           *big.Int
-	destGasEstimator         gas.EvmFeeEstimator
+	destChainSelector        uint64
+	destGasEstimator         gas.EvmFeeEstimator // todo: this is evm specific
 	tokenDataProviders       map[common.Address]tokendata.Reader
 	priceRegistryProvider    ccipdataprovider.PriceRegistry
 }

--- a/core/services/ocr2/plugins/ccip/execution_reporting_plugin.go
+++ b/core/services/ocr2/plugins/ccip/execution_reporting_plugin.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
-	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/gas"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/evm_2_evm_offramp"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal"
@@ -54,7 +53,6 @@ type ExecutionPluginStaticConfig struct {
 	sourcePriceRegistry      ccipdata.PriceRegistryReader
 	sourceWrappedNativeToken common.Address
 	destChainSelector        uint64
-	destGasEstimator         gas.EvmFeeEstimator // todo: this is evm specific
 	tokenDataProviders       map[common.Address]tokendata.Reader
 	priceRegistryProvider    ccipdataprovider.PriceRegistry
 }

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/ccipdataprovider/provider.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/ccipdataprovider/provider.go
@@ -37,5 +37,6 @@ func (p *EvmPriceRegistry) NewPriceRegistryReader(_ context.Context, addr common
 	if err != nil {
 		return nil, err
 	}
+
 	return observability.NewPriceRegistryReader(destPriceRegistryReader, p.ec.ConfiguredChainID().Int64(), p.pluginLabel), nil
 }

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/ccipdataprovider/provider.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/ccipdataprovider/provider.go
@@ -1,0 +1,41 @@
+package ccipdataprovider
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/client"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipdata"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/observability"
+)
+
+type PriceRegistry interface {
+	NewPriceRegistryReader(ctx context.Context, addr common.Address) (ccipdata.PriceRegistryReader, error)
+}
+
+type EvmPriceRegistry struct {
+	lp          logpoller.LogPoller
+	ec          client.Client
+	lggr        logger.Logger
+	pluginLabel string
+}
+
+func NewEvmPriceRegistry(lp logpoller.LogPoller, ec client.Client, lggr logger.Logger, pluginLabel string) *EvmPriceRegistry {
+	return &EvmPriceRegistry{
+		lp:          lp,
+		ec:          ec,
+		lggr:        lggr,
+		pluginLabel: pluginLabel,
+	}
+}
+
+func (p *EvmPriceRegistry) NewPriceRegistryReader(_ context.Context, addr common.Address) (ccipdata.PriceRegistryReader, error) {
+	destPriceRegistryReader, err := ccipdata.NewPriceRegistryReader(p.lggr, addr, p.lp, p.ec)
+	if err != nil {
+		return nil, err
+	}
+	return observability.NewPriceRegistryReader(destPriceRegistryReader, p.ec.ConfiguredChainID().Int64(), p.pluginLabel), nil
+}


### PR DESCRIPTION
Making ocr2 plugin factories chain-agnostic.

1. Create `ccipdataprovider` package that contains `PriceRegistryProvider`. This replaces the access to logPoller and ethereum client for dynamic initialization of price registry.

2. Replace chainIDs with chainSelectors.

3. Remove unused fields.


NOTES:
- The `destChainEVMID` field of commit plugin was not initialized.
- Wondering if replacing the chainID with chainSelector for exec plugin will break something:
```
promwrapper.NewPromFactory(..., chainID)
-->
promwrapper.NewPromFactory(..., chainSelector)
```
