### PR TITLE
ocr2: add CCIP spec validation

### DIFF
--- a/core/services/ocr2/plugins/ccip/commit_plugin.go
+++ b/core/services/ocr2/plugins/ccip/commit_plugin.go
@@ -33,7 +33,7 @@ import (
 
 type BackfillArgs struct {
 	sourceLP, destLP                 logpoller.LogPoller
-	sourceStartBlock, destStartBlock int64
+	sourceStartBlock, destStartBlock uint64
 }
 
 func jobSpecToCommitPluginConfig(lggr logger.Logger, jb job.Job, pr pipeline.Runner, chainSet evm.LegacyChainContainer, qopts ...pg.QOpt) (*CommitPluginStaticConfig, *BackfillArgs, error) {
@@ -80,7 +80,7 @@ func jobSpecToCommitPluginConfig(lggr logger.Logger, jb job.Job, pr pipeline.Run
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed onramp reader")
 	}
-	offRampReader, err := factory.NewOffRampReader(commitLggr, common.HexToAddress(pluginConfig.OffRamp), destChain.Client(), destChain.LogPoller(), destChain.GasEstimator())
+	offRampReader, err := factory.NewOffRampReader(commitLggr, pluginConfig.OffRamp, destChain.Client(), destChain.LogPoller(), destChain.GasEstimator())
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed offramp reader")
 	}

--- a/core/services/ocr2/plugins/ccip/config/config.go
+++ b/core/services/ocr2/plugins/ccip/config/config.go
@@ -8,10 +8,9 @@ import (
 )
 
 // CommitPluginJobSpecConfig contains the plugin specific variables for the ccip.CCIPCommit plugin.
-// We use ID here to keep it as general as possible, e.g. abstracting for chains which don't have an address concept.
 type CommitPluginJobSpecConfig struct {
-	SourceStartBlock, DestStartBlock int64  // Only for first time job add.
-	OffRamp                          string `json:"offRamp"`
+	SourceStartBlock, DestStartBlock uint64         // Only for first time job add.
+	OffRamp                          common.Address `json:"offRamp"`
 	// TokenPricesUSDPipeline should contain a token price pipeline for the following tokens:
 	//		The SOURCE chain wrapped native
 	// 		The DESTINATION supported tokens (including fee tokens) as defined in destination OffRamp and PriceRegistry.
@@ -20,7 +19,7 @@ type CommitPluginJobSpecConfig struct {
 
 // ExecutionPluginJobSpecConfig contains the plugin specific variables for the ccip.CCIPExecution plugin.
 type ExecutionPluginJobSpecConfig struct {
-	SourceStartBlock, DestStartBlock int64 // Only for first time job add.
+	SourceStartBlock, DestStartBlock uint64 // Only for first time job add.
 	USDCConfig                       USDCConfig
 }
 

--- a/core/services/ocr2/plugins/ccip/config/config_test.go
+++ b/core/services/ocr2/plugins/ccip/config/config_test.go
@@ -67,14 +67,14 @@ func TestUSDCValidate(t *testing.T) {
 		{
 			config: USDCConfig{
 				AttestationAPI:     "api",
-				SourceTokenAddress: common.HexToAddress("0x0123456789012345678901234567890123456789"),
+				SourceTokenAddress: utils.RandomAddress(),
 			},
 			err: "SourceMessageTransmitterAddress is required",
 		},
 		{
 			config: USDCConfig{
 				AttestationAPI:                  "api",
-				SourceTokenAddress:              common.HexToAddress("0x0123456789012345678901234567890123456789"),
+				SourceTokenAddress:              utils.RandomAddress(),
 				SourceMessageTransmitterAddress: utils.ZeroAddress,
 			},
 			err: "SourceMessageTransmitterAddress is required",
@@ -82,16 +82,16 @@ func TestUSDCValidate(t *testing.T) {
 		{
 			config: USDCConfig{
 				AttestationAPI:                  "api",
-				SourceTokenAddress:              common.HexToAddress("0x0123456789012345678901234567890123456789"),
-				SourceMessageTransmitterAddress: common.HexToAddress("0x0123456789012345678901234567890123456789"),
+				SourceTokenAddress:              utils.RandomAddress(),
+				SourceMessageTransmitterAddress: utils.RandomAddress(),
 			},
 			err: "",
 		},
 		{
 			config: USDCConfig{
 				AttestationAPI:                  "api",
-				SourceTokenAddress:              common.HexToAddress("0x0123456789012345678901234567890123456789"),
-				SourceMessageTransmitterAddress: common.HexToAddress("0x0123456789012345678901234567890123456789"),
+				SourceTokenAddress:              utils.RandomAddress(),
+				SourceMessageTransmitterAddress: utils.RandomAddress(),
 				AttestationAPITimeoutSeconds:    -1,
 			},
 			err: "AttestationAPITimeoutSeconds must be non-negative",

--- a/core/services/ocr2/plugins/ccip/config/config_test.go
+++ b/core/services/ocr2/plugins/ccip/config/config_test.go
@@ -2,8 +2,11 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/smartcontractkit/chainlink/v2/core/utils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -11,7 +14,7 @@ func TestCommitConfig(t *testing.T) {
 	exampleConfig := CommitPluginJobSpecConfig{
 		SourceStartBlock:       222,
 		DestStartBlock:         333,
-		OffRamp:                "0x123",
+		OffRamp:                common.HexToAddress("0x123"),
 		TokenPricesUSDPipeline: `merge [type=merge left="{}" right="{\"0xC79b96044906550A5652BCf20a6EA02f139B9Ae5\":\"1000000000000000000\"}"];`,
 	}
 
@@ -37,4 +40,74 @@ func TestExecutionConfig(t *testing.T) {
 	require.NoError(t, json.Unmarshal(bts, &parsedConfig))
 
 	require.Equal(t, exampleConfig, parsedConfig)
+}
+
+func TestUSDCValidate(t *testing.T) {
+	testcases := []struct {
+		config USDCConfig
+		err    string
+	}{
+		{
+			config: USDCConfig{},
+			err:    "AttestationAPI is required",
+		},
+		{
+			config: USDCConfig{
+				AttestationAPI: "api",
+			},
+			err: "SourceTokenAddress is required",
+		},
+		{
+			config: USDCConfig{
+				AttestationAPI:     "api",
+				SourceTokenAddress: utils.ZeroAddress,
+			},
+			err: "SourceTokenAddress is required",
+		},
+		{
+			config: USDCConfig{
+				AttestationAPI:     "api",
+				SourceTokenAddress: common.HexToAddress("0x0123456789012345678901234567890123456789"),
+			},
+			err: "SourceMessageTransmitterAddress is required",
+		},
+		{
+			config: USDCConfig{
+				AttestationAPI:                  "api",
+				SourceTokenAddress:              common.HexToAddress("0x0123456789012345678901234567890123456789"),
+				SourceMessageTransmitterAddress: utils.ZeroAddress,
+			},
+			err: "SourceMessageTransmitterAddress is required",
+		},
+		{
+			config: USDCConfig{
+				AttestationAPI:                  "api",
+				SourceTokenAddress:              common.HexToAddress("0x0123456789012345678901234567890123456789"),
+				SourceMessageTransmitterAddress: common.HexToAddress("0x0123456789012345678901234567890123456789"),
+			},
+			err: "",
+		},
+		{
+			config: USDCConfig{
+				AttestationAPI:                  "api",
+				SourceTokenAddress:              common.HexToAddress("0x0123456789012345678901234567890123456789"),
+				SourceMessageTransmitterAddress: common.HexToAddress("0x0123456789012345678901234567890123456789"),
+				AttestationAPITimeoutSeconds:    -1,
+			},
+			err: "AttestationAPITimeoutSeconds must be non-negative",
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(fmt.Sprintf("error = %s", tc.err), func(t *testing.T) {
+			t.Parallel()
+			err := tc.config.ValidateUSDCConfig()
+			if tc.err != "" {
+				require.ErrorContains(t, err, tc.err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }

--- a/core/services/ocr2/plugins/ccip/internal/oraclelib/backfilled_oracle.go
+++ b/core/services/ocr2/plugins/ccip/internal/oraclelib/backfilled_oracle.go
@@ -14,7 +14,7 @@ import (
 )
 
 type BackfilledOracle struct {
-	srcStartBlock, dstStartBlock int64
+	srcStartBlock, dstStartBlock uint64
 	oracleStarted                atomic.Bool
 	cancelFn                     context.CancelFunc
 	src, dst                     logpoller.LogPoller
@@ -22,7 +22,7 @@ type BackfilledOracle struct {
 	lggr                         logger.Logger
 }
 
-func NewBackfilledOracle(lggr logger.Logger, src, dst logpoller.LogPoller, srcStartBlock, dstStartBlock int64, oracle job.ServiceCtx) *BackfilledOracle {
+func NewBackfilledOracle(lggr logger.Logger, src, dst logpoller.LogPoller, srcStartBlock, dstStartBlock uint64, oracle job.ServiceCtx) *BackfilledOracle {
 	return &BackfilledOracle{
 		srcStartBlock: srcStartBlock,
 		dstStartBlock: dstStartBlock,
@@ -57,7 +57,7 @@ func (r *BackfilledOracle) Run() {
 			defer wg.Done()
 			s := time.Now()
 			r.lggr.Infow("start replaying src chain", "fromBlock", r.srcStartBlock)
-			srcReplayErr := r.src.Replay(ctx, r.srcStartBlock)
+			srcReplayErr := r.src.Replay(ctx, int64(r.srcStartBlock))
 			errMu.Lock()
 			err = multierr.Combine(err, srcReplayErr)
 			errMu.Unlock()
@@ -70,7 +70,7 @@ func (r *BackfilledOracle) Run() {
 			defer wg.Done()
 			s := time.Now()
 			r.lggr.Infow("start replaying dst chain", "fromBlock", r.dstStartBlock)
-			dstReplayErr := r.dst.Replay(ctx, r.dstStartBlock)
+			dstReplayErr := r.dst.Replay(ctx, int64(r.dstStartBlock))
 			errMu.Lock()
 			err = multierr.Combine(err, dstReplayErr)
 			errMu.Unlock()


### PR DESCRIPTION
## Motivation

Validate CCIP plugin configuration prior to loading the plugin when possible so that we can fail fast rather than attempting to start with bad configuration.
 
## Solution

Add handling to existing `validateSpec` function.