### PR TITLE
rebalancer - move discovery logic under lm

### DIFF
--- a/core/services/ocr2/plugins/rebalancer/liquiditymanager/evm.go
+++ b/core/services/ocr2/plugins/rebalancer/liquiditymanager/evm.go
@@ -2,12 +2,19 @@ package liquiditymanager
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 
+	mapset "github.com/deckarep/golang-set/v2"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/rebalancer/liquiditygraph"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/rebalancer/models"
 )
 
-type EvmLiquidityManager struct{}
+type EvmLiquidityManager struct {
+	address   models.Address
+	networkID models.NetworkID
+}
 
 func NewEvmLiquidityManager(address models.Address) *EvmLiquidityManager {
 	return &EvmLiquidityManager{}
@@ -27,6 +34,59 @@ func (e EvmLiquidityManager) GetBalance(ctx context.Context) (*big.Int, error) {
 
 func (e EvmLiquidityManager) GetPendingTransfers(ctx context.Context) ([]models.PendingTransfer, error) {
 	return nil, nil
+}
+
+func (e EvmLiquidityManager) Discover(ctx context.Context, lmFactory Factory) (*Registry, liquiditygraph.LiquidityGraph, error) {
+	g := liquiditygraph.NewGraph()
+	lms := NewRegistry()
+
+	type qItem struct {
+		networkID models.NetworkID
+		lmAddress models.Address
+	}
+
+	seen := mapset.NewSet[qItem]()
+	queue := mapset.NewSet[qItem]()
+
+	elem := qItem{networkID: e.networkID, lmAddress: e.address}
+	queue.Add(elem)
+	seen.Add(elem)
+
+	for queue.Cardinality() > 0 {
+		elem, ok := queue.Pop()
+		if !ok {
+			return nil, nil, fmt.Errorf("unexpected internal error, there is a bug in the algorithm")
+		}
+
+		// TODO: investigate fetching the balance here.
+		g.AddNetwork(elem.networkID, big.NewInt(0))
+
+		lm, err := lmFactory.NewLiquidityManager(elem.networkID, elem.lmAddress)
+		if err != nil {
+			return nil, nil, fmt.Errorf("init liquidity manager: %w", err)
+		}
+
+		destinationLMs, err := lm.GetLiquidityManagers(ctx)
+		if err != nil {
+			return nil, nil, fmt.Errorf("get %v destination liquidity managers: %w", elem.networkID, err)
+		}
+
+		for destNetworkID, lmAddr := range destinationLMs {
+			g.AddConnection(elem.networkID, destNetworkID)
+
+			newElem := qItem{networkID: destNetworkID, lmAddress: lmAddr}
+			if !seen.Contains(newElem) {
+				queue.Add(newElem)
+				seen.Add(newElem)
+
+				if _, exists := lms.Get(destNetworkID); !exists {
+					lms.Add(destNetworkID, lmAddr)
+				}
+			}
+		}
+	}
+
+	return lms, g, nil
 }
 
 func (e EvmLiquidityManager) Close(ctx context.Context) error {

--- a/core/services/ocr2/plugins/rebalancer/liquiditymanager/liquiditymanager.go
+++ b/core/services/ocr2/plugins/rebalancer/liquiditymanager/liquiditymanager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math/big"
 
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/rebalancer/liquiditygraph"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/rebalancer/models"
 )
 
@@ -23,6 +24,9 @@ type LiquidityManager interface {
 
 	// GetPendingTransfers returns the pending liquidity transfers.
 	GetPendingTransfers(ctx context.Context) ([]models.PendingTransfer, error)
+
+	// Discover discovers other liquidity managers
+	Discover(ctx context.Context, lmFactory Factory) (*Registry, liquiditygraph.LiquidityGraph, error)
 
 	// Close releases any resources.
 	Close(ctx context.Context) error

--- a/core/services/ocr2/plugins/rebalancer/plugin_test.go
+++ b/core/services/ocr2/plugins/rebalancer/plugin_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/rebalancer/liquiditygraph"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/rebalancer/liquiditymanager"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/rebalancer/models"
 	mocks "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/rebalancer/rebalancermocks"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
@@ -57,7 +58,11 @@ func TestPluginObservation(t *testing.T) {
 	mockLM := mocks.NewLiquidityManager(t)
 	deps.mockFactory.On("NewLiquidityManager", net, addr).Return(mockLM, nil)
 
-	mockLM.On("GetLiquidityManagers", ctx).Return(map[models.NetworkID]models.Address{}, nil)
+	g := liquiditygraph.NewGraph()
+	g.AddNetwork(net, big.NewInt(1234))
+	reg := liquiditymanager.NewRegistry()
+	reg.Add(net, addr)
+	mockLM.On("Discover", ctx, deps.mockFactory).Return(reg, g, nil)
 	mockLM.On("GetBalance", ctx).Return(big.NewInt(1234), nil)
 	mockLM.On("GetPendingTransfers", ctx).Return([]models.PendingTransfer{}, nil)
 

--- a/core/services/ocr2/plugins/rebalancer/rebalancermocks/lm_mock.go
+++ b/core/services/ocr2/plugins/rebalancer/rebalancermocks/lm_mock.go
@@ -6,6 +6,9 @@ import (
 	context "context"
 	big "math/big"
 
+	liquiditygraph "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/rebalancer/liquiditygraph"
+	liquiditymanager "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/rebalancer/liquiditymanager"
+
 	mock "github.com/stretchr/testify/mock"
 
 	models "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/rebalancer/models"
@@ -32,6 +35,45 @@ func (_m *LiquidityManager) Close(ctx context.Context) error {
 	}
 
 	return r0
+}
+
+// Discover provides a mock function with given fields: ctx, lmFactory
+func (_m *LiquidityManager) Discover(ctx context.Context, lmFactory liquiditymanager.Factory) (*liquiditymanager.Registry, liquiditygraph.LiquidityGraph, error) {
+	ret := _m.Called(ctx, lmFactory)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Discover")
+	}
+
+	var r0 *liquiditymanager.Registry
+	var r1 liquiditygraph.LiquidityGraph
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, liquiditymanager.Factory) (*liquiditymanager.Registry, liquiditygraph.LiquidityGraph, error)); ok {
+		return rf(ctx, lmFactory)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, liquiditymanager.Factory) *liquiditymanager.Registry); ok {
+		r0 = rf(ctx, lmFactory)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*liquiditymanager.Registry)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, liquiditymanager.Factory) liquiditygraph.LiquidityGraph); ok {
+		r1 = rf(ctx, lmFactory)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(liquiditygraph.LiquidityGraph)
+		}
+	}
+
+	if rf, ok := ret.Get(2).(func(context.Context, liquiditymanager.Factory) error); ok {
+		r2 = rf(ctx, lmFactory)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // GetBalance provides a mock function with given fields: ctx


### PR DESCRIPTION
Example standalone discovery

```
lmFactory := newLmFactory(evmParams{
   chainID1: { logPoller1, client1 },
   chainID2: { logPoller2, client2 },
})

net = models.NetworkID(1)
addr = common.Address("0x123")

lm := lmFactory.NewLiquidityManager(net, addr)
lms, graph, err = lm.Discover(ctx, lmFactory)

```