### PR TITLE
Pass in value when simulating tx error

### DIFF
--- a/core/scripts/ccip/revert-reason/handler/reason.go
+++ b/core/scripts/ccip/revert-reason/handler/reason.go
@@ -150,6 +150,7 @@ func GetErrorForTx(client *ethclient.Client, txHash string, requester string) (s
 		From:     common.HexToAddress(requester),
 		To:       tx.To(),
 		Data:     tx.Data(),
+		Value:    tx.Value(),
 		Gas:      tx.Gas(),
 		GasPrice: tx.GasPrice(),
 	}


### PR DESCRIPTION
## Motivation
If sender paid by native, we need to simulate the tx with value, otherwise the simulation will revert with `InsufficientFeeTokenAmount` instead of the actual error

## Example
```
	ChainId     = uint64(42161)
	TxHash      = "0xf7eac32e354c3525cc902991de057f49c0591441b08524d12bbf631417e792ea"
	TxRequester = "0xafa2c441a83bbcedc2e8c5c6f66248afd8b9af3d"
```