### PR TITLE
Move helper function in its test

### DIFF
--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/factory/offramp.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/factory/offramp.go
@@ -77,10 +77,3 @@ func execReportToEthTxMeta(execReport ccipdata.ExecReport) (*txmgr.TxMeta, error
 		MessageIDs: msgIDs,
 	}, nil
 }
-
-// EncodeExecutionReport is only used in tests
-// TODO should remove it and update tests to use Reader interface.
-func EncodeExecutionReport(report ccipdata.ExecReport) ([]byte, error) {
-	offRampABI := abihelpers.MustParseABI(evm_2_evm_offramp.EVM2EVMOffRampABI)
-	return v1_2_0.EncodeExecutionReport(abihelpers.MustGetMethodInputs(ccipdata.ManuallyExecute, offRampABI)[:1], report)
-}


### PR DESCRIPTION
## Motivation

This function is used only in one test file.
Until removed, this function should be moved in the related test file.

## Solution

Move the function to the test file and make it private.
