### PR TITLE
ccip: Return an error from ParseLogs.

### DIFF
--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/reader.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/reader.go
@@ -62,7 +62,7 @@ func ParseLogs[T any](logs []logpoller.Log, lggr logger.Logger, parseFunc func(l
 		})
 	}
 
-	if len(reqs) != len(logs) {
+	if len(logs) != len(reqs) {
 		return nil, fmt.Errorf("%d logs were not parsed", len(logs)-len(reqs))
 	}
 	return reqs, nil

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/reader.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/reader.go
@@ -63,9 +63,8 @@ func ParseLogs[T any](logs []logpoller.Log, lggr logger.Logger, parseFunc func(l
 	}
 
 	if len(reqs) != len(logs) {
-		err := fmt.Errorf("%d logs were not parsed", len(logs)-len(reqs))
 		lggr.Warnw("Some logs were not parsed", "logs", len(logs), "requests", len(reqs))
-		return nil, err
+		return nil, fmt.Errorf("%d logs were not parsed", len(logs)-len(reqs))
 	}
 	return reqs, nil
 }

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/reader.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/reader.go
@@ -63,7 +63,6 @@ func ParseLogs[T any](logs []logpoller.Log, lggr logger.Logger, parseFunc func(l
 	}
 
 	if len(reqs) != len(logs) {
-		lggr.Warnw("Some logs were not parsed", "logs", len(logs), "requests", len(reqs))
 		return nil, fmt.Errorf("%d logs were not parsed", len(logs)-len(reqs))
 	}
 	return reqs, nil

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/reader.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/reader.go
@@ -48,7 +48,7 @@ func ParseLogs[T any](logs []logpoller.Log, lggr logger.Logger, parseFunc func(l
 	for _, log := range logs {
 		data, err := parseFunc(log.ToGethLog())
 		if err != nil {
-			lggr.Warnw(fmt.Sprintf("Unable to parse log %v: %s", log, err.Error()))
+			lggr.Errorw("Unable to parse log", "err", err)
 			continue
 		}
 		reqs = append(reqs, Event[T]{

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/reader_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/reader_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
@@ -22,21 +24,51 @@ func Test_parseLogs(t *testing.T) {
 	}
 
 	parseFn := func(log types.Log) (*uint, error) {
-		// Simulate some random error
-		if log.Index == 100 {
-			return nil, fmt.Errorf("some error")
-		}
 		return &log.Index, nil
 	}
 
 	parsedEvents, err := ParseLogs[uint](logs, logger.TestLogger(t), parseFn)
-	assert.NoError(t, err)
-	assert.Len(t, parsedEvents, 99)
+	require.NoError(t, err)
+	assert.Len(t, parsedEvents, 100)
 
 	// Make sure everything is parsed according to the parse func
 	for i, ev := range parsedEvents {
 		assert.Equal(t, i+1, int(ev.Data))
 		assert.Equal(t, int(i)*1000, int(ev.BlockNumber))
 		assert.Greater(t, ev.BlockTimestamp, time.Now().Add(-time.Minute))
+	}
+}
+
+func Test_parseLogs_withErrors(t *testing.T) {
+	// generate 50 valid logs and 50 errors
+	actualErrorCount := 50
+	logs := make([]logpoller.Log, actualErrorCount*2)
+	for i := range logs {
+		logs[i].LogIndex = int64(i + 1)
+	}
+
+	// return an error for half of the logs.
+	parseFn := func(log types.Log) (*uint, error) {
+		if log.Index%2 == 0 {
+			return nil, fmt.Errorf("cannot parse %d", log.Index)
+		}
+		return &log.Index, nil
+	}
+
+	log, observed := logger.TestLoggerObserved(t, zapcore.DebugLevel)
+	parsedEvents, err := ParseLogs[uint](logs, log, parseFn)
+	assert.ErrorContains(t, err, fmt.Sprintf("%d logs were not parsed", len(logs)/2))
+	assert.Nil(t, parsedEvents, "No events are returned if there was an error.")
+
+	// logs are written for errors.
+	require.Equal(t, actualErrorCount+1, observed.Len(), "Expect 51 warnings: one for each error and a summary.")
+	for i, log := range observed.All() {
+		assert.Equal(t, zapcore.WarnLevel, log.Level)
+		if i < actualErrorCount {
+			assert.Contains(t, log.Message, fmt.Sprintf("cannot parse %d", (i+1)*2), "each error should be logged as a warning")
+		} else {
+			// summary is written at the end.
+			assert.Contains(t, log.Message, "Some logs were not parsed", "overview for entire batch of logs being parsed")
+		}
 	}
 }

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/reader_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/reader_test.go
@@ -61,14 +61,12 @@ func Test_parseLogs_withErrors(t *testing.T) {
 	assert.Nil(t, parsedEvents, "No events are returned if there was an error.")
 
 	// logs are written for errors.
-	require.Equal(t, actualErrorCount+1, observed.Len(), "Expect 51 warnings: one for each error and a summary.")
-	for i, log := range observed.All() {
-		assert.Equal(t, zapcore.WarnLevel, log.Level)
-		if i < actualErrorCount {
-			assert.Contains(t, log.Message, fmt.Sprintf("cannot parse %d", (i+1)*2), "each error should be logged as a warning")
-		} else {
-			// summary is written at the end.
-			assert.Contains(t, log.Message, "Some logs were not parsed", "overview for entire batch of logs being parsed")
-		}
+	require.Equal(t, actualErrorCount, observed.Len(), "Expect 51 warnings: one for each error and a summary.")
+	for i, entry := range observed.All() {
+		assert.Equal(t, zapcore.ErrorLevel, entry.Level)
+		assert.Contains(t, entry.Message, "Unable to parse log")
+		contextMap := entry.ContextMap()
+		require.Contains(t, contextMap, "err")
+		assert.Contains(t, contextMap["err"], fmt.Sprintf("cannot parse %d", (i+1)*2), "each error should be logged as a warning")
 	}
 }


### PR DESCRIPTION
## Motivation
Parsing errors should not be ignored in case there is a legitimate problem. This could occur if a newer version is deployed and starts writing an unknown log format, in this case we should fail with an error rather than ignoring the unknown messages.

## Solution

Return the error. To ensure this wont be a problem, the following command was run on nodes 1-15 to verify this warning has not been seen in the last 90 days:

```
{app="clc-ocr-multichain-ccip-testnet"} |~ "logs were not parsed"
```
