### PR TITLE
Don't fail when some token prices are missing

### DIFF
--- a/core/services/ocr2/plugins/ccip/ccipcommit/ocr2_test.go
+++ b/core/services/ocr2/plugins/ccip/ccipcommit/ocr2_test.go
@@ -57,7 +57,7 @@ func TestCommitReportingPlugin_Observation(t *testing.T) {
 		epochAndRound       types.ReportTimestamp
 		commitStoreIsPaused bool
 		commitStoreSeqNum   uint64
-		tokenPrices         []pricegetter.TokenPriceResult
+		tokenPrices         map[common.Address]pricegetter.TokenPriceResult
 		sendReqs            []ccipdata.Event[internal.EVM2EVMMessage]
 		tokenDecimals       map[common.Address]uint8
 		fee                 *big.Int
@@ -68,9 +68,9 @@ func TestCommitReportingPlugin_Observation(t *testing.T) {
 		{
 			name:              "base report",
 			commitStoreSeqNum: 54,
-			tokenPrices: []pricegetter.TokenPriceResult{
-				{TokenAddress: someTokenAddr, Price: big.NewInt(2)},
-				{TokenAddress: sourceNativeTokenAddr, Price: sourceNativeTokenPrice},
+			tokenPrices: map[common.Address]pricegetter.TokenPriceResult{
+				someTokenAddr:         {Price: big.NewInt(2)},
+				sourceNativeTokenAddr: {Price: sourceNativeTokenPrice},
 			},
 			sendReqs: []ccipdata.Event[internal.EVM2EVMMessage]{
 				{Data: internal.EVM2EVMMessage{SequenceNumber: 54}},
@@ -979,7 +979,7 @@ func TestCommitReportingPlugin_generatePriceUpdates(t *testing.T) {
 		name                 string
 		tokenDecimals        map[common.Address]uint8
 		sourceNativeToken    common.Address
-		priceGetterRespData  []pricegetter.TokenPriceResult
+		priceGetterRespData  map[common.Address]pricegetter.TokenPriceResult
 		priceGetterRespErr   error
 		feeEstimatorRespFee  prices.GasPrice
 		feeEstimatorRespErr  error
@@ -995,9 +995,9 @@ func TestCommitReportingPlugin_generatePriceUpdates(t *testing.T) {
 				tokens[1]: 18,
 			},
 			sourceNativeToken: tokens[0],
-			priceGetterRespData: []pricegetter.TokenPriceResult{
-				{TokenAddress: tokens[0], Price: val1e18(100)},
-				{TokenAddress: tokens[1], Price: val1e18(200)},
+			priceGetterRespData: map[common.Address]pricegetter.TokenPriceResult{
+				tokens[0]: {Price: val1e18(100)},
+				tokens[1]: {Price: val1e18(200)},
 			},
 			priceGetterRespErr:   nil,
 			feeEstimatorRespFee:  big.NewInt(10),
@@ -1028,8 +1028,8 @@ func TestCommitReportingPlugin_generatePriceUpdates(t *testing.T) {
 				tokens[1]: 18,
 			},
 			sourceNativeToken: tokens[0],
-			priceGetterRespData: []pricegetter.TokenPriceResult{
-				{TokenAddress: tokens[0], Price: val1e18(100)},
+			priceGetterRespData: map[common.Address]pricegetter.TokenPriceResult{
+				tokens[0]: {Price: val1e18(100)},
 			},
 			priceGetterRespErr:   nil,
 			feeEstimatorRespFee:  big.NewInt(10),
@@ -1047,9 +1047,9 @@ func TestCommitReportingPlugin_generatePriceUpdates(t *testing.T) {
 				tokens[1]: 18,
 			},
 			sourceNativeToken: tokens[2],
-			priceGetterRespData: []pricegetter.TokenPriceResult{
-				{TokenAddress: tokens[0], Price: val1e18(100)},
-				{TokenAddress: tokens[1], Price: val1e18(200)},
+			priceGetterRespData: map[common.Address]pricegetter.TokenPriceResult{
+				tokens[0]: {Price: val1e18(100)},
+				tokens[1]: {Price: val1e18(200)},
 			},
 			priceGetterRespErr: nil,
 			expErr:             true,
@@ -1061,9 +1061,9 @@ func TestCommitReportingPlugin_generatePriceUpdates(t *testing.T) {
 				tokens[1]: 18,
 			},
 			sourceNativeToken: tokens[0],
-			priceGetterRespData: []pricegetter.TokenPriceResult{
-				{TokenAddress: tokens[0], Price: val1e18(100)},
-				{TokenAddress: tokens[1], Price: val1e18(200)},
+			priceGetterRespData: map[common.Address]pricegetter.TokenPriceResult{
+				tokens[0]: {Price: val1e18(100)},
+				tokens[1]: {Price: val1e18(200)},
 			},
 			priceGetterRespErr:   nil,
 			feeEstimatorRespFee:  big.NewInt(10),
@@ -1083,9 +1083,9 @@ func TestCommitReportingPlugin_generatePriceUpdates(t *testing.T) {
 				tokens[1]: 18,
 			},
 			sourceNativeToken: tokens[0],
-			priceGetterRespData: []pricegetter.TokenPriceResult{
-				{TokenAddress: tokens[0], Price: val1e18(100)},
-				{TokenAddress: tokens[1], Price: val1e18(200)},
+			priceGetterRespData: map[common.Address]pricegetter.TokenPriceResult{
+				tokens[0]: {Price: val1e18(100)},
+				tokens[1]: {Price: val1e18(200)},
 			},
 			priceGetterRespErr:   nil,
 			feeEstimatorRespFee:  big.NewInt(20),
@@ -1105,9 +1105,9 @@ func TestCommitReportingPlugin_generatePriceUpdates(t *testing.T) {
 				tokens[1]: 18,
 			},
 			sourceNativeToken: tokens[0],
-			priceGetterRespData: []pricegetter.TokenPriceResult{
-				{TokenAddress: tokens[0], Price: val1e18(100)},
-				{TokenAddress: tokens[1], Price: val1e18(200)},
+			priceGetterRespData: map[common.Address]pricegetter.TokenPriceResult{
+				tokens[0]: {Price: val1e18(100)},
+				tokens[1]: {Price: val1e18(200)},
 			},
 			feeEstimatorRespFee: nil,
 			maxGasPrice:         1e18,

--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/mock.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/mock.go
@@ -16,23 +16,23 @@ type MockPriceGetter struct {
 }
 
 // TokenPricesUSD provides a mock function with given fields: ctx, tokens
-func (_m *MockPriceGetter) TokenPricesUSD(ctx context.Context, tokens []common.Address) ([]TokenPriceResult, error) {
+func (_m *MockPriceGetter) TokenPricesUSD(ctx context.Context, tokens []common.Address) (map[common.Address]TokenPriceResult, error) {
 	ret := _m.Called(ctx, tokens)
 
 	if len(ret) == 0 {
 		panic("no return value specified for TokenPricesUSD")
 	}
 
-	var r0 []TokenPriceResult
+	var r0 map[common.Address]TokenPriceResult
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, []common.Address) ([]TokenPriceResult, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, []common.Address) (map[common.Address]TokenPriceResult, error)); ok {
 		return rf(ctx, tokens)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, []common.Address) []TokenPriceResult); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, []common.Address) map[common.Address]TokenPriceResult); ok {
 		r0 = rf(ctx, tokens)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]TokenPriceResult)
+			r0 = ret.Get(0).(map[common.Address]TokenPriceResult)
 		}
 	}
 

--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/mock.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/mock.go
@@ -4,7 +4,6 @@ package pricegetter
 
 import (
 	context "context"
-	big "math/big"
 
 	common "github.com/ethereum/go-ethereum/common"
 
@@ -17,23 +16,23 @@ type MockPriceGetter struct {
 }
 
 // TokenPricesUSD provides a mock function with given fields: ctx, tokens
-func (_m *MockPriceGetter) TokenPricesUSD(ctx context.Context, tokens []common.Address) (map[common.Address]*big.Int, error) {
+func (_m *MockPriceGetter) TokenPricesUSD(ctx context.Context, tokens []common.Address) ([]TokenPriceResult, error) {
 	ret := _m.Called(ctx, tokens)
 
 	if len(ret) == 0 {
 		panic("no return value specified for TokenPricesUSD")
 	}
 
-	var r0 map[common.Address]*big.Int
+	var r0 []TokenPriceResult
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, []common.Address) (map[common.Address]*big.Int, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, []common.Address) ([]TokenPriceResult, error)); ok {
 		return rf(ctx, tokens)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, []common.Address) map[common.Address]*big.Int); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, []common.Address) []TokenPriceResult); ok {
 		r0 = rf(ctx, tokens)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[common.Address]*big.Int)
+			r0 = ret.Get(0).([]TokenPriceResult)
 		}
 	}
 

--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/pipeline.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/pipeline.go
@@ -82,9 +82,11 @@ func (d *PipelineGetter) TokenPricesUSD(ctx context.Context, tokens []common.Add
 
 	// The mapping of token address to source of token price has to live offchain.
 	// Best we can do is sanity check that the token price spec covers all our desired execution token prices.
+	// We don't want to fail here in case of spotting missing token, but rather log it. This should make CCIP more resilient.
+	// In case of missing tokens in the spec, Exec will skip messages containing those tokens.
 	for _, token := range tokens {
 		if _, ok = tokenPrices[token]; !ok {
-			return nil, errors.Errorf("missing token %s from tokensForFeeCoin spec", token)
+			d.lggr.Errorw("missing token from tokensForFeeCoin spec", "token", token.Hex())
 		}
 	}
 

--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/pipeline_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/pipeline_test.go
@@ -62,8 +62,9 @@ func TestDataSource(t *testing.T) {
 	})
 
 	// Ask a non-existent price.
-	_, err = priceGetter.TokenPricesUSD(context.Background(), []common.Address{common.HexToAddress("0x1591690b8638f5fb2dbec82ac741805ac5da8b45dc5263f4875b0496fdce4e11")})
-	require.Error(t, err)
+	prices, err = priceGetter.TokenPricesUSD(context.Background(), []common.Address{common.HexToAddress("0x1591690b8638f5fb2dbec82ac741805ac5da8b45dc5263f4875b0496fdce4e11")})
+	require.NoError(t, err)
+	assert.Empty(t, prices)
 
 	// Ask only one price
 	prices, err = priceGetter.TokenPricesUSD(context.Background(), []common.Address{linkTokenAddress})

--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/pricegetter.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/pricegetter.go
@@ -5,12 +5,39 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
+
+type TokenPriceResult struct {
+	TokenAddress common.Address
+	Price        *big.Int
+	Error        error
+}
 
 //go:generate mockery --quiet --name PriceGetter --output . --filename mock.go --inpackage --case=underscore
 type PriceGetter interface {
 	// TokenPricesUSD returns token prices in USD.
-	// Note: The result might contain tokens that are not passed with the 'tokens' param.
-	//       The opposite cannot happen, an error will be returned if a token price was not found.
-	TokenPricesUSD(ctx context.Context, tokens []common.Address) (map[common.Address]*big.Int, error)
+	//
+	// All tokens should be returned in the same order as they were provided.
+	// Top level error indicates problems not related to specific tokens. If a token is not found or can't be fetched,
+	// the TokenPriceResult must contain an error for that token.
+	TokenPricesUSD(ctx context.Context, tokens []common.Address) ([]TokenPriceResult, error)
+}
+
+// PriceResultsToMapSkipErrors transforms a slice of TokenPriceResult to a map of token address to price.
+// It skips tokens with errors and only log this information.
+//
+// In Commit Plugin, we don't want to fail in case of spotting missing token, but rather log it.
+// This should make CCIP more resilient. In case of missing tokens in the spec, Exec will skip messages containing those tokens.
+func PriceResultsToMapSkipErrors(lggr logger.Logger, results []TokenPriceResult) map[common.Address]*big.Int {
+	m := make(map[common.Address]*big.Int)
+	for _, r := range results {
+		if r.Error != nil {
+			lggr.Errorw("error when fetching token price", "token", r.TokenAddress, "error", r.Error)
+			continue
+		}
+		m[r.TokenAddress] = r.Price
+	}
+	return m
 }

--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/pricegetter.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/pricegetter.go
@@ -5,39 +5,18 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-
-	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 type TokenPriceResult struct {
-	TokenAddress common.Address
-	Price        *big.Int
-	Error        error
+	Price *big.Int
+	Error error
 }
 
 //go:generate mockery --quiet --name PriceGetter --output . --filename mock.go --inpackage --case=underscore
 type PriceGetter interface {
 	// TokenPricesUSD returns token prices in USD.
 	//
-	// All tokens should be returned in the same order as they were provided.
 	// Top level error indicates problems not related to specific tokens. If a token is not found or can't be fetched,
 	// the TokenPriceResult must contain an error for that token.
-	TokenPricesUSD(ctx context.Context, tokens []common.Address) ([]TokenPriceResult, error)
-}
-
-// PriceResultsToMapSkipErrors transforms a slice of TokenPriceResult to a map of token address to price.
-// It skips tokens with errors and only log this information.
-//
-// In Commit Plugin, we don't want to fail in case of spotting missing token, but rather log it.
-// This should make CCIP more resilient. In case of missing tokens in the spec, Exec will skip messages containing those tokens.
-func PriceResultsToMapSkipErrors(lggr logger.Logger, results []TokenPriceResult) map[common.Address]*big.Int {
-	m := make(map[common.Address]*big.Int)
-	for _, r := range results {
-		if r.Error != nil {
-			lggr.Errorw("error when fetching token price", "token", r.TokenAddress, "error", r.Error)
-			continue
-		}
-		m[r.TokenAddress] = r.Price
-	}
-	return m
+	TokenPricesUSD(ctx context.Context, tokens []common.Address) (map[common.Address]TokenPriceResult, error)
 }


### PR DESCRIPTION
## Motivation

Enforcing all tokens to be present in the job spec creates an implicit dependency between adding tokens to the offramp and creating a job spec with updated token prices. That poses some risk, when the token is added first and then forgotten to be added to job specs or added with some delay, Commit will halt and stop transmitting. Not returning errors in Commit will let us process all the messages. Further, when Exec sees messages with a token without price, it skips those messages and logs an error.

In this case, we favor availability over consistency. Spotting missing tokens in config will be harder, but that won't stop the bridge

## Solution

Replace error with log in PriceGetter 