### PR TITLE
Fixing flakiness - Checking if port is available before passing to bootstrap node

### DIFF
--- a/core/services/ocr2/plugins/ccip/testhelpers/integration/chainlink.go
+++ b/core/services/ocr2/plugins/ccip/testhelpers/integration/chainlink.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"math/rand"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -958,6 +959,21 @@ func (n NoopFeedsClient) CancelledJob(ctx context.Context, in *pb.CancelledJobRe
 
 func generateRandomBootstrapPort() int64 {
 	minPort := int64(10000)
-	maxPort := int64(30000)
-	return rand.Int63n(maxPort-minPort+1) + minPort
+	maxPort := int64(65500)
+	for {
+		port := rand.Int63n(maxPort-minPort+1) + minPort
+		if isPortAvailable(port) {
+			return port
+		}
+	}
+}
+
+func isPortAvailable(port int64) bool {
+	address := fmt.Sprintf(":%d", port)
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		return false
+	}
+	listener.Close()
+	return true
 }


### PR DESCRIPTION
Example failure
https://github.com/smartcontractkit/ccip/actions/runs/7200983052/job/19616140296

```
Error Trace:	/home/runner/work/ccip/ccip/core/services/ocr2/plugins/ccip/testhelpers/integration/chainlink.go:855
        	            				/home/runner/work/ccip/ccip/core/services/ocr2/plugins/ccip/testhelpers/integration/chainlink.go:877
        	            				/home/runner/work/ccip/ccip/core/services/ocr2/plugins/ccip/clo_ccip_integration_test.go:23
        	Error:      	Received unexpected error:
        	            	error calling NewPeer: failed to make v2 peer: failed to start ragep2p host: net.Listen("127.0.0.1:28020") failed: listen tcp 127.0.0.1:28020: bind: address already in use
        	Test:       	Test_CLOSpecApprovalFlow
```