### PR TITLE
chore(ccipdata): make v1.0 offramp reader fields public

### DIFF
--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_0_0/offramp.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_0_0/offramp.go
@@ -145,32 +145,33 @@ func (c ExecOffchainConfig) Validate() error {
 }
 
 type OffRamp struct {
-	OffRampV100             evm_2_evm_offramp_1_0_0.EVM2EVMOffRampInterface
-	Addr                    common.Address
-	LogPoller               logpoller.LogPoller
+	offRampV100             evm_2_evm_offramp_1_0_0.EVM2EVMOffRampInterface
+	addr                    common.Address
+	lp                      logpoller.LogPoller
 	Logger                  logger.Logger
 	Client                  client.Client
-	EvmBatchCaller          rpclib.EvmBatchCaller
-	Filters                 []logpoller.Filter
+	evmBatchCaller          rpclib.EvmBatchCaller
+	filters                 []logpoller.Filter
 	Estimator               gas.EvmFeeEstimator
 	ExecutionReportArgs     abi.Arguments
-	EventIndex              int
-	EventSig                common.Hash
-	CachedOffRampTokens     cache.AutoSync[ccipdata.OffRampTokens]
-	SourceToDestTokensCache sync.Map
+	eventIndex              int
+	eventSig                common.Hash
+	cachedOffRampTokens     cache.AutoSync[ccipdata.OffRampTokens]
+	sourceToDestTokensCache sync.Map
 
 	// Dynamic config
-	ConfigMu              sync.RWMutex
-	GasPriceEstimatorExec prices.GasPriceEstimatorExec
-	OffchainConfigCache   ccipdata.ExecOffchainConfig
-	OnchainConfigCache    ccipdata.ExecOnchainConfig
+	// configMu guards all the dynamic config fields.
+	configMu          sync.RWMutex
+	gasPriceEstimator prices.GasPriceEstimatorExec
+	offchainConfig    ccipdata.ExecOffchainConfig
+	onchainConfig     ccipdata.ExecOnchainConfig
 }
 
 func (o *OffRamp) GetStaticConfig(ctx context.Context) (ccipdata.OffRampStaticConfig, error) {
-	if o.OffRampV100 == nil {
+	if o.offRampV100 == nil {
 		return ccipdata.OffRampStaticConfig{}, fmt.Errorf("offramp not initialized")
 	}
-	c, err := o.OffRampV100.GetStaticConfig(&bind.CallOpts{Context: ctx})
+	c, err := o.offRampV100.GetStaticConfig(&bind.CallOpts{Context: ctx})
 	if err != nil {
 		return ccipdata.OffRampStaticConfig{}, fmt.Errorf("error while retrieving offramp config: %w", err)
 	}
@@ -185,15 +186,15 @@ func (o *OffRamp) GetStaticConfig(ctx context.Context) (ccipdata.OffRampStaticCo
 }
 
 func (o *OffRamp) GetExecutionState(ctx context.Context, sequenceNumber uint64) (uint8, error) {
-	return o.OffRampV100.GetExecutionState(&bind.CallOpts{Context: ctx}, sequenceNumber)
+	return o.offRampV100.GetExecutionState(&bind.CallOpts{Context: ctx}, sequenceNumber)
 }
 
 func (o *OffRamp) GetSenderNonce(ctx context.Context, sender common.Address) (uint64, error) {
-	return o.OffRampV100.GetSenderNonce(&bind.CallOpts{Context: ctx}, sender)
+	return o.offRampV100.GetSenderNonce(&bind.CallOpts{Context: ctx}, sender)
 }
 
 func (o *OffRamp) CurrentRateLimiterState(ctx context.Context) (evm_2_evm_offramp.RateLimiterTokenBucket, error) {
-	state, err := o.OffRampV100.CurrentRateLimiterState(&bind.CallOpts{Context: ctx})
+	state, err := o.offRampV100.CurrentRateLimiterState(&bind.CallOpts{Context: ctx})
 	if err != nil {
 		return *new(evm_2_evm_offramp.RateLimiterTokenBucket), err
 	}
@@ -207,14 +208,14 @@ func (o *OffRamp) CurrentRateLimiterState(ctx context.Context) (evm_2_evm_offram
 }
 
 func (o *OffRamp) GetDestinationToken(ctx context.Context, address common.Address) (common.Address, error) {
-	return o.OffRampV100.GetDestinationToken(&bind.CallOpts{Context: ctx}, address)
+	return o.offRampV100.GetDestinationToken(&bind.CallOpts{Context: ctx}, address)
 }
 
 func (o *OffRamp) getDestinationTokensFromSourceTokens(ctx context.Context, tokenAddresses []common.Address) ([]common.Address, error) {
 	destTokens := make([]common.Address, len(tokenAddresses))
 	found := make(map[common.Address]bool)
 	for i, tokenAddress := range tokenAddresses {
-		if v, exists := o.SourceToDestTokensCache.Load(tokenAddress); exists {
+		if v, exists := o.sourceToDestTokensCache.Load(tokenAddress); exists {
 			if destToken, isAddr := v.(common.Address); isAddr {
 				destTokens[i] = destToken
 				found[tokenAddress] = true
@@ -231,16 +232,16 @@ func (o *OffRamp) getDestinationTokensFromSourceTokens(ctx context.Context, toke
 	evmCalls := make([]rpclib.EvmCall, 0, len(tokenAddresses))
 	for _, sourceTk := range tokenAddresses {
 		if !found[sourceTk] {
-			evmCalls = append(evmCalls, rpclib.NewEvmCall(abiOffRamp, "getDestinationToken", o.Addr, sourceTk))
+			evmCalls = append(evmCalls, rpclib.NewEvmCall(abiOffRamp, "getDestinationToken", o.addr, sourceTk))
 		}
 	}
 
-	latestBlock, err := o.LogPoller.LatestBlock(pg.WithParentCtx(ctx))
+	latestBlock, err := o.lp.LatestBlock(pg.WithParentCtx(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("get latest block: %w", err)
 	}
 
-	results, err := o.EvmBatchCaller.BatchCall(ctx, uint64(latestBlock.BlockNumber), evmCalls)
+	results, err := o.evmBatchCaller.BatchCall(ctx, uint64(latestBlock.BlockNumber), evmCalls)
 	if err != nil {
 		return nil, fmt.Errorf("batch call limit: %w", err)
 	}
@@ -256,7 +257,7 @@ func (o *OffRamp) getDestinationTokensFromSourceTokens(ctx context.Context, toke
 	for i, sourceToken := range tokenAddresses {
 		if !found[sourceToken] {
 			destTokens[i] = destTokensFromRpc[j]
-			o.SourceToDestTokensCache.Store(sourceToken, destTokens[i])
+			o.sourceToDestTokensCache.Store(sourceToken, destTokens[i])
 			j++
 		}
 	}
@@ -283,16 +284,16 @@ func (o *OffRamp) GetTokenPoolsRateLimits(ctx context.Context, poolAddresses []c
 			abiCustomTokenPool,
 			"currentOffRampRateLimiterState",
 			poolAddress,
-			o.Addr,
+			o.addr,
 		))
 	}
 
-	latestBlock, err := o.LogPoller.LatestBlock(pg.WithParentCtx(ctx))
+	latestBlock, err := o.lp.LatestBlock(pg.WithParentCtx(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("get latest block: %w", err)
 	}
 
-	results, err := o.EvmBatchCaller.BatchCall(ctx, uint64(latestBlock.BlockNumber), evmCalls)
+	results, err := o.evmBatchCaller.BatchCall(ctx, uint64(latestBlock.BlockNumber), evmCalls)
 	if err != nil {
 		return nil, fmt.Errorf("batch call limit: %w", err)
 	}
@@ -325,12 +326,12 @@ func (o *OffRamp) GetSourceToDestTokensMapping(ctx context.Context) (map[common.
 }
 
 func (o *OffRamp) GetTokens(ctx context.Context) (ccipdata.OffRampTokens, error) {
-	return o.CachedOffRampTokens.Get(ctx, func(ctx context.Context) (ccipdata.OffRampTokens, error) {
-		destTokens, err := o.OffRampV100.GetDestinationTokens(&bind.CallOpts{Context: ctx})
+	return o.cachedOffRampTokens.Get(ctx, func(ctx context.Context) (ccipdata.OffRampTokens, error) {
+		destTokens, err := o.offRampV100.GetDestinationTokens(&bind.CallOpts{Context: ctx})
 		if err != nil {
 			return ccipdata.OffRampTokens{}, fmt.Errorf("get destination tokens: %w", err)
 		}
-		sourceTokens, err := o.OffRampV100.GetSupportedTokens(&bind.CallOpts{Context: ctx})
+		sourceTokens, err := o.offRampV100.GetSupportedTokens(&bind.CallOpts{Context: ctx})
 		if err != nil {
 			return ccipdata.OffRampTokens{}, err
 		}
@@ -357,17 +358,17 @@ func (o *OffRamp) getPoolsByDestTokens(ctx context.Context, tokenAddrs []common.
 		evmCalls = append(evmCalls, rpclib.NewEvmCall(
 			abiOffRamp,
 			"getPoolByDestToken",
-			o.Addr,
+			o.addr,
 			tk,
 		))
 	}
 
-	latestBlock, err := o.LogPoller.LatestBlock(pg.WithParentCtx(ctx))
+	latestBlock, err := o.lp.LatestBlock(pg.WithParentCtx(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("get latest block: %w", err)
 	}
 
-	results, err := o.EvmBatchCaller.BatchCall(ctx, uint64(latestBlock.FinalizedBlockNumber), evmCalls)
+	results, err := o.evmBatchCaller.BatchCall(ctx, uint64(latestBlock.FinalizedBlockNumber), evmCalls)
 	if err != nil {
 		return nil, fmt.Errorf("batch call limit: %w", err)
 	}
@@ -383,34 +384,42 @@ func (o *OffRamp) getPoolsByDestTokens(ctx context.Context, tokenAddrs []common.
 }
 
 func (o *OffRamp) OffchainConfig() ccipdata.ExecOffchainConfig {
-	o.ConfigMu.RLock()
-	defer o.ConfigMu.RUnlock()
-	return o.OffchainConfigCache
+	o.configMu.RLock()
+	defer o.configMu.RUnlock()
+	return o.offchainConfig
 }
 
 func (o *OffRamp) OnchainConfig() ccipdata.ExecOnchainConfig {
-	o.ConfigMu.RLock()
-	defer o.ConfigMu.RUnlock()
-	return o.OnchainConfigCache
+	o.configMu.RLock()
+	defer o.configMu.RUnlock()
+	return o.onchainConfig
 }
 
 func (o *OffRamp) GasPriceEstimator() prices.GasPriceEstimatorExec {
-	o.ConfigMu.RLock()
-	defer o.ConfigMu.RUnlock()
-	return o.GasPriceEstimatorExec
+	o.configMu.RLock()
+	defer o.configMu.RUnlock()
+	return o.gasPriceEstimator
 }
 
 func (o *OffRamp) Address() common.Address {
-	return o.Addr
+	return o.addr
 }
 
-func (o *OffRamp) ChangeConfig(onchainConfig []byte, offchainConfig []byte) (common.Address, common.Address, error) {
-	onchainConfigParsed, err := abihelpers.DecodeAbiStruct[ExecOnchainConfig](onchainConfig)
+func (o *OffRamp) UpdateDynamicConfig(onchainConfig ccipdata.ExecOnchainConfig, offchainConfig ccipdata.ExecOffchainConfig, gasPriceEstimator prices.GasPriceEstimatorExec) {
+	o.configMu.Lock()
+	o.onchainConfig = onchainConfig
+	o.offchainConfig = offchainConfig
+	o.gasPriceEstimator = gasPriceEstimator
+	o.configMu.Unlock()
+}
+
+func (o *OffRamp) ChangeConfig(onchainConfigBytes []byte, offchainConfigBytes []byte) (common.Address, common.Address, error) {
+	onchainConfigParsed, err := abihelpers.DecodeAbiStruct[ExecOnchainConfig](onchainConfigBytes)
 	if err != nil {
 		return common.Address{}, common.Address{}, err
 	}
 
-	offchainConfigParsed, err := ccipconfig.DecodeOffchainConfig[ExecOffchainConfig](offchainConfig)
+	offchainConfigParsed, err := ccipconfig.DecodeOffchainConfig[ExecOffchainConfig](offchainConfigBytes)
 	if err != nil {
 		return common.Address{}, common.Address{}, err
 	}
@@ -422,17 +431,17 @@ func (o *OffRamp) ChangeConfig(onchainConfig []byte, offchainConfig []byte) (com
 	if err != nil {
 		return common.Address{}, common.Address{}, err
 	}
-	o.ConfigMu.Lock()
-	o.OffchainConfigCache = ccipdata.ExecOffchainConfig{
+
+	offchainConfig := ccipdata.ExecOffchainConfig{
 		DestOptimisticConfirmations: offchainConfigParsed.DestOptimisticConfirmations,
 		BatchGasLimit:               offchainConfigParsed.BatchGasLimit,
 		RelativeBoostPerWaitHour:    offchainConfigParsed.RelativeBoostPerWaitHour,
 		InflightCacheExpiry:         offchainConfigParsed.InflightCacheExpiry,
 		RootSnoozeTime:              offchainConfigParsed.RootSnoozeTime,
 	}
-	o.OnchainConfigCache = ccipdata.ExecOnchainConfig{PermissionLessExecutionThresholdSeconds: time.Second * time.Duration(onchainConfigParsed.PermissionLessExecutionThresholdSeconds)}
-	o.GasPriceEstimatorExec = prices.NewExecGasPriceEstimator(o.Estimator, big.NewInt(int64(offchainConfigParsed.MaxGasPrice)), 0)
-	o.ConfigMu.Unlock()
+	onchainConfig := ccipdata.ExecOnchainConfig{PermissionLessExecutionThresholdSeconds: time.Second * time.Duration(onchainConfigParsed.PermissionLessExecutionThresholdSeconds)}
+	gasPriceEstimator := prices.NewExecGasPriceEstimator(o.Estimator, big.NewInt(int64(offchainConfigParsed.MaxGasPrice)), 0)
+	o.UpdateDynamicConfig(onchainConfig, offchainConfig, gasPriceEstimator)
 
 	o.Logger.Infow("Starting exec plugin",
 		"offchainConfig", onchainConfigParsed,
@@ -441,19 +450,19 @@ func (o *OffRamp) ChangeConfig(onchainConfig []byte, offchainConfig []byte) (com
 }
 
 func (o *OffRamp) Close(qopts ...pg.QOpt) error {
-	return logpollerutil.UnregisterLpFilters(o.LogPoller, o.Filters, qopts...)
+	return logpollerutil.UnregisterLpFilters(o.lp, o.filters, qopts...)
 }
 
 func (o *OffRamp) GetExecutionStateChangesBetweenSeqNums(ctx context.Context, seqNumMin, seqNumMax uint64, confs int) ([]ccipdata.Event[ccipdata.ExecutionStateChanged], error) {
-	latestBlock, err := o.LogPoller.LatestBlock(pg.WithParentCtx(ctx))
+	latestBlock, err := o.lp.LatestBlock(pg.WithParentCtx(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("get lp latest block: %w", err)
 	}
 
-	logs, err := o.LogPoller.IndexedLogsTopicRange(
-		o.EventSig,
-		o.Addr,
-		o.EventIndex,
+	logs, err := o.lp.IndexedLogsTopicRange(
+		o.eventSig,
+		o.addr,
+		o.eventIndex,
 		logpoller.EvmWord(seqNumMin),
 		logpoller.EvmWord(seqNumMax),
 		logpoller.Confirmations(confs),
@@ -467,7 +476,7 @@ func (o *OffRamp) GetExecutionStateChangesBetweenSeqNums(ctx context.Context, se
 		logs,
 		o.Logger,
 		func(log types.Log) (*ccipdata.ExecutionStateChanged, error) {
-			sc, err := o.OffRampV100.ParseExecutionStateChanged(log)
+			sc, err := o.offRampV100.ParseExecutionStateChanged(log)
 			if err != nil {
 				return nil, err
 			}
@@ -602,7 +611,7 @@ func (o *OffRamp) TokenEvents() []common.Hash {
 }
 
 func (o *OffRamp) RegisterFilters(qopts ...pg.QOpt) error {
-	return logpollerutil.RegisterLpFilters(o.LogPoller, o.Filters, qopts...)
+	return logpollerutil.RegisterLpFilters(o.lp, o.filters, qopts...)
 }
 
 func NewOffRamp(lggr logger.Logger, addr common.Address, ec client.Client, lp logpoller.LogPoller, estimator gas.EvmFeeEstimator) (*OffRamp, error) {
@@ -632,32 +641,32 @@ func NewOffRamp(lggr logger.Logger, addr common.Address, ec client.Client, lp lo
 	}
 
 	return &OffRamp{
-		OffRampV100:         offRamp,
+		offRampV100:         offRamp,
 		Client:              ec,
-		Addr:                addr,
+		addr:                addr,
 		Logger:              lggr,
-		LogPoller:           lp,
-		Filters:             filters,
+		lp:                  lp,
+		filters:             filters,
 		Estimator:           estimator,
 		ExecutionReportArgs: executionReportArgs,
-		EventSig:            ExecutionStateChangedEvent,
-		EventIndex:          executionStateChangedSequenceNumberIndex,
-		ConfigMu:            sync.RWMutex{},
-		EvmBatchCaller: rpclib.NewDynamicLimitedBatchCaller(
+		eventSig:            ExecutionStateChangedEvent,
+		eventIndex:          executionStateChangedSequenceNumberIndex,
+		configMu:            sync.RWMutex{},
+		evmBatchCaller: rpclib.NewDynamicLimitedBatchCaller(
 			lggr,
 			ec,
 			rpclib.DefaultRpcBatchSizeLimit,
 			rpclib.DefaultRpcBatchBackOffMultiplier,
 		),
-		CachedOffRampTokens: cache.NewLogpollerEventsBased[ccipdata.OffRampTokens](
+		cachedOffRampTokens: cache.NewLogpollerEventsBased[ccipdata.OffRampTokens](
 			lp,
 			offRamp_poolAddedPoolRemovedEvents,
 			offRamp.Address(),
 		),
 
 		// values set on the fly after ChangeConfig is called
-		GasPriceEstimatorExec: prices.ExecGasPriceEstimator{},
-		OffchainConfigCache:   ccipdata.ExecOffchainConfig{},
-		OnchainConfigCache:    ccipdata.ExecOnchainConfig{},
+		gasPriceEstimator: prices.ExecGasPriceEstimator{},
+		offchainConfig:    ccipdata.ExecOffchainConfig{},
+		onchainConfig:     ccipdata.ExecOnchainConfig{},
 	}, nil
 }

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_0_0/offramp_reader_unit_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_0_0/offramp_reader_unit_test.go
@@ -77,7 +77,7 @@ func TestOffRampGetDestinationTokensFromSourceTokens(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			batchCaller := rpclibmocks.NewEvmBatchCaller(t)
-			o := &OffRamp{evmBatchCaller: batchCaller, lp: lp}
+			o := &OffRamp{EvmBatchCaller: batchCaller, LogPoller: lp}
 			srcTks, dstTks, outputs := generateTokensAndOutputs(numSrcTokens)
 			outputs = tc.outputChangeFn(outputs)
 			batchCaller.On("BatchCall", mock.Anything, mock.Anything, mock.Anything).
@@ -114,12 +114,12 @@ func TestCachedOffRampTokens(t *testing.T) {
 	batchCaller.On("BatchCall", mock.Anything, mock.Anything, mock.Anything).Return(outputs, nil)
 
 	offRamp := OffRamp{
-		offRamp:        mockOffRamp,
-		lp:             lp,
-		lggr:           logger.TestLogger(t),
-		ec:             ec,
-		evmBatchCaller: batchCaller,
-		cachedOffRampTokens: cache.NewLogpollerEventsBased[ccipdata.OffRampTokens](
+		OffRampV100:    mockOffRamp,
+		LogPoller:      lp,
+		Logger:         logger.TestLogger(t),
+		Client:         ec,
+		EvmBatchCaller: batchCaller,
+		CachedOffRampTokens: cache.NewLogpollerEventsBased[ccipdata.OffRampTokens](
 			lp,
 			offRamp_poolAddedPoolRemovedEvents,
 			mockOffRamp.Address(),

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_0_0/offramp_reader_unit_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_0_0/offramp_reader_unit_test.go
@@ -77,7 +77,7 @@ func TestOffRampGetDestinationTokensFromSourceTokens(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			batchCaller := rpclibmocks.NewEvmBatchCaller(t)
-			o := &OffRamp{EvmBatchCaller: batchCaller, LogPoller: lp}
+			o := &OffRamp{evmBatchCaller: batchCaller, lp: lp}
 			srcTks, dstTks, outputs := generateTokensAndOutputs(numSrcTokens)
 			outputs = tc.outputChangeFn(outputs)
 			batchCaller.On("BatchCall", mock.Anything, mock.Anything, mock.Anything).
@@ -114,12 +114,12 @@ func TestCachedOffRampTokens(t *testing.T) {
 	batchCaller.On("BatchCall", mock.Anything, mock.Anything, mock.Anything).Return(outputs, nil)
 
 	offRamp := OffRamp{
-		OffRampV100:    mockOffRamp,
-		LogPoller:      lp,
+		offRampV100:    mockOffRamp,
+		lp:             lp,
 		Logger:         logger.TestLogger(t),
 		Client:         ec,
-		EvmBatchCaller: batchCaller,
-		CachedOffRampTokens: cache.NewLogpollerEventsBased[ccipdata.OffRampTokens](
+		evmBatchCaller: batchCaller,
+		cachedOffRampTokens: cache.NewLogpollerEventsBased[ccipdata.OffRampTokens](
 			lp,
 			offRamp_poolAddedPoolRemovedEvents,
 			mockOffRamp.Address(),


### PR DESCRIPTION
## Motivation

Currently, fields in structs implementing readers in `ccipdata` are private. This design makes extending these structs relatively hard:
1. Each extension copies many fields and methods.
2. It’s hard to check whether the extension copied _enough_ methods. For example, if the new version overrides the default fee estimator, the programmer must remember to copy all the methods involving the new fee estimator.  

## Solution

This change makes fields in the `OffRamp` v1.0 reader implementation public. This allows us to remove some code duplication from `OffRamp` v1.2 and paves the road for implementing `OffRamp` v1.3 more easily.
