### PR TITLE
feat: multichain transmitter/config tracker

### DIFF
--- a/core/gethwrappers/shared/generated/no_op_ocr3/no_op_ocr3.go
+++ b/core/gethwrappers/shared/generated/no_op_ocr3/no_op_ocr3.go
@@ -1,0 +1,962 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package no_op_ocr3
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated"
+)
+
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+var NoOpOCR3MetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"expected\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"actual\",\"type\":\"bytes32\"}],\"name\":\"ConfigDigestMismatch\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"expected\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"actual\",\"type\":\"uint256\"}],\"name\":\"ForkedChain\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"message\",\"type\":\"string\"}],\"name\":\"InvalidConfig\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint64\",\"name\":\"sequenceNumber\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"latestSequenceNumber\",\"type\":\"uint64\"}],\"name\":\"NonIncreasingSequenceNumber\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NonUniqueSignatures\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"OracleCannotBeZeroAddress\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"SignaturesOutOfRegistration\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"UnauthorizedSigner\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"UnauthorizedTransmitter\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"expected\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"actual\",\"type\":\"uint256\"}],\"name\":\"WrongMessageLength\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"WrongNumberOfSignatures\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"previousConfigBlockNumber\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"configDigest\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"configCount\",\"type\":\"uint64\"},{\"indexed\":false,\"internalType\":\"address[]\",\"name\":\"signers\",\"type\":\"address[]\"},{\"indexed\":false,\"internalType\":\"address[]\",\"name\":\"transmitters\",\"type\":\"address[]\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"f\",\"type\":\"uint8\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"onchainConfig\",\"type\":\"bytes\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"offchainConfigVersion\",\"type\":\"uint64\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"offchainConfig\",\"type\":\"bytes\"}],\"name\":\"ConfigSet\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"}],\"name\":\"OwnershipTransferRequested\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"configDigest\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"sequenceNumber\",\"type\":\"uint64\"}],\"name\":\"Transmitted\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"acceptOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getTransmitters\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"\",\"type\":\"address[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"latestConfigDetails\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"configCount\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"blockNumber\",\"type\":\"uint32\"},{\"internalType\":\"bytes32\",\"name\":\"configDigest\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"latestConfigDigestAndEpoch\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"scanLogs\",\"type\":\"bool\"},{\"internalType\":\"bytes32\",\"name\":\"configDigest\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"sequenceNumber\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address[]\",\"name\":\"signers\",\"type\":\"address[]\"},{\"internalType\":\"address[]\",\"name\":\"transmitters\",\"type\":\"address[]\"},{\"internalType\":\"uint8\",\"name\":\"f\",\"type\":\"uint8\"},{\"internalType\":\"bytes\",\"name\":\"onchainConfig\",\"type\":\"bytes\"},{\"internalType\":\"uint64\",\"name\":\"offchainConfigVersion\",\"type\":\"uint64\"},{\"internalType\":\"bytes\",\"name\":\"offchainConfig\",\"type\":\"bytes\"}],\"name\":\"setOCR3Config\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32[3]\",\"name\":\"reportContext\",\"type\":\"bytes32[3]\"},{\"internalType\":\"bytes\",\"name\":\"report\",\"type\":\"bytes\"},{\"internalType\":\"bytes32[]\",\"name\":\"rs\",\"type\":\"bytes32[]\"},{\"internalType\":\"bytes32[]\",\"name\":\"ss\",\"type\":\"bytes32[]\"},{\"internalType\":\"bytes32\",\"name\":\"rawVs\",\"type\":\"bytes32\"}],\"name\":\"transmit\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"typeAndVersion\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
+	Bin: "0x60a060405234801561001057600080fd5b5033806000816100675760405162461bcd60e51b815260206004820152601860248201527f43616e6e6f7420736574206f776e657220746f207a65726f000000000000000060448201526064015b60405180910390fd5b600080546001600160a01b0319166001600160a01b038481169190911790915581161561009757610097816100a3565b5050466080525061014c565b336001600160a01b038216036100fb5760405162461bcd60e51b815260206004820152601760248201527f43616e6e6f74207472616e7366657220746f2073656c66000000000000000000604482015260640161005e565b600180546001600160a01b0319166001600160a01b0383811691821790925560008054604051929316917fed8889f560326eb138920d842192f0eb3dd22b4f139c87a2c57538e05bae12789190a350565b608051611c386200016f60003960008181610c9f0152610ceb0152611c386000f3fe608060405234801561001057600080fd5b50600436106100a35760003560e01c806381ff704811610076578063afcb95d71161005b578063afcb95d714610184578063b1dc65a4146101bd578063f2fde38b146101d057600080fd5b806381ff70481461012c5780638da5cb5b1461015c57600080fd5b8063181f5a77146100a8578063666cab8d146100fa5780636a11ee901461010f57806379ba509714610124575b600080fd5b6100e46040518060400160405280600e81526020017f4e6f4f704f43523320312e302e3000000000000000000000000000000000000081525081565b6040516100f1919061152f565b60405180910390f35b6101026101e3565b6040516100f1919061159a565b61012261011d366004611792565b610252565b005b610122610a6a565b6004546002546040805163ffffffff808516825264010000000090940490931660208401528201526060016100f1565b60005460405173ffffffffffffffffffffffffffffffffffffffff90911681526020016100f1565b600254600454604080516001815260208101939093526801000000000000000090910467ffffffffffffffff16908201526060016100f1565b6101226101cb3660046118ab565b610b67565b6101226101de366004611990565b6111d6565b6060600780548060200260200160405190810160405280929190818152602001828054801561024857602002820191906000526020600020905b815473ffffffffffffffffffffffffffffffffffffffff16815260019091019060200180831161021d575b5050505050905090565b855185518560ff16601f8311156102ca576040517f89a6198900000000000000000000000000000000000000000000000000000000815260206004820152601060248201527f746f6f206d616e79207369676e6572730000000000000000000000000000000060448201526064015b60405180910390fd5b80600003610334576040517f89a6198900000000000000000000000000000000000000000000000000000000815260206004820152601260248201527f66206d75737420626520706f736974697665000000000000000000000000000060448201526064016102c1565b8183146103c2576040517f89a61989000000000000000000000000000000000000000000000000000000008152602060048201526024808201527f6f7261636c6520616464726573736573206f7574206f6620726567697374726160448201527f74696f6e0000000000000000000000000000000000000000000000000000000060648201526084016102c1565b6103cd8160036119da565b8311610435576040517f89a6198900000000000000000000000000000000000000000000000000000000815260206004820152601860248201527f6661756c74792d6f7261636c65206620746f6f2068696768000000000000000060448201526064016102c1565b61043d6111ea565b60065460005b81811015610539576005600060068381548110610462576104626119f7565b600091825260208083209091015473ffffffffffffffffffffffffffffffffffffffff168352820192909252604001812080547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0000169055600780546005929190849081106104d2576104d26119f7565b600091825260208083209091015473ffffffffffffffffffffffffffffffffffffffff168352820192909252604001902080547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff000016905561053281611a26565b9050610443565b50895160005b818110156109125760008c828151811061055b5761055b6119f7565b602002602001015190506000600281111561057857610578611a5e565b73ffffffffffffffffffffffffffffffffffffffff8216600090815260056020526040902054610100900460ff1660028111156105b7576105b7611a5e565b1461061e576040517f89a6198900000000000000000000000000000000000000000000000000000000815260206004820152601760248201527f7265706561746564207369676e6572206164647265737300000000000000000060448201526064016102c1565b73ffffffffffffffffffffffffffffffffffffffff811661066b576040517fd6c62c9b00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b6040805180820190915260ff83168152602081016001905273ffffffffffffffffffffffffffffffffffffffff821660009081526005602090815260409091208251815460ff9091167fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0082168117835592840151919283917fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0000161761010083600281111561071b5761071b611a5e565b021790555090505060008c8381518110610737576107376119f7565b602002602001015190506000600281111561075457610754611a5e565b73ffffffffffffffffffffffffffffffffffffffff8216600090815260056020526040902054610100900460ff16600281111561079357610793611a5e565b146107fa576040517f89a6198900000000000000000000000000000000000000000000000000000000815260206004820152601c60248201527f7265706561746564207472616e736d697474657220616464726573730000000060448201526064016102c1565b73ffffffffffffffffffffffffffffffffffffffff8116610847576040517fd6c62c9b00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b6040805180820190915260ff84168152602081016002905273ffffffffffffffffffffffffffffffffffffffff821660009081526005602090815260409091208251815460ff9091167fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0082168117835592840151919283917fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff000016176101008360028111156108f7576108f7611a5e565b021790555090505050508061090b90611a26565b905061053f565b508a516109269060069060208e019061140d565b50895161093a9060079060208d019061140d565b506003805460ff838116610100027fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0000909216908c1617179055600480546109c09146913091906000906109929063ffffffff16611a8d565b91906101000a81548163ffffffff021916908363ffffffff160217905563ffffffff168e8e8e8e8e8e61126d565b600260000181905550600060048054906101000a900463ffffffff169050436004806101000a81548163ffffffff021916908363ffffffff1602179055507f1591690b8638f5fb2dbec82ac741805ac5da8b45dc5263f4875b0496fdce4e0581600260000154600460009054906101000a900463ffffffff168f8f8f8f8f8f604051610a5499989796959493929190611ab0565b60405180910390a1505050505050505050505050565b60015473ffffffffffffffffffffffffffffffffffffffff163314610aeb576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601660248201527f4d7573742062652070726f706f736564206f776e65720000000000000000000060448201526064016102c1565b60008054337fffffffffffffffffffffffff00000000000000000000000000000000000000008083168217845560018054909116905560405173ffffffffffffffffffffffffffffffffffffffff90921692909183917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e091a350565b60045460208901359067ffffffffffffffff68010000000000000000909104811690821611610bea57600480546040517f6e376b6600000000000000000000000000000000000000000000000000000000815267ffffffffffffffff808516938201939093526801000000000000000090910490911660248201526044016102c1565b600480547fffffffffffffffffffffffffffffffff0000000000000000ffffffffffffffff166801000000000000000067ffffffffffffffff8416021790556040805160608101825260025480825260035460ff808216602085015261010090910416928201929092528a35918214610c9c5780516040517f93df584c0000000000000000000000000000000000000000000000000000000081526004810191909152602481018390526044016102c1565b467f000000000000000000000000000000000000000000000000000000000000000014610d1d576040517f0f01ce850000000000000000000000000000000000000000000000000000000081527f000000000000000000000000000000000000000000000000000000000000000060048201524660248201526044016102c1565b6040805183815267ffffffffffffffff851660208201527fe893c2681d327421d89e1cb54fbe64645b4dcea668d6826130b62cf4c6eefea2910160405180910390a16020810151610d6f906001611b46565b60ff168714610daa576040517f71253a2500000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b868514610de3576040517fa75d88af00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b3360009081526005602090815260408083208151808301909252805460ff80821684529293919291840191610100909104166002811115610e2657610e26611a5e565b6002811115610e3757610e37611a5e565b9052509050600281602001516002811115610e5457610e54611a5e565b148015610e9b57506007816000015160ff1681548110610e7657610e766119f7565b60009182526020909120015473ffffffffffffffffffffffffffffffffffffffff1633145b610ed1576040517fda0f08e800000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b506000610edf8660206119da565b610eea8960206119da565b610ef68c610144611b5f565b610f009190611b5f565b610f0a9190611b5f565b9050368114610f4e576040517f8e1192e1000000000000000000000000000000000000000000000000000000008152600481018290523660248201526044016102c1565b5060008a8a604051610f61929190611b72565b604051908190038120610f78918e90602001611b82565b604051602081830303815290604052805190602001209050610f98611497565b8860005b818110156111c55760006001858a8460208110610fbb57610fbb6119f7565b610fc891901a601b611b46565b8f8f86818110610fda57610fda6119f7565b905060200201358e8e87818110610ff357610ff36119f7565b9050602002013560405160008152602001604052604051611030949392919093845260ff9290921660208401526040830152606082015260800190565b6020604051602081039080840390855afa158015611052573d6000803e3d6000fd5b5050604080517fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe081015173ffffffffffffffffffffffffffffffffffffffff8116600090815260056020908152848220848601909552845460ff80821686529397509195509293928401916101009091041660028111156110d5576110d5611a5e565b60028111156110e6576110e6611a5e565b905250905060018160200151600281111561110357611103611a5e565b1461113a576040517fca31867a00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b8051859060ff16601f8110611151576111516119f7565b60200201511561118d576040517ff67bc7c400000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b600185826000015160ff16601f81106111a8576111a86119f7565b91151560209092020152506111be905081611a26565b9050610f9c565b505050505050505050505050505050565b6111de6111ea565b6111e781611318565b50565b60005473ffffffffffffffffffffffffffffffffffffffff16331461126b576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601660248201527f4f6e6c792063616c6c61626c65206279206f776e65720000000000000000000060448201526064016102c1565b565b6000808a8a8a8a8a8a8a8a8a60405160200161129199989796959493929190611b96565b604080517fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe081840301815291905280516020909101207dffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff167e01000000000000000000000000000000000000000000000000000000000000179150509998505050505050505050565b3373ffffffffffffffffffffffffffffffffffffffff821603611397576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601760248201527f43616e6e6f74207472616e7366657220746f2073656c6600000000000000000060448201526064016102c1565b600180547fffffffffffffffffffffffff00000000000000000000000000000000000000001673ffffffffffffffffffffffffffffffffffffffff83811691821790925560008054604051929316917fed8889f560326eb138920d842192f0eb3dd22b4f139c87a2c57538e05bae12789190a350565b828054828255906000526020600020908101928215611487579160200282015b8281111561148757825182547fffffffffffffffffffffffff00000000000000000000000000000000000000001673ffffffffffffffffffffffffffffffffffffffff90911617825560209092019160019091019061142d565b506114939291506114b6565b5090565b604051806103e00160405280601f906020820280368337509192915050565b5b8082111561149357600081556001016114b7565b6000815180845260005b818110156114f1576020818501810151868301820152016114d5565b5060006020828601015260207fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0601f83011685010191505092915050565b60208152600061154260208301846114cb565b9392505050565b600081518084526020808501945080840160005b8381101561158f57815173ffffffffffffffffffffffffffffffffffffffff168752958201959082019060010161155d565b509495945050505050565b6020815260006115426020830184611549565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052604160045260246000fd5b604051601f82017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe016810167ffffffffffffffff81118282101715611623576116236115ad565b604052919050565b803573ffffffffffffffffffffffffffffffffffffffff8116811461164f57600080fd5b919050565b600082601f83011261166557600080fd5b8135602067ffffffffffffffff821115611681576116816115ad565b8160051b6116908282016115dc565b92835284810182019282810190878511156116aa57600080fd5b83870192505b848310156116d0576116c18361162b565b825291830191908301906116b0565b979650505050505050565b803560ff8116811461164f57600080fd5b600082601f8301126116fd57600080fd5b813567ffffffffffffffff811115611717576117176115ad565b61174860207fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0601f840116016115dc565b81815284602083860101111561175d57600080fd5b816020850160208301376000918101602001919091529392505050565b803567ffffffffffffffff8116811461164f57600080fd5b60008060008060008060c087890312156117ab57600080fd5b863567ffffffffffffffff808211156117c357600080fd5b6117cf8a838b01611654565b975060208901359150808211156117e557600080fd5b6117f18a838b01611654565b96506117ff60408a016116db565b9550606089013591508082111561181557600080fd5b6118218a838b016116ec565b945061182f60808a0161177a565b935060a089013591508082111561184557600080fd5b5061185289828a016116ec565b9150509295509295509295565b60008083601f84011261187157600080fd5b50813567ffffffffffffffff81111561188957600080fd5b6020830191508360208260051b85010111156118a457600080fd5b9250929050565b60008060008060008060008060e0898b0312156118c757600080fd5b606089018a8111156118d857600080fd5b8998503567ffffffffffffffff808211156118f257600080fd5b818b0191508b601f83011261190657600080fd5b81358181111561191557600080fd5b8c602082850101111561192757600080fd5b6020830199508098505060808b013591508082111561194557600080fd5b6119518c838d0161185f565b909750955060a08b013591508082111561196a57600080fd5b506119778b828c0161185f565b999c989b50969995989497949560c00135949350505050565b6000602082840312156119a257600080fd5b6115428261162b565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052601160045260246000fd5b80820281158282048414176119f1576119f16119ab565b92915050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052603260045260246000fd5b60007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8203611a5757611a576119ab565b5060010190565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052602160045260246000fd5b600063ffffffff808316818103611aa657611aa66119ab565b6001019392505050565b600061012063ffffffff808d1684528b6020850152808b16604085015250806060840152611ae08184018a611549565b90508281036080840152611af48189611549565b905060ff871660a084015282810360c0840152611b1181876114cb565b905067ffffffffffffffff851660e0840152828103610100840152611b3681856114cb565b9c9b505050505050505050505050565b60ff81811683821601908111156119f1576119f16119ab565b808201808211156119f1576119f16119ab565b8183823760009101908152919050565b828152606082602083013760800192915050565b60006101208b835273ffffffffffffffffffffffffffffffffffffffff8b16602084015267ffffffffffffffff808b166040850152816060850152611bdd8285018b611549565b91508382036080850152611bf1828a611549565b915060ff881660a085015283820360c0850152611c0e82886114cb565b90861660e08501528381036101008501529050611b3681856114cb56fea164736f6c6343000813000a",
+}
+
+var NoOpOCR3ABI = NoOpOCR3MetaData.ABI
+
+var NoOpOCR3Bin = NoOpOCR3MetaData.Bin
+
+func DeployNoOpOCR3(auth *bind.TransactOpts, backend bind.ContractBackend) (common.Address, *types.Transaction, *NoOpOCR3, error) {
+	parsed, err := NoOpOCR3MetaData.GetAbi()
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	if parsed == nil {
+		return common.Address{}, nil, nil, errors.New("GetABI returned nil")
+	}
+
+	address, tx, contract, err := bind.DeployContract(auth, *parsed, common.FromHex(NoOpOCR3Bin), backend)
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	return address, tx, &NoOpOCR3{address: address, abi: *parsed, NoOpOCR3Caller: NoOpOCR3Caller{contract: contract}, NoOpOCR3Transactor: NoOpOCR3Transactor{contract: contract}, NoOpOCR3Filterer: NoOpOCR3Filterer{contract: contract}}, nil
+}
+
+type NoOpOCR3 struct {
+	address common.Address
+	abi     abi.ABI
+	NoOpOCR3Caller
+	NoOpOCR3Transactor
+	NoOpOCR3Filterer
+}
+
+type NoOpOCR3Caller struct {
+	contract *bind.BoundContract
+}
+
+type NoOpOCR3Transactor struct {
+	contract *bind.BoundContract
+}
+
+type NoOpOCR3Filterer struct {
+	contract *bind.BoundContract
+}
+
+type NoOpOCR3Session struct {
+	Contract     *NoOpOCR3
+	CallOpts     bind.CallOpts
+	TransactOpts bind.TransactOpts
+}
+
+type NoOpOCR3CallerSession struct {
+	Contract *NoOpOCR3Caller
+	CallOpts bind.CallOpts
+}
+
+type NoOpOCR3TransactorSession struct {
+	Contract     *NoOpOCR3Transactor
+	TransactOpts bind.TransactOpts
+}
+
+type NoOpOCR3Raw struct {
+	Contract *NoOpOCR3
+}
+
+type NoOpOCR3CallerRaw struct {
+	Contract *NoOpOCR3Caller
+}
+
+type NoOpOCR3TransactorRaw struct {
+	Contract *NoOpOCR3Transactor
+}
+
+func NewNoOpOCR3(address common.Address, backend bind.ContractBackend) (*NoOpOCR3, error) {
+	abi, err := abi.JSON(strings.NewReader(NoOpOCR3ABI))
+	if err != nil {
+		return nil, err
+	}
+	contract, err := bindNoOpOCR3(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &NoOpOCR3{address: address, abi: abi, NoOpOCR3Caller: NoOpOCR3Caller{contract: contract}, NoOpOCR3Transactor: NoOpOCR3Transactor{contract: contract}, NoOpOCR3Filterer: NoOpOCR3Filterer{contract: contract}}, nil
+}
+
+func NewNoOpOCR3Caller(address common.Address, caller bind.ContractCaller) (*NoOpOCR3Caller, error) {
+	contract, err := bindNoOpOCR3(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &NoOpOCR3Caller{contract: contract}, nil
+}
+
+func NewNoOpOCR3Transactor(address common.Address, transactor bind.ContractTransactor) (*NoOpOCR3Transactor, error) {
+	contract, err := bindNoOpOCR3(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &NoOpOCR3Transactor{contract: contract}, nil
+}
+
+func NewNoOpOCR3Filterer(address common.Address, filterer bind.ContractFilterer) (*NoOpOCR3Filterer, error) {
+	contract, err := bindNoOpOCR3(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &NoOpOCR3Filterer{contract: contract}, nil
+}
+
+func bindNoOpOCR3(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := NoOpOCR3MetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+func (_NoOpOCR3 *NoOpOCR3Raw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _NoOpOCR3.Contract.NoOpOCR3Caller.contract.Call(opts, result, method, params...)
+}
+
+func (_NoOpOCR3 *NoOpOCR3Raw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _NoOpOCR3.Contract.NoOpOCR3Transactor.contract.Transfer(opts)
+}
+
+func (_NoOpOCR3 *NoOpOCR3Raw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _NoOpOCR3.Contract.NoOpOCR3Transactor.contract.Transact(opts, method, params...)
+}
+
+func (_NoOpOCR3 *NoOpOCR3CallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _NoOpOCR3.Contract.contract.Call(opts, result, method, params...)
+}
+
+func (_NoOpOCR3 *NoOpOCR3TransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _NoOpOCR3.Contract.contract.Transfer(opts)
+}
+
+func (_NoOpOCR3 *NoOpOCR3TransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _NoOpOCR3.Contract.contract.Transact(opts, method, params...)
+}
+
+func (_NoOpOCR3 *NoOpOCR3Caller) GetTransmitters(opts *bind.CallOpts) ([]common.Address, error) {
+	var out []interface{}
+	err := _NoOpOCR3.contract.Call(opts, &out, "getTransmitters")
+
+	if err != nil {
+		return *new([]common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]common.Address)).(*[]common.Address)
+
+	return out0, err
+
+}
+
+func (_NoOpOCR3 *NoOpOCR3Session) GetTransmitters() ([]common.Address, error) {
+	return _NoOpOCR3.Contract.GetTransmitters(&_NoOpOCR3.CallOpts)
+}
+
+func (_NoOpOCR3 *NoOpOCR3CallerSession) GetTransmitters() ([]common.Address, error) {
+	return _NoOpOCR3.Contract.GetTransmitters(&_NoOpOCR3.CallOpts)
+}
+
+func (_NoOpOCR3 *NoOpOCR3Caller) LatestConfigDetails(opts *bind.CallOpts) (LatestConfigDetails,
+
+	error) {
+	var out []interface{}
+	err := _NoOpOCR3.contract.Call(opts, &out, "latestConfigDetails")
+
+	outstruct := new(LatestConfigDetails)
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.ConfigCount = *abi.ConvertType(out[0], new(uint32)).(*uint32)
+	outstruct.BlockNumber = *abi.ConvertType(out[1], new(uint32)).(*uint32)
+	outstruct.ConfigDigest = *abi.ConvertType(out[2], new([32]byte)).(*[32]byte)
+
+	return *outstruct, err
+
+}
+
+func (_NoOpOCR3 *NoOpOCR3Session) LatestConfigDetails() (LatestConfigDetails,
+
+	error) {
+	return _NoOpOCR3.Contract.LatestConfigDetails(&_NoOpOCR3.CallOpts)
+}
+
+func (_NoOpOCR3 *NoOpOCR3CallerSession) LatestConfigDetails() (LatestConfigDetails,
+
+	error) {
+	return _NoOpOCR3.Contract.LatestConfigDetails(&_NoOpOCR3.CallOpts)
+}
+
+func (_NoOpOCR3 *NoOpOCR3Caller) LatestConfigDigestAndEpoch(opts *bind.CallOpts) (LatestConfigDigestAndEpoch,
+
+	error) {
+	var out []interface{}
+	err := _NoOpOCR3.contract.Call(opts, &out, "latestConfigDigestAndEpoch")
+
+	outstruct := new(LatestConfigDigestAndEpoch)
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.ScanLogs = *abi.ConvertType(out[0], new(bool)).(*bool)
+	outstruct.ConfigDigest = *abi.ConvertType(out[1], new([32]byte)).(*[32]byte)
+	outstruct.SequenceNumber = *abi.ConvertType(out[2], new(uint64)).(*uint64)
+
+	return *outstruct, err
+
+}
+
+func (_NoOpOCR3 *NoOpOCR3Session) LatestConfigDigestAndEpoch() (LatestConfigDigestAndEpoch,
+
+	error) {
+	return _NoOpOCR3.Contract.LatestConfigDigestAndEpoch(&_NoOpOCR3.CallOpts)
+}
+
+func (_NoOpOCR3 *NoOpOCR3CallerSession) LatestConfigDigestAndEpoch() (LatestConfigDigestAndEpoch,
+
+	error) {
+	return _NoOpOCR3.Contract.LatestConfigDigestAndEpoch(&_NoOpOCR3.CallOpts)
+}
+
+func (_NoOpOCR3 *NoOpOCR3Caller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _NoOpOCR3.contract.Call(opts, &out, "owner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+func (_NoOpOCR3 *NoOpOCR3Session) Owner() (common.Address, error) {
+	return _NoOpOCR3.Contract.Owner(&_NoOpOCR3.CallOpts)
+}
+
+func (_NoOpOCR3 *NoOpOCR3CallerSession) Owner() (common.Address, error) {
+	return _NoOpOCR3.Contract.Owner(&_NoOpOCR3.CallOpts)
+}
+
+func (_NoOpOCR3 *NoOpOCR3Caller) TypeAndVersion(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _NoOpOCR3.contract.Call(opts, &out, "typeAndVersion")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+func (_NoOpOCR3 *NoOpOCR3Session) TypeAndVersion() (string, error) {
+	return _NoOpOCR3.Contract.TypeAndVersion(&_NoOpOCR3.CallOpts)
+}
+
+func (_NoOpOCR3 *NoOpOCR3CallerSession) TypeAndVersion() (string, error) {
+	return _NoOpOCR3.Contract.TypeAndVersion(&_NoOpOCR3.CallOpts)
+}
+
+func (_NoOpOCR3 *NoOpOCR3Transactor) AcceptOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _NoOpOCR3.contract.Transact(opts, "acceptOwnership")
+}
+
+func (_NoOpOCR3 *NoOpOCR3Session) AcceptOwnership() (*types.Transaction, error) {
+	return _NoOpOCR3.Contract.AcceptOwnership(&_NoOpOCR3.TransactOpts)
+}
+
+func (_NoOpOCR3 *NoOpOCR3TransactorSession) AcceptOwnership() (*types.Transaction, error) {
+	return _NoOpOCR3.Contract.AcceptOwnership(&_NoOpOCR3.TransactOpts)
+}
+
+func (_NoOpOCR3 *NoOpOCR3Transactor) SetOCR3Config(opts *bind.TransactOpts, signers []common.Address, transmitters []common.Address, f uint8, onchainConfig []byte, offchainConfigVersion uint64, offchainConfig []byte) (*types.Transaction, error) {
+	return _NoOpOCR3.contract.Transact(opts, "setOCR3Config", signers, transmitters, f, onchainConfig, offchainConfigVersion, offchainConfig)
+}
+
+func (_NoOpOCR3 *NoOpOCR3Session) SetOCR3Config(signers []common.Address, transmitters []common.Address, f uint8, onchainConfig []byte, offchainConfigVersion uint64, offchainConfig []byte) (*types.Transaction, error) {
+	return _NoOpOCR3.Contract.SetOCR3Config(&_NoOpOCR3.TransactOpts, signers, transmitters, f, onchainConfig, offchainConfigVersion, offchainConfig)
+}
+
+func (_NoOpOCR3 *NoOpOCR3TransactorSession) SetOCR3Config(signers []common.Address, transmitters []common.Address, f uint8, onchainConfig []byte, offchainConfigVersion uint64, offchainConfig []byte) (*types.Transaction, error) {
+	return _NoOpOCR3.Contract.SetOCR3Config(&_NoOpOCR3.TransactOpts, signers, transmitters, f, onchainConfig, offchainConfigVersion, offchainConfig)
+}
+
+func (_NoOpOCR3 *NoOpOCR3Transactor) TransferOwnership(opts *bind.TransactOpts, to common.Address) (*types.Transaction, error) {
+	return _NoOpOCR3.contract.Transact(opts, "transferOwnership", to)
+}
+
+func (_NoOpOCR3 *NoOpOCR3Session) TransferOwnership(to common.Address) (*types.Transaction, error) {
+	return _NoOpOCR3.Contract.TransferOwnership(&_NoOpOCR3.TransactOpts, to)
+}
+
+func (_NoOpOCR3 *NoOpOCR3TransactorSession) TransferOwnership(to common.Address) (*types.Transaction, error) {
+	return _NoOpOCR3.Contract.TransferOwnership(&_NoOpOCR3.TransactOpts, to)
+}
+
+func (_NoOpOCR3 *NoOpOCR3Transactor) Transmit(opts *bind.TransactOpts, reportContext [3][32]byte, report []byte, rs [][32]byte, ss [][32]byte, rawVs [32]byte) (*types.Transaction, error) {
+	return _NoOpOCR3.contract.Transact(opts, "transmit", reportContext, report, rs, ss, rawVs)
+}
+
+func (_NoOpOCR3 *NoOpOCR3Session) Transmit(reportContext [3][32]byte, report []byte, rs [][32]byte, ss [][32]byte, rawVs [32]byte) (*types.Transaction, error) {
+	return _NoOpOCR3.Contract.Transmit(&_NoOpOCR3.TransactOpts, reportContext, report, rs, ss, rawVs)
+}
+
+func (_NoOpOCR3 *NoOpOCR3TransactorSession) Transmit(reportContext [3][32]byte, report []byte, rs [][32]byte, ss [][32]byte, rawVs [32]byte) (*types.Transaction, error) {
+	return _NoOpOCR3.Contract.Transmit(&_NoOpOCR3.TransactOpts, reportContext, report, rs, ss, rawVs)
+}
+
+type NoOpOCR3ConfigSetIterator struct {
+	Event *NoOpOCR3ConfigSet
+
+	contract *bind.BoundContract
+	event    string
+
+	logs chan types.Log
+	sub  ethereum.Subscription
+	done bool
+	fail error
+}
+
+func (it *NoOpOCR3ConfigSetIterator) Next() bool {
+
+	if it.fail != nil {
+		return false
+	}
+
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(NoOpOCR3ConfigSet)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+
+	select {
+	case log := <-it.logs:
+		it.Event = new(NoOpOCR3ConfigSet)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+func (it *NoOpOCR3ConfigSetIterator) Error() error {
+	return it.fail
+}
+
+func (it *NoOpOCR3ConfigSetIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+type NoOpOCR3ConfigSet struct {
+	PreviousConfigBlockNumber uint32
+	ConfigDigest              [32]byte
+	ConfigCount               uint64
+	Signers                   []common.Address
+	Transmitters              []common.Address
+	F                         uint8
+	OnchainConfig             []byte
+	OffchainConfigVersion     uint64
+	OffchainConfig            []byte
+	Raw                       types.Log
+}
+
+func (_NoOpOCR3 *NoOpOCR3Filterer) FilterConfigSet(opts *bind.FilterOpts) (*NoOpOCR3ConfigSetIterator, error) {
+
+	logs, sub, err := _NoOpOCR3.contract.FilterLogs(opts, "ConfigSet")
+	if err != nil {
+		return nil, err
+	}
+	return &NoOpOCR3ConfigSetIterator{contract: _NoOpOCR3.contract, event: "ConfigSet", logs: logs, sub: sub}, nil
+}
+
+func (_NoOpOCR3 *NoOpOCR3Filterer) WatchConfigSet(opts *bind.WatchOpts, sink chan<- *NoOpOCR3ConfigSet) (event.Subscription, error) {
+
+	logs, sub, err := _NoOpOCR3.contract.WatchLogs(opts, "ConfigSet")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+
+				event := new(NoOpOCR3ConfigSet)
+				if err := _NoOpOCR3.contract.UnpackLog(event, "ConfigSet", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+func (_NoOpOCR3 *NoOpOCR3Filterer) ParseConfigSet(log types.Log) (*NoOpOCR3ConfigSet, error) {
+	event := new(NoOpOCR3ConfigSet)
+	if err := _NoOpOCR3.contract.UnpackLog(event, "ConfigSet", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+type NoOpOCR3OwnershipTransferRequestedIterator struct {
+	Event *NoOpOCR3OwnershipTransferRequested
+
+	contract *bind.BoundContract
+	event    string
+
+	logs chan types.Log
+	sub  ethereum.Subscription
+	done bool
+	fail error
+}
+
+func (it *NoOpOCR3OwnershipTransferRequestedIterator) Next() bool {
+
+	if it.fail != nil {
+		return false
+	}
+
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(NoOpOCR3OwnershipTransferRequested)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+
+	select {
+	case log := <-it.logs:
+		it.Event = new(NoOpOCR3OwnershipTransferRequested)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+func (it *NoOpOCR3OwnershipTransferRequestedIterator) Error() error {
+	return it.fail
+}
+
+func (it *NoOpOCR3OwnershipTransferRequestedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+type NoOpOCR3OwnershipTransferRequested struct {
+	From common.Address
+	To   common.Address
+	Raw  types.Log
+}
+
+func (_NoOpOCR3 *NoOpOCR3Filterer) FilterOwnershipTransferRequested(opts *bind.FilterOpts, from []common.Address, to []common.Address) (*NoOpOCR3OwnershipTransferRequestedIterator, error) {
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _NoOpOCR3.contract.FilterLogs(opts, "OwnershipTransferRequested", fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return &NoOpOCR3OwnershipTransferRequestedIterator{contract: _NoOpOCR3.contract, event: "OwnershipTransferRequested", logs: logs, sub: sub}, nil
+}
+
+func (_NoOpOCR3 *NoOpOCR3Filterer) WatchOwnershipTransferRequested(opts *bind.WatchOpts, sink chan<- *NoOpOCR3OwnershipTransferRequested, from []common.Address, to []common.Address) (event.Subscription, error) {
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _NoOpOCR3.contract.WatchLogs(opts, "OwnershipTransferRequested", fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+
+				event := new(NoOpOCR3OwnershipTransferRequested)
+				if err := _NoOpOCR3.contract.UnpackLog(event, "OwnershipTransferRequested", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+func (_NoOpOCR3 *NoOpOCR3Filterer) ParseOwnershipTransferRequested(log types.Log) (*NoOpOCR3OwnershipTransferRequested, error) {
+	event := new(NoOpOCR3OwnershipTransferRequested)
+	if err := _NoOpOCR3.contract.UnpackLog(event, "OwnershipTransferRequested", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+type NoOpOCR3OwnershipTransferredIterator struct {
+	Event *NoOpOCR3OwnershipTransferred
+
+	contract *bind.BoundContract
+	event    string
+
+	logs chan types.Log
+	sub  ethereum.Subscription
+	done bool
+	fail error
+}
+
+func (it *NoOpOCR3OwnershipTransferredIterator) Next() bool {
+
+	if it.fail != nil {
+		return false
+	}
+
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(NoOpOCR3OwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+
+	select {
+	case log := <-it.logs:
+		it.Event = new(NoOpOCR3OwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+func (it *NoOpOCR3OwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+func (it *NoOpOCR3OwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+type NoOpOCR3OwnershipTransferred struct {
+	From common.Address
+	To   common.Address
+	Raw  types.Log
+}
+
+func (_NoOpOCR3 *NoOpOCR3Filterer) FilterOwnershipTransferred(opts *bind.FilterOpts, from []common.Address, to []common.Address) (*NoOpOCR3OwnershipTransferredIterator, error) {
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _NoOpOCR3.contract.FilterLogs(opts, "OwnershipTransferred", fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return &NoOpOCR3OwnershipTransferredIterator{contract: _NoOpOCR3.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+func (_NoOpOCR3 *NoOpOCR3Filterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *NoOpOCR3OwnershipTransferred, from []common.Address, to []common.Address) (event.Subscription, error) {
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _NoOpOCR3.contract.WatchLogs(opts, "OwnershipTransferred", fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+
+				event := new(NoOpOCR3OwnershipTransferred)
+				if err := _NoOpOCR3.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+func (_NoOpOCR3 *NoOpOCR3Filterer) ParseOwnershipTransferred(log types.Log) (*NoOpOCR3OwnershipTransferred, error) {
+	event := new(NoOpOCR3OwnershipTransferred)
+	if err := _NoOpOCR3.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+type NoOpOCR3TransmittedIterator struct {
+	Event *NoOpOCR3Transmitted
+
+	contract *bind.BoundContract
+	event    string
+
+	logs chan types.Log
+	sub  ethereum.Subscription
+	done bool
+	fail error
+}
+
+func (it *NoOpOCR3TransmittedIterator) Next() bool {
+
+	if it.fail != nil {
+		return false
+	}
+
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(NoOpOCR3Transmitted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+
+	select {
+	case log := <-it.logs:
+		it.Event = new(NoOpOCR3Transmitted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+func (it *NoOpOCR3TransmittedIterator) Error() error {
+	return it.fail
+}
+
+func (it *NoOpOCR3TransmittedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+type NoOpOCR3Transmitted struct {
+	ConfigDigest   [32]byte
+	SequenceNumber uint64
+	Raw            types.Log
+}
+
+func (_NoOpOCR3 *NoOpOCR3Filterer) FilterTransmitted(opts *bind.FilterOpts) (*NoOpOCR3TransmittedIterator, error) {
+
+	logs, sub, err := _NoOpOCR3.contract.FilterLogs(opts, "Transmitted")
+	if err != nil {
+		return nil, err
+	}
+	return &NoOpOCR3TransmittedIterator{contract: _NoOpOCR3.contract, event: "Transmitted", logs: logs, sub: sub}, nil
+}
+
+func (_NoOpOCR3 *NoOpOCR3Filterer) WatchTransmitted(opts *bind.WatchOpts, sink chan<- *NoOpOCR3Transmitted) (event.Subscription, error) {
+
+	logs, sub, err := _NoOpOCR3.contract.WatchLogs(opts, "Transmitted")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+
+				event := new(NoOpOCR3Transmitted)
+				if err := _NoOpOCR3.contract.UnpackLog(event, "Transmitted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+func (_NoOpOCR3 *NoOpOCR3Filterer) ParseTransmitted(log types.Log) (*NoOpOCR3Transmitted, error) {
+	event := new(NoOpOCR3Transmitted)
+	if err := _NoOpOCR3.contract.UnpackLog(event, "Transmitted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+type LatestConfigDetails struct {
+	ConfigCount  uint32
+	BlockNumber  uint32
+	ConfigDigest [32]byte
+}
+type LatestConfigDigestAndEpoch struct {
+	ScanLogs       bool
+	ConfigDigest   [32]byte
+	SequenceNumber uint64
+}
+
+func (_NoOpOCR3 *NoOpOCR3) ParseLog(log types.Log) (generated.AbigenLog, error) {
+	switch log.Topics[0] {
+	case _NoOpOCR3.abi.Events["ConfigSet"].ID:
+		return _NoOpOCR3.ParseConfigSet(log)
+	case _NoOpOCR3.abi.Events["OwnershipTransferRequested"].ID:
+		return _NoOpOCR3.ParseOwnershipTransferRequested(log)
+	case _NoOpOCR3.abi.Events["OwnershipTransferred"].ID:
+		return _NoOpOCR3.ParseOwnershipTransferred(log)
+	case _NoOpOCR3.abi.Events["Transmitted"].ID:
+		return _NoOpOCR3.ParseTransmitted(log)
+
+	default:
+		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
+	}
+}
+
+func (NoOpOCR3ConfigSet) Topic() common.Hash {
+	return common.HexToHash("0x1591690b8638f5fb2dbec82ac741805ac5da8b45dc5263f4875b0496fdce4e05")
+}
+
+func (NoOpOCR3OwnershipTransferRequested) Topic() common.Hash {
+	return common.HexToHash("0xed8889f560326eb138920d842192f0eb3dd22b4f139c87a2c57538e05bae1278")
+}
+
+func (NoOpOCR3OwnershipTransferred) Topic() common.Hash {
+	return common.HexToHash("0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0")
+}
+
+func (NoOpOCR3Transmitted) Topic() common.Hash {
+	return common.HexToHash("0xe893c2681d327421d89e1cb54fbe64645b4dcea668d6826130b62cf4c6eefea2")
+}
+
+func (_NoOpOCR3 *NoOpOCR3) Address() common.Address {
+	return _NoOpOCR3.address
+}
+
+type NoOpOCR3Interface interface {
+	GetTransmitters(opts *bind.CallOpts) ([]common.Address, error)
+
+	LatestConfigDetails(opts *bind.CallOpts) (LatestConfigDetails,
+
+		error)
+
+	LatestConfigDigestAndEpoch(opts *bind.CallOpts) (LatestConfigDigestAndEpoch,
+
+		error)
+
+	Owner(opts *bind.CallOpts) (common.Address, error)
+
+	TypeAndVersion(opts *bind.CallOpts) (string, error)
+
+	AcceptOwnership(opts *bind.TransactOpts) (*types.Transaction, error)
+
+	SetOCR3Config(opts *bind.TransactOpts, signers []common.Address, transmitters []common.Address, f uint8, onchainConfig []byte, offchainConfigVersion uint64, offchainConfig []byte) (*types.Transaction, error)
+
+	TransferOwnership(opts *bind.TransactOpts, to common.Address) (*types.Transaction, error)
+
+	Transmit(opts *bind.TransactOpts, reportContext [3][32]byte, report []byte, rs [][32]byte, ss [][32]byte, rawVs [32]byte) (*types.Transaction, error)
+
+	FilterConfigSet(opts *bind.FilterOpts) (*NoOpOCR3ConfigSetIterator, error)
+
+	WatchConfigSet(opts *bind.WatchOpts, sink chan<- *NoOpOCR3ConfigSet) (event.Subscription, error)
+
+	ParseConfigSet(log types.Log) (*NoOpOCR3ConfigSet, error)
+
+	FilterOwnershipTransferRequested(opts *bind.FilterOpts, from []common.Address, to []common.Address) (*NoOpOCR3OwnershipTransferRequestedIterator, error)
+
+	WatchOwnershipTransferRequested(opts *bind.WatchOpts, sink chan<- *NoOpOCR3OwnershipTransferRequested, from []common.Address, to []common.Address) (event.Subscription, error)
+
+	ParseOwnershipTransferRequested(log types.Log) (*NoOpOCR3OwnershipTransferRequested, error)
+
+	FilterOwnershipTransferred(opts *bind.FilterOpts, from []common.Address, to []common.Address) (*NoOpOCR3OwnershipTransferredIterator, error)
+
+	WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *NoOpOCR3OwnershipTransferred, from []common.Address, to []common.Address) (event.Subscription, error)
+
+	ParseOwnershipTransferred(log types.Log) (*NoOpOCR3OwnershipTransferred, error)
+
+	FilterTransmitted(opts *bind.FilterOpts) (*NoOpOCR3TransmittedIterator, error)
+
+	WatchTransmitted(opts *bind.WatchOpts, sink chan<- *NoOpOCR3Transmitted) (event.Subscription, error)
+
+	ParseTransmitted(log types.Log) (*NoOpOCR3Transmitted, error)
+
+	ParseLog(log types.Log) (generated.AbigenLog, error)
+
+	Address() common.Address
+}

--- a/core/services/ocr2/plugins/ccip/ccipexec/ocr2_test.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/ocr2_test.go
@@ -73,7 +73,7 @@ func TestExecutionReportingPlugin_Observation(t *testing.T) {
 				},
 			},
 			blessedRoots: map[[32]byte]bool{
-				[32]byte{123}: true,
+				{123}: true,
 			},
 			rateLimiterState: evm_2_evm_offramp.RateLimiterTokenBucket{
 				IsEnabled: false,

--- a/core/services/ocr2/plugins/rebalancer/models/models.go
+++ b/core/services/ocr2/plugins/rebalancer/models/models.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
 )
 
 type Address common.Address
@@ -106,6 +107,10 @@ func (r ReportMetadata) Encode() []byte {
 		panic(fmt.Errorf("report meta %#v encoding unexpected internal error: %w", r, err))
 	}
 	return b
+}
+
+func (r ReportMetadata) GetDestinationChain() relay.ID {
+	return relay.NewID(relay.EVM, fmt.Sprintf("%d", r.NetworkID))
 }
 
 func DecodeReportMetadata(b []byte) (ReportMetadata, error) {

--- a/core/services/ocr2/plugins/rebalancer/ocr3impls/contract_transmitter.go
+++ b/core/services/ocr2/plugins/rebalancer/ocr3impls/contract_transmitter.go
@@ -1,0 +1,129 @@
+package ocr3impls
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/pkg/errors"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/chains/evmutil"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+)
+
+type Transmitter interface {
+	CreateEthTransaction(ctx context.Context, toAddress gethcommon.Address, payload []byte, txMeta *txmgr.TxMeta) error
+	FromAddress() gethcommon.Address
+}
+
+type ReportToEthMetadata func([]byte) (*txmgr.TxMeta, error)
+
+func reportToEvmTxMetaNoop([]byte) (*txmgr.TxMeta, error) {
+	return nil, nil
+}
+
+func transmitterFilterName(addr gethcommon.Address) string {
+	return logpoller.FilterName("OCR3 ContractTransmitter", addr.String())
+}
+
+var _ ocr3types.ContractTransmitter[any] = &contractTransmitterOCR3[any]{}
+
+type contractTransmitterOCR3[RI any] struct {
+	contractAddress     gethcommon.Address
+	contractABI         abi.ABI
+	transmitter         Transmitter
+	transmittedEventSig gethcommon.Hash
+	lp                  logpoller.LogPoller
+	lggr                logger.Logger
+	reportToEvmTxMeta   ReportToEthMetadata
+}
+
+func NewOCR3ContractTransmitter[RI any](
+	address gethcommon.Address,
+	contractABI abi.ABI,
+	transmitter Transmitter,
+	lp logpoller.LogPoller,
+	lggr logger.Logger,
+	reportToEvmTxMeta ReportToEthMetadata,
+) (*contractTransmitterOCR3[RI], error) {
+	transmitted, ok := contractABI.Events["Transmitted"]
+	if !ok {
+		return nil, fmt.Errorf("abi missing Transmitted event")
+	}
+
+	err := lp.RegisterFilter(logpoller.Filter{
+		Name:      transmitterFilterName(address),
+		EventSigs: []gethcommon.Hash{transmitted.ID},
+		Addresses: []gethcommon.Address{address},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to register filter: %w", err)
+	}
+	if reportToEvmTxMeta == nil {
+		reportToEvmTxMeta = reportToEvmTxMetaNoop
+	}
+	return &contractTransmitterOCR3[RI]{
+		contractAddress:     address,
+		contractABI:         contractABI,
+		transmitter:         transmitter,
+		transmittedEventSig: transmitted.ID,
+		lp:                  lp,
+		lggr:                lggr,
+		reportToEvmTxMeta:   reportToEvmTxMeta,
+	}, nil
+}
+
+// FromAccount implements ocr3types.ContractTransmitter.
+func (c *contractTransmitterOCR3[RI]) FromAccount() (types.Account, error) {
+	return types.Account(c.transmitter.FromAddress().Hex()), nil
+}
+
+// Transmit implements ocr3types.ContractTransmitter.
+func (c *contractTransmitterOCR3[RI]) Transmit(ctx context.Context, configDigest types.ConfigDigest, seqNum uint64, rwi ocr3types.ReportWithInfo[RI], sigs []types.AttributedOnchainSignature) error {
+	var rs [][32]byte
+	var ss [][32]byte
+	var vs [32]byte
+	if len(sigs) > 32 {
+		return errors.New("too many signatures, maximum is 32")
+	}
+	for i, as := range sigs {
+		r, s, v, err := evmutil.SplitSignature(as.Signature)
+		if err != nil {
+			panic("eventTransmit(ev): error in SplitSignature")
+		}
+		rs = append(rs, r)
+		ss = append(ss, s)
+		vs[i] = v
+	}
+
+	// report ctx for OCR3 consists of the following
+	// reportContext[0]: ConfigDigest
+	// reportContext[1]: 24 byte padding, 8 byte sequence number
+	// reportContext[2]: unused
+	var rawReportCtx [3][32]byte
+	copy(rawReportCtx[0][:], configDigest[:])
+	binary.BigEndian.PutUint64(rawReportCtx[1][24:], seqNum)
+
+	txMeta, err := c.reportToEvmTxMeta(rwi.Report)
+	if err != nil {
+		c.lggr.Warnw("failed to generate tx metadata for report", "err", err)
+	}
+
+	c.lggr.Debugw("Transmitting report", "report", hex.EncodeToString(rwi.Report), "rawReportCtx", rawReportCtx, "contractAddress", c.contractAddress, "txMeta", txMeta)
+
+	payload, err := c.contractABI.Pack("transmit", rawReportCtx, []byte(rwi.Report), rs, ss, vs)
+	if err != nil {
+		return fmt.Errorf("%w: abi.Pack failed with args: (%+v, %s, %+v, %+v, %+v)", err, rawReportCtx, hex.EncodeToString(rwi.Report), rs, ss, vs)
+	}
+
+	c.lggr.Debugw("payload", "payload", hex.EncodeToString(payload))
+
+	return errors.Wrap(c.transmitter.CreateEthTransaction(ctx, c.contractAddress, payload, txMeta), "failed to send Eth transaction")
+}

--- a/core/services/ocr2/plugins/rebalancer/ocr3impls/contract_transmitter_test.go
+++ b/core/services/ocr2/plugins/rebalancer/ocr3impls/contract_transmitter_test.go
@@ -1,0 +1,236 @@
+package ocr3impls_test
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/libocr/commontypes"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
+	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/assets"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/client"
+	logpollermocks "github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller/mocks"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
+	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/shared/generated/no_op_ocr3"
+	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/chaintype"
+	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ocr2key"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/rebalancer/ocr3impls"
+)
+
+type testUniverse[RI any] struct {
+	simClient       *client.SimulatedBackendClient
+	backend         *backends.SimulatedBackend
+	deployer        *bind.TransactOpts
+	transmitters    []*bind.TransactOpts
+	signers         []common.Address
+	wrapper         *no_op_ocr3.NoOpOCR3
+	ocr3Transmitter ocr3types.ContractTransmitter[RI]
+	bundles         []ocr2key.KeyBundle
+	f               uint8
+}
+
+type bundlesAndSigners struct {
+	bundles []ocr2key.KeyBundle
+	signers []common.Address
+}
+
+func newTestUniverse[RI any](
+	t *testing.T,
+	bs *bundlesAndSigners) testUniverse[RI] {
+	t.Helper()
+
+	deployer := testutils.MustNewSimTransactor(t)
+
+	// create many transmitters but only need to fund one, rest are to get
+	// setOCR3Config to pass.
+	var transmitters []*bind.TransactOpts
+	for i := 0; i < 4; i++ {
+		transmitters = append(transmitters, testutils.MustNewSimTransactor(t))
+	}
+
+	backend := backends.NewSimulatedBackend(core.GenesisAlloc{
+		deployer.From: core.GenesisAccount{
+			Balance: assets.Ether(1000).ToInt(),
+		},
+		transmitters[0].From: core.GenesisAccount{
+			Balance: assets.Ether(1000).ToInt(),
+		},
+	}, 30e6)
+	addr, _, _, err := no_op_ocr3.DeployNoOpOCR3(deployer, backend)
+	require.NoError(t, err, "failed to deploy NoOpOCR3 contract")
+	backend.Commit()
+	wrapper, err := no_op_ocr3.NewNoOpOCR3(addr, backend)
+	require.NoError(t, err, "failed to create NoOpOCR3 wrapper")
+
+	// create the oracle identities for setConfig
+	// need to create at least 4 identities otherwise setConfig will fail
+	var (
+		bundles []ocr2key.KeyBundle
+		signers []common.Address
+	)
+	if bs != nil {
+		bundles = bs.bundles
+		signers = bs.signers
+	} else {
+		for i := 0; i < 4; i++ {
+			kb, err2 := ocr2key.New(chaintype.EVM)
+			require.NoError(t, err2, "failed to create key bundle")
+			signers = append(signers, common.HexToAddress(kb.OnChainPublicKey()))
+			bundles = append(bundles, kb)
+		}
+	}
+	f := uint8(1)
+	_, err = wrapper.SetOCR3Config(
+		deployer,
+		signers,
+		[]common.Address{transmitters[0].From, transmitters[1].From, transmitters[2].From, transmitters[3].From},
+		f,
+		[]byte{},
+		3,
+		[]byte{})
+	require.NoError(t, err, "failed to set config")
+	backend.Commit()
+
+	contractABI, err := no_op_ocr3.NoOpOCR3MetaData.GetAbi()
+	require.NoError(t, err, "failed to get abi")
+	tImpl := &transmitterImpl{
+		backend: backend,
+		from:    transmitters[0],
+		t:       t,
+	}
+	mockLogPoller := logpollermocks.NewLogPoller(t)
+	mockLogPoller.On("RegisterFilter", mock.Anything).Return(nil)
+	defer mockLogPoller.AssertExpectations(t)
+	ocr3Transmitter, err := ocr3impls.NewOCR3ContractTransmitter[RI](
+		addr,
+		*contractABI,
+		tImpl,
+		mockLogPoller,
+		logger.TestLogger(t),
+		nil, // reportToEvmTxMeta, unused
+	)
+	require.NoError(t, err, "failed to create OCR3ContractTransmitter")
+
+	return testUniverse[RI]{
+		backend:         backend,
+		deployer:        deployer,
+		transmitters:    transmitters,
+		signers:         signers,
+		wrapper:         wrapper,
+		bundles:         bundles,
+		ocr3Transmitter: ocr3Transmitter,
+		f:               f,
+		simClient:       client.NewSimulatedBackendClient(t, backend, testutils.SimulatedChainID),
+	}
+}
+
+func (uni testUniverse[RI]) SignReport(t *testing.T, configDigest ocrtypes.ConfigDigest, rwi ocr3types.ReportWithInfo[RI], seqNum uint64) []ocrtypes.AttributedOnchainSignature {
+	var attributedSigs []ocrtypes.AttributedOnchainSignature
+	for i := uint8(0); i < uni.f+1; i++ {
+		sig, err := uni.bundles[i].Sign(ocrtypes.ReportContext{
+			ReportTimestamp: ocrtypes.ReportTimestamp{
+				ConfigDigest: configDigest,
+				Epoch:        uint32(seqNum),
+			},
+		}, rwi.Report)
+		require.NoError(t, err, "failed to sign report")
+		attributedSigs = append(attributedSigs, ocrtypes.AttributedOnchainSignature{
+			Signature: sig,
+			Signer:    commontypes.OracleID(i),
+		})
+	}
+	return attributedSigs
+}
+
+func (uni testUniverse[RI]) TransmittedEvents(t *testing.T) []*no_op_ocr3.NoOpOCR3Transmitted {
+	iter, err := uni.wrapper.FilterTransmitted(nil)
+	require.NoError(t, err, "failed to create filter iterator")
+	var events []*no_op_ocr3.NoOpOCR3Transmitted
+	for iter.Next() {
+		event := iter.Event
+		events = append(events, event)
+	}
+	return events
+}
+
+func TestContractTransmitter(t *testing.T) {
+	t.Parallel()
+
+	uni := newTestUniverse[struct{}](t, nil)
+
+	c, err := uni.wrapper.LatestConfigDigestAndEpoch(nil)
+	require.NoError(t, err, "failed to get latest config digest and epoch")
+	configDigest := c.ConfigDigest
+
+	// create the attributed signatures
+	// only need f+1 which is 2 in this case
+	rwi := ocr3types.ReportWithInfo[struct{}]{
+		Report: []byte{},
+		Info:   struct{}{},
+	}
+	seqNum := uint64(1)
+	attributedSigs := uni.SignReport(t, configDigest, rwi, seqNum)
+
+	account, err := uni.ocr3Transmitter.FromAccount()
+	require.NoError(t, err, "failed to get from account")
+	require.Equal(t, account, ocrtypes.Account(uni.transmitters[0].From.Hex()), "unexpected from account")
+	err = uni.ocr3Transmitter.Transmit(context.Background(), configDigest, seqNum, rwi, attributedSigs)
+	require.NoError(t, err, "failed to transmit report")
+
+	// check for transmitted event
+	// TODO: for some reason this event isn't being emitted in the simulated backend
+	// events := uni.TransmittedEvents(t)
+	// require.Len(t, events, 1, "expected one transmitted event")
+	// event := events[0]
+	// require.Equal(t, configDigest, event.ConfigDigest, "unexpected config digest")
+	// require.Equal(t, seqNum, event.SequenceNumber, "unexpected sequence number")
+}
+
+type transmitterImpl struct {
+	backend *backends.SimulatedBackend
+	from    *bind.TransactOpts
+	t       *testing.T
+}
+
+func (t *transmitterImpl) FromAddress() common.Address {
+	return t.from.From
+}
+
+func (t *transmitterImpl) CreateEthTransaction(ctx context.Context, to common.Address, data []byte, txMeta *txmgr.TxMeta) error {
+	nonce, err := t.backend.PendingNonceAt(ctx, t.from.From)
+	require.NoError(t.t, err, "failed to get nonce")
+	gp, err := t.backend.SuggestGasPrice(ctx)
+	require.NoError(t.t, err, "failed to get gas price")
+	rawTx := types.NewTx(&types.LegacyTx{
+		Nonce:    nonce,
+		GasPrice: gp,
+		Gas:      500_000,
+		To:       &to,
+		Value:    big.NewInt(0),
+		Data:     data,
+	})
+	signedTx, err := t.from.Signer(t.from.From, rawTx)
+	require.NoError(t.t, err, "failed to sign tx")
+	err = t.backend.SendTransaction(ctx, signedTx)
+	require.NoError(t.t, err, "failed to send tx")
+	t.backend.Commit()
+	logs, err := t.backend.FilterLogs(ctx, ethereum.FilterQuery{})
+	require.NoError(t.t, err, "failed to filter logs")
+	for _, lg := range logs {
+		t.t.Log("topic:", lg.Topics[0], "transmitted topic:", no_op_ocr3.NoOpOCR3Transmitted{}.Topic(), "configset topic:", no_op_ocr3.NoOpOCR3ConfigSet{}.Topic())
+	}
+	return nil
+}

--- a/core/services/ocr2/plugins/rebalancer/ocr3impls/helpers.go
+++ b/core/services/ocr2/plugins/rebalancer/ocr3impls/helpers.go
@@ -1,0 +1,113 @@
+package ocr3impls
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
+	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/shared/generated/no_op_ocr3"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
+)
+
+func configTrackerFilterName(id relay.ID, addr common.Address) string {
+	return logpoller.FilterName("OCR3 MultichainConfigTracker", id.String(), addr.String())
+}
+
+func unpackLogData(d []byte) (*no_op_ocr3.NoOpOCR3ConfigSet, error) {
+	unpacked := new(no_op_ocr3.NoOpOCR3ConfigSet)
+	err := defaultABI.UnpackIntoInterface(unpacked, "ConfigSet", d)
+	if err != nil {
+		return nil, err
+	}
+	return unpacked, nil
+}
+
+func configFromLog(logData []byte) (ocrtypes.ContractConfig, error) {
+	unpacked, err := unpackLogData(logData)
+	if err != nil {
+		return ocrtypes.ContractConfig{}, err
+	}
+
+	var transmitAccounts []ocrtypes.Account
+	for _, addr := range unpacked.Transmitters {
+		transmitAccounts = append(transmitAccounts, ocrtypes.Account(addr.Hex()))
+	}
+	var signers []ocrtypes.OnchainPublicKey
+	for _, addr := range unpacked.Signers {
+		addr := addr
+		signers = append(signers, addr[:])
+	}
+
+	return ocrtypes.ContractConfig{
+		ConfigDigest:          unpacked.ConfigDigest,
+		ConfigCount:           unpacked.ConfigCount,
+		Signers:               signers,
+		Transmitters:          transmitAccounts,
+		F:                     unpacked.F,
+		OnchainConfig:         unpacked.OnchainConfig,
+		OffchainConfigVersion: unpacked.OffchainConfigVersion,
+		OffchainConfig:        unpacked.OffchainConfig,
+	}, nil
+}
+
+// TransmitterCombiner is a CombinerFn that combines all transmitter addresses
+// for the same signer on many different chains into a single string.
+func TransmitterCombiner(masterConfig ocrtypes.ContractConfig, followerConfigs []ocrtypes.ContractConfig) (ocrtypes.ContractConfig, error) {
+	toReturn := ocrtypes.ContractConfig{
+		ConfigDigest: masterConfig.ConfigDigest,
+		ConfigCount:  masterConfig.ConfigCount,
+		Signers:      masterConfig.Signers,
+		// Transmitters:          []ocrtypes.Account{}, // will be filled below
+		F:                     masterConfig.F,
+		OnchainConfig:         masterConfig.OnchainConfig,
+		OffchainConfigVersion: masterConfig.OffchainConfigVersion,
+		OffchainConfig:        masterConfig.OffchainConfig,
+	}
+
+	var combinedTransmitters []ocrtypes.Account
+	for i, signer := range masterConfig.Signers {
+		// the transmitter index is the same as the signer index for the same config object.
+		// this is enforced in the standard OCR3Base.setOCR3Config method.
+		transmitters := []string{string(masterConfig.Transmitters[i])}
+
+		for _, followerConfig := range followerConfigs {
+			// signer might be at a different index than master chain (but ideally shouldn't be)
+			// so we can't just use i here.
+			signerIdx := slices.IndexFunc(followerConfig.Signers, func(opk ocrtypes.OnchainPublicKey) bool {
+				return hexutil.Encode(opk) == hexutil.Encode(signer)
+			})
+			if signerIdx == -1 {
+				// signer not found, bad config
+				return ocrtypes.ContractConfig{}, fmt.Errorf("unable to find signer %x (oracle index %d) in follower config %+v", signer, i, followerConfig)
+			}
+			// the transmitter index is the same as the signer index for the same config object.
+			transmitters = append(transmitters, string(followerConfig.Transmitters[signerIdx]))
+		}
+		combinedTransmitter := JoinTransmitters(transmitters)
+		combinedTransmitters = append(combinedTransmitters, ocrtypes.Account(combinedTransmitter))
+	}
+
+	// sanity check
+	if len(combinedTransmitters) != len(masterConfig.Signers) {
+		return ocrtypes.ContractConfig{}, fmt.Errorf("unexpected length mismatch between combined transmitters (%d) and master config signers (%d)", len(combinedTransmitters), len(masterConfig.Signers))
+	}
+
+	toReturn.Transmitters = combinedTransmitters
+	return toReturn, nil
+}
+
+// JoinTransmitters is a helper that combines many transmitters into one
+// Note that this is pulled out so that it can be used in the CombinerFn
+// and the contract transmitter since the output of FromAccount() in the
+// ContractTransmitter and the ContractConfig.Transmitters output for a
+// particular signer must match in order for OCR3 to work.
+func JoinTransmitters(transmitters []string) string {
+	// sort first to ensure deterministic ordering
+	slices.Sort(transmitters)
+	return strings.Join(transmitters, ",")
+}

--- a/core/services/ocr2/plugins/rebalancer/ocr3impls/multichain_config_tracker.go
+++ b/core/services/ocr2/plugins/rebalancer/ocr3impls/multichain_config_tracker.go
@@ -1,0 +1,268 @@
+package ocr3impls
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+
+	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
+
+	evmclient "github.com/smartcontractkit/chainlink/v2/core/chains/evm/client"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
+	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/shared/generated/no_op_ocr3"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/rebalancer/liquiditymanager"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/rebalancer/models"
+	"github.com/smartcontractkit/chainlink/v2/core/services/pg"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
+)
+
+var (
+	// See https://github.com/smartcontractkit/ccip/compare/ccip-develop...CCIP-1438-op-stack-bridge-adapter-l-1#diff-2fe14bb9d1ecbc62f43cef26daff5d1f86275f16e1296fc9827b934a518d3f4cR20
+	ConfigSet common.Hash
+
+	defaultABI abi.ABI
+
+	_ ocrtypes.ContractConfigTracker = &multichainConfigTracker{}
+
+	defaultTimeout = 1 * time.Minute
+)
+
+func init() {
+	var err error
+	tabi, err := no_op_ocr3.NoOpOCR3MetaData.GetAbi()
+	if err != nil {
+		panic(err)
+	}
+	defaultABI = *tabi
+	ConfigSet = defaultABI.Events["ConfigSet"].ID
+}
+
+type CombinerFn func(masterConfig ocrtypes.ContractConfig, followerConfigs []ocrtypes.ContractConfig) (ocrtypes.ContractConfig, error)
+
+type multichainConfigTracker struct {
+	services.StateMachine
+
+	// masterChain is the chain that contains the "master" OCR3 configuration
+	// contract.
+	masterChain       relay.ID
+	lggr              logger.Logger
+	logPollers        map[relay.ID]logpoller.LogPoller
+	masterClient      evmclient.Client
+	contractAddresses map[relay.ID]common.Address
+	masterContract    no_op_ocr3.NoOpOCR3Interface
+	combiner          CombinerFn
+}
+
+func NewMultichainConfigTracker(
+	masterChain relay.ID,
+	lggr logger.Logger,
+	logPollers map[relay.ID]logpoller.LogPoller,
+	masterClient evmclient.Client,
+	masterContract common.Address,
+	lmFactory liquiditymanager.Factory,
+	combiner CombinerFn,
+) (*multichainConfigTracker, error) {
+	// Ensure master chain is in the log pollers
+	if _, ok := logPollers[masterChain]; !ok {
+		return nil, fmt.Errorf("master chain %s not in log pollers", masterChain)
+	}
+
+	// Ensure combiner is not nil
+	if combiner == nil {
+		return nil, fmt.Errorf("provide non-nil combiner")
+	}
+
+	// Ensure factory is not nil
+	if lmFactory == nil {
+		return nil, fmt.Errorf("provide non-nil liquidity manager factory")
+	}
+
+	// before we register filters we need to discover all the available liquidity managers
+	// on all the chains
+	masterChainID, err := strconv.ParseInt(masterChain.ChainID, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse network ID %s: %w", masterChain, err)
+	}
+	masterLM, err := lmFactory.NewLiquidityManager(
+		models.NetworkID(masterChainID),
+		models.Address(masterContract))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create master liquidity manager: %w", err)
+	}
+
+	// Discover all the liquidity managers
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	lms, _, err := masterLM.Discover(ctx, lmFactory)
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover liquidity managers: %w", err)
+	}
+	all := lms.GetAll()
+
+	// sanity check, there should be only one liquidity manager per-chain per-asset
+	if len(all) != len(logPollers) {
+		return nil, fmt.Errorf("expected %d liquidity managers but found %d", len(logPollers), len(all))
+	}
+
+	// Register filters on all log pollers
+	contracts := make(map[relay.ID]common.Address)
+	for id, lp := range logPollers {
+		nid, err2 := strconv.ParseInt(id.ChainID, 10, 64)
+		if err2 != nil {
+			return nil, fmt.Errorf("failed to parse network ID %s: %w", id, err2)
+		}
+		address, ok := all[models.NetworkID(nid)]
+		if !ok {
+			return nil, fmt.Errorf("no liquidity manager found for network ID %d", nid)
+		}
+		fName := configTrackerFilterName(id, common.Address(address))
+		err2 = lp.RegisterFilter(logpoller.Filter{
+			Name:      fName,
+			EventSigs: []common.Hash{ConfigSet},
+			Addresses: []common.Address{common.Address(address)},
+		})
+		if err2 != nil {
+			return nil, err2
+		}
+		contracts[id] = common.Address(address)
+	}
+
+	wrapper, err := no_op_ocr3.NewNoOpOCR3(masterContract, masterClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create wrapper: %w", err)
+	}
+
+	return &multichainConfigTracker{
+		lggr:              lggr,
+		logPollers:        logPollers,
+		masterChain:       masterChain,
+		combiner:          combiner,
+		masterClient:      masterClient,
+		contractAddresses: contracts,
+		masterContract:    wrapper,
+	}, nil
+}
+
+func (m *multichainConfigTracker) GetContractAddresses() map[relay.ID]common.Address {
+	return m.contractAddresses
+}
+
+func (m *multichainConfigTracker) Start() {}
+
+func (m *multichainConfigTracker) Close() error {
+	return nil
+}
+
+// Notify noop method
+func (m *multichainConfigTracker) Notify() <-chan struct{} {
+	return nil
+}
+
+// Replay abstracts the logpoller.LogPoller Replay() implementation
+func (m *multichainConfigTracker) Replay(ctx context.Context, id relay.ID, fromBlock int64) error {
+	if _, ok := m.logPollers[id]; !ok {
+		return fmt.Errorf("chain %s not in log pollers", id)
+	}
+	return m.logPollers[id].Replay(ctx, fromBlock)
+}
+
+// LatestBlockHeight implements types.ContractConfigTracker.
+// Returns the block height of the master chain.
+func (m *multichainConfigTracker) LatestBlockHeight(ctx context.Context) (blockHeight uint64, err error) {
+	latestBlock, err := m.logPollers[m.masterChain].LatestBlock(pg.WithParentCtx(ctx))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	return uint64(latestBlock.BlockNumber), nil
+}
+
+// LatestConfig implements types.ContractConfigTracker.
+// LatestConfig fetches the config from the master chain and then fetches the
+// remaining configurations from all the other chains.
+func (m *multichainConfigTracker) LatestConfig(ctx context.Context, changedInBlock uint64) (ocrtypes.ContractConfig, error) {
+	lgs, err := m.logPollers[m.masterChain].Logs(int64(changedInBlock), int64(changedInBlock), ConfigSet, m.contractAddresses[m.masterChain], pg.WithParentCtx(ctx))
+	if err != nil {
+		return ocrtypes.ContractConfig{}, err
+	}
+	if len(lgs) == 0 {
+		return ocrtypes.ContractConfig{}, fmt.Errorf("no logs found for config on contract %s (chain %s) at block %d",
+			m.contractAddresses[m.masterChain].Hex(), m.masterChain.String(), changedInBlock)
+	}
+	masterConfig, err := configFromLog(lgs[len(lgs)-1].Data)
+	if err != nil {
+		return ocrtypes.ContractConfig{}, err
+	}
+	m.lggr.Infow("LatestConfig from master chain", "latestConfig", masterConfig)
+
+	// check all other chains for their config
+	var followerConfigs []ocrtypes.ContractConfig
+	for id, lp := range m.logPollers {
+		if id == m.masterChain {
+			continue
+		}
+
+		lgs, err2 := lp.Logs(int64(changedInBlock), int64(changedInBlock), ConfigSet, m.contractAddresses[id], pg.WithParentCtx(ctx))
+		if err2 != nil {
+			return ocrtypes.ContractConfig{}, err2
+		}
+
+		if len(lgs) == 0 {
+			return ocrtypes.ContractConfig{}, fmt.Errorf("no logs found for config on contract %s (chain %s) at block %d",
+				m.contractAddresses[id].Hex(), id.String(), changedInBlock)
+		}
+
+		configSet, err2 := configFromLog(lgs[len(lgs)-1].Data)
+		if err2 != nil {
+			return ocrtypes.ContractConfig{}, err2
+		}
+		followerConfigs = append(followerConfigs, configSet)
+	}
+
+	// at this point we can combine the configs into a single one
+	combined, err := m.combiner(masterConfig, followerConfigs)
+	if err != nil {
+		return ocrtypes.ContractConfig{}, fmt.Errorf("error combining configs: %w", err)
+	}
+
+	return combined, nil
+}
+
+// LatestConfigDetails implements types.ContractConfigTracker.
+func (m *multichainConfigTracker) LatestConfigDetails(ctx context.Context) (changedInBlock uint64, configDigest ocrtypes.ConfigDigest, err error) {
+	latest, err := m.logPollers[m.masterChain].LatestLogByEventSigWithConfs(ConfigSet, m.contractAddresses[m.masterChain], 1, pg.WithParentCtx(ctx))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return m.callLatestConfigDetails(ctx)
+		}
+		return 0, ocrtypes.ConfigDigest{}, err
+	}
+	masterConfig, err := configFromLog(latest.Data)
+	if err != nil {
+		return 0, ocrtypes.ConfigDigest{}, fmt.Errorf("failed to unpack latest config details: %w", err)
+	}
+
+	return uint64(latest.BlockNumber), masterConfig.ConfigDigest, nil
+}
+
+func (m *multichainConfigTracker) callLatestConfigDetails(ctx context.Context) (changedInBlock uint64, configDigest ocrtypes.ConfigDigest, err error) {
+	lcd, err := m.masterContract.LatestConfigDetails(&bind.CallOpts{
+		Context: ctx,
+	})
+	if err != nil {
+		return 0, ocrtypes.ConfigDigest{}, fmt.Errorf("failed to get latest config details: %w", err)
+	}
+	return uint64(lcd.BlockNumber), lcd.ConfigDigest, nil
+}

--- a/core/services/ocr2/plugins/rebalancer/ocr3impls/multichain_config_tracker_test.go
+++ b/core/services/ocr2/plugins/rebalancer/ocr3impls/multichain_config_tracker_test.go
@@ -1,0 +1,273 @@
+package ocr3impls_test
+
+import (
+	"encoding/hex"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
+	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/shared/generated/no_op_ocr3"
+	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest/heavyweight"
+	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
+	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/rebalancer/liquiditygraph"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/rebalancer/liquiditymanager"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/rebalancer/models"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/rebalancer/ocr3impls"
+	mocks "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/rebalancer/rebalancermocks"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
+)
+
+func setupLogPoller[RI any](t *testing.T, db *sqlx.DB, bs *bundlesAndSigners) (logpoller.LogPoller, testUniverse[RI]) {
+	lggr := logger.TestLogger(t)
+
+	o := logpoller.NewORM(testutils.SimulatedChainID, db, lggr, pgtest.NewQConfig(false))
+
+	// create the universe which will deploy the OCR contract and set config
+	// we will replay on the log poller to get the appropriate ConfigSet log
+	uni := newTestUniverse[RI](t, bs)
+
+	lp := logpoller.NewLogPoller(o, uni.simClient, lggr, 1*time.Second, false, 100, 100, 100, 200)
+	return lp, uni
+}
+
+func TestConfigSet(t *testing.T) {
+	require.Equal(t, no_op_ocr3.NoOpOCR3ConfigSet{}.Topic().Hex(), ocr3impls.ConfigSet.Hex())
+}
+
+func TestMultichainConfigTracker_New(t *testing.T) {
+	t.Run("master chain not in log pollers", func(t *testing.T) {
+		db := pgtest.NewSqlxDB(t)
+		_, uni := setupLogPoller[struct{}](t, db, nil)
+
+		masterChain := relay.ID{
+			Network: relay.EVM,
+			ChainID: testutils.SimulatedChainID.String(),
+		}
+		mockLMFactory := mocks.NewFactory(t)
+		_, err := ocr3impls.NewMultichainConfigTracker(
+			masterChain,
+			logger.TestLogger(t),
+			map[relay.ID]logpoller.LogPoller{},
+			uni.simClient,
+			uni.wrapper.Address(),
+			mockLMFactory,
+			ocr3impls.TransmitterCombiner,
+		)
+		require.Error(t, err, "expected error creating multichain config tracker")
+	})
+
+	t.Run("combiner is nil", func(t *testing.T) {
+		db := pgtest.NewSqlxDB(t)
+		lp, uni := setupLogPoller[struct{}](t, db, nil)
+
+		masterChain := relay.ID{
+			Network: relay.EVM,
+			ChainID: testutils.SimulatedChainID.String(),
+		}
+		mockLMFactory := mocks.NewFactory(t)
+		_, err := ocr3impls.NewMultichainConfigTracker(
+			masterChain,
+			logger.TestLogger(t),
+			map[relay.ID]logpoller.LogPoller{masterChain: lp},
+			uni.simClient,
+			uni.wrapper.Address(),
+			mockLMFactory,
+			nil,
+		)
+		require.Error(t, err, "expected error creating multichain config tracker")
+	})
+
+	t.Run("factory is nil", func(t *testing.T) {
+		db := pgtest.NewSqlxDB(t)
+		lp, uni := setupLogPoller[struct{}](t, db, nil)
+
+		masterChain := relay.ID{
+			Network: relay.EVM,
+			ChainID: testutils.SimulatedChainID.String(),
+		}
+		_, err := ocr3impls.NewMultichainConfigTracker(
+			masterChain,
+			logger.TestLogger(t),
+			map[relay.ID]logpoller.LogPoller{masterChain: lp},
+			uni.simClient,
+			uni.wrapper.Address(),
+			nil,
+			ocr3impls.TransmitterCombiner,
+		)
+		require.Error(t, err, "expected error creating multichain config tracker")
+	})
+}
+
+func TestMultichainConfigTracker_SingleChain(t *testing.T) {
+	db := pgtest.NewSqlxDB(t)
+	lp, uni := setupLogPoller[struct{}](t, db, nil)
+	require.NoError(t, lp.Start(testutils.Context(t)))
+
+	masterChain := relay.ID{
+		Network: relay.EVM,
+		ChainID: testutils.SimulatedChainID.String(),
+	}
+	// for this test only one LM is "deployed"
+	// so the discovery will return a single LM which is the master LM
+	reg := liquiditymanager.NewRegistry()
+	reg.Add(models.NetworkID(mustStrToI64(t, masterChain.ChainID)), models.Address(uni.wrapper.Address()))
+	mockMasterLM := mocks.NewLiquidityManager(t)
+	mockMasterLM.On("Discover", mock.Anything, mock.Anything).Return(reg, liquiditygraph.NewGraph(), nil)
+	defer mockMasterLM.AssertExpectations(t)
+	mockLMFactory := mocks.NewFactory(t)
+	mockLMFactory.On("NewLiquidityManager", models.NetworkID(mustStrToI64(t, masterChain.ChainID)), models.Address(uni.wrapper.Address())).
+		Return(mockMasterLM, nil)
+	defer mockLMFactory.AssertExpectations(t)
+	tracker, err := ocr3impls.NewMultichainConfigTracker(
+		masterChain,
+		logger.TestLogger(t),
+		map[relay.ID]logpoller.LogPoller{masterChain: lp},
+		uni.simClient,
+		uni.wrapper.Address(),
+		mockLMFactory,
+		ocr3impls.TransmitterCombiner,
+	)
+	require.NoError(t, err, "failed to create multichain config tracker")
+
+	// Replay the log poller to get the ConfigSet log
+	err = tracker.Replay(testutils.Context(t), masterChain, 1)
+	require.NoError(t, err, "failed to replay log poller")
+
+	// fetch config digest from the tracker
+	changedInBlock, configDigest, err := tracker.LatestConfigDetails(testutils.Context(t))
+	require.NoError(t, err, "failed to get latest config details")
+	c, err := uni.wrapper.LatestConfigDigestAndEpoch(nil)
+	require.NoError(t, err, "failed to get latest config digest and epoch")
+	require.Equal(t, hex.EncodeToString(c.ConfigDigest[:]), configDigest.Hex(), "expected latest config digest to match")
+
+	// fetch config details from the tracker
+	config, err := tracker.LatestConfig(testutils.Context(t), changedInBlock)
+	require.NoError(t, err, "failed to get latest config")
+	require.Equal(t, uint64(1), config.ConfigCount, "expected config count to match")
+	require.Equal(t, configDigest, config.ConfigDigest, "expected config digest to match")
+	require.Equal(t, uint8(1), config.F, "expected f to match")
+	require.Equal(t, []byte{}, config.OnchainConfig, "expected onchain config to match")
+	require.Equal(t, []byte{}, config.OffchainConfig, "expected offchain config to match")
+	require.Equal(t, uint64(3), config.OffchainConfigVersion, "expected offchain config version to match")
+	expectedSigners := func() []ocrtypes.OnchainPublicKey {
+		var signers []ocrtypes.OnchainPublicKey
+		for _, b := range uni.bundles {
+			signers = append(signers, b.PublicKey())
+		}
+		return signers
+	}()
+	expectedTransmitters := func() []ocrtypes.Account {
+		var accounts []ocrtypes.Account
+		for _, tm := range uni.transmitters {
+			accounts = append(accounts, ocrtypes.Account(tm.From.Hex()))
+		}
+		return accounts
+	}()
+	require.Equal(t, expectedSigners, config.Signers, "expected signers to match")
+	require.Equal(t, expectedTransmitters, config.Transmitters, "expected transmitters to match")
+}
+
+func TestMultichainConfigTracker_Multichain(t *testing.T) {
+	// create heavyweight db's because the log pollers need to have separate
+	// databases to avoid conflicts.
+	_, db1 := heavyweight.FullTestDBV2(t, nil)
+	_, db2 := heavyweight.FullTestDBV2(t, nil)
+
+	lp1, uni1 := setupLogPoller[struct{}](t, db1, nil)
+	lp2, uni2 := setupLogPoller[struct{}](t, db2, &bundlesAndSigners{
+		bundles: uni1.bundles,
+		signers: uni1.signers,
+	})
+
+	// start the log pollers
+	require.NoError(t, lp1.Start(testutils.Context(t)))
+	require.NoError(t, lp2.Start(testutils.Context(t)))
+
+	// create the multichain config tracker
+	// the chain id's we're using in the mappings are different from the
+	// simulated chain id but that should be fine for this test.
+	masterChain := relay.ID{
+		Network: relay.EVM,
+		ChainID: testutils.NewRandomEVMChainID().String(),
+	}
+	secondChain := relay.ID{
+		Network: relay.EVM,
+		ChainID: testutils.NewRandomEVMChainID().String(),
+	}
+	reg := liquiditymanager.NewRegistry()
+	reg.Add(models.NetworkID(mustStrToI64(t, masterChain.ChainID)), models.Address(uni1.wrapper.Address()))
+	reg.Add(models.NetworkID(mustStrToI64(t, secondChain.ChainID)), models.Address(uni2.wrapper.Address()))
+	mockMasterLM := mocks.NewLiquidityManager(t)
+	mockMasterLM.On("Discover", mock.Anything, mock.Anything).Return(reg, liquiditygraph.NewGraph(), nil)
+	defer mockMasterLM.AssertExpectations(t)
+	mockLMFactory := mocks.NewFactory(t)
+	mockLMFactory.On("NewLiquidityManager", models.NetworkID(mustStrToI64(t, masterChain.ChainID)), models.Address(uni1.wrapper.Address())).
+		Return(mockMasterLM, nil)
+	defer mockLMFactory.AssertExpectations(t)
+	tracker, err := ocr3impls.NewMultichainConfigTracker(
+		masterChain,
+		logger.TestLogger(t),
+		map[relay.ID]logpoller.LogPoller{
+			masterChain: lp1,
+			secondChain: lp2,
+		},
+		uni1.simClient,
+		uni1.wrapper.Address(),
+		mockLMFactory,
+		ocr3impls.TransmitterCombiner,
+	)
+	require.NoError(t, err, "failed to create multichain config tracker")
+
+	// Replay the log pollers to get the ConfigSet log
+	// on each respective chain
+	require.NoError(t, tracker.Replay(testutils.Context(t), masterChain, 1), "failed to replay log poller on master chain")
+	require.NoError(t, tracker.Replay(testutils.Context(t), secondChain, 1), "failed to replay log poller on second chain")
+
+	// fetch config digest from the tracker
+	changedInBlock, configDigest, err := tracker.LatestConfigDetails(testutils.Context(t))
+	require.NoError(t, err, "failed to get latest config details")
+	c, err := uni1.wrapper.LatestConfigDigestAndEpoch(nil)
+	require.NoError(t, err, "failed to get latest config digest and epoch")
+	require.Equal(t, hex.EncodeToString(c.ConfigDigest[:]), configDigest.Hex(), "expected latest config digest to match")
+
+	// fetch config details from the tracker
+	config, err := tracker.LatestConfig(testutils.Context(t), changedInBlock)
+	require.NoError(t, err, "failed to get latest config")
+	require.Equal(t, uint64(1), config.ConfigCount, "expected config count to match")
+	require.Equal(t, configDigest, config.ConfigDigest, "expected config digest to match")
+	require.Equal(t, uint8(1), config.F, "expected f to match")
+	require.Equal(t, []byte{}, config.OnchainConfig, "expected onchain config to match")
+	require.Equal(t, []byte{}, config.OffchainConfig, "expected offchain config to match")
+	require.Equal(t, uint64(3), config.OffchainConfigVersion, "expected offchain config version to match")
+	expectedSigners := func() []ocrtypes.OnchainPublicKey {
+		var signers []ocrtypes.OnchainPublicKey
+		for _, b := range uni1.bundles {
+			signers = append(signers, b.PublicKey())
+		}
+		return signers
+	}()
+	require.Equal(t, expectedSigners, config.Signers, "expected signers to match")
+	expectedTransmitters := func() []ocrtypes.Account {
+		var accounts []ocrtypes.Account
+		for i := range uni1.transmitters {
+			t1, t2 := uni1.transmitters[i].From.Hex(), uni2.transmitters[i].From.Hex()
+			accounts = append(accounts, ocrtypes.Account(ocr3impls.JoinTransmitters([]string{t1, t2})))
+		}
+		return accounts
+	}()
+	require.Equal(t, expectedTransmitters, config.Transmitters, "expected transmitters to match")
+}
+
+func mustStrToI64(t *testing.T, s string) int64 {
+	i, err := strconv.ParseInt(s, 10, 64)
+	require.NoError(t, err)
+	return i
+}

--- a/core/services/ocr2/plugins/rebalancer/ocr3impls/multichain_transmitter.go
+++ b/core/services/ocr2/plugins/rebalancer/ocr3impls/multichain_transmitter.go
@@ -1,0 +1,60 @@
+package ocr3impls
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
+)
+
+type MultichainMeta interface {
+	GetDestinationChain() relay.ID
+}
+
+// multichainTransmitterOCR3 is a transmitter that can transmit to multiple chains.
+// It uses the information in the MultichainMeta to determine which chain to transmit to.
+// Note that this would only work with the appropriate multi-chain config tracker implementation.
+type multichainTransmitterOCR3[RI MultichainMeta] struct {
+	transmitters map[relay.ID]ocr3types.ContractTransmitter[RI]
+	lp           logpoller.LogPoller
+	lggr         logger.Logger
+}
+
+func NewMultichainTransmitterOCR3[RI MultichainMeta](
+	transmitters map[relay.ID]ocr3types.ContractTransmitter[RI],
+	lp logpoller.LogPoller,
+	lggr logger.Logger,
+) (*multichainTransmitterOCR3[RI], error) {
+	return &multichainTransmitterOCR3[RI]{
+		transmitters: transmitters,
+		lp:           lp,
+		lggr:         lggr,
+	}, nil
+}
+
+// FromAccount implements ocr3types.ContractTransmitter.
+func (m *multichainTransmitterOCR3[RI]) FromAccount() (types.Account, error) {
+	var accounts []string
+	for _, t := range m.transmitters {
+		account, err := t.FromAccount()
+		if err != nil {
+			return "", err
+		}
+		accounts = append(accounts, string(account))
+	}
+	return types.Account(JoinTransmitters(accounts)), nil
+}
+
+// Transmit implements ocr3types.ContractTransmitter.
+func (m *multichainTransmitterOCR3[RI]) Transmit(ctx context.Context, configDigest types.ConfigDigest, seqNr uint64, rwi ocr3types.ReportWithInfo[RI], sigs []types.AttributedOnchainSignature) error {
+	transmitter, ok := m.transmitters[rwi.Info.GetDestinationChain()]
+	if !ok {
+		return fmt.Errorf("no transmitter for chain %s", rwi.Info.GetDestinationChain())
+	}
+	return transmitter.Transmit(ctx, configDigest, seqNr, rwi, sigs)
+}

--- a/core/services/ocr2/plugins/rebalancer/ocr3impls/multichain_transmitter_test.go
+++ b/core/services/ocr2/plugins/rebalancer/ocr3impls/multichain_transmitter_test.go
@@ -1,0 +1,91 @@
+package ocr3impls_test
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/rebalancer/ocr3impls"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
+	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMultichainTransmitter(t *testing.T) {
+	t.Parallel()
+	// create many separate transmitters and separate chains
+	numChains := 4
+	unis := make(map[int]testUniverse[multichainMeta])
+	for i := 0; i < numChains; i++ {
+		unis[i] = newTestUniverse[multichainMeta](t, nil)
+	}
+
+	mct, err := ocr3impls.NewMultichainTransmitterOCR3[multichainMeta](
+		map[relay.ID]ocr3types.ContractTransmitter[multichainMeta]{
+			relay.NewID(relay.EVM, "0"): unis[0].ocr3Transmitter,
+			relay.NewID(relay.EVM, "1"): unis[1].ocr3Transmitter,
+			relay.NewID(relay.EVM, "2"): unis[2].ocr3Transmitter,
+			relay.NewID(relay.EVM, "3"): unis[3].ocr3Transmitter,
+		},
+		nil, // log poller, unused for now
+		logger.TestLogger(t),
+	)
+	require.NoError(t, err)
+
+	expectedTransmitters := []string{
+		unis[0].transmitters[0].From.String(),
+		unis[1].transmitters[0].From.String(),
+		unis[2].transmitters[0].From.String(),
+		unis[3].transmitters[0].From.String(),
+	}
+	slices.Sort(expectedTransmitters)
+	expectedFromAccount := strings.Join(expectedTransmitters, ",")
+	fromAccount, err := mct.FromAccount()
+	require.NoError(t, err)
+	require.Equal(t, expectedFromAccount, string(fromAccount))
+
+	var configDigests []ocrtypes.ConfigDigest
+	for _, uni := range unis {
+		c, err2 := uni.wrapper.LatestConfigDigestAndEpoch(nil)
+		require.NoError(t, err2)
+		configDigests = append(configDigests, c.ConfigDigest)
+	}
+
+	// generate a report for each chain and sign it
+	// note that in this test each chain has a different set of signers
+	// this is okay because it's just a test
+	// in actuality the same signers will be used across all chains
+	var reports []ocr3types.ReportWithInfo[multichainMeta]
+	for i := 0; i < numChains; i++ {
+		report := ocr3types.ReportWithInfo[multichainMeta]{
+			Info:   multichainMeta{destChainIndex: i},
+			Report: []byte{},
+		}
+		reports = append(reports, report)
+	}
+	seqNum := uint64(1)
+	for i := range reports {
+		attributedSigs := unis[i].SignReport(t, configDigests[i], reports[i], seqNum)
+		err = mct.Transmit(testutils.Context(t), configDigests[i], seqNum, reports[i], attributedSigs)
+		require.NoError(t, err)
+		// TODO: for some reason this event isn't being emitted in the simulated backend
+		// events := unis[i].TransmittedEvents(t)
+		// require.Len(t, events, 1)
+		// require.Equal(t, configDigests[i], events[0].ConfigDigest, "config digest mismatch")
+		// require.Equal(t, seqNum, events[0].SequenceNumber, "sequence number mismatch")
+		// increment sequence number so that each chain gets a unique one for this test
+		seqNum++
+	}
+}
+
+type multichainMeta struct {
+	destChainIndex int
+}
+
+func (m multichainMeta) GetDestinationChain() relay.ID {
+	return relay.NewID(relay.EVM, fmt.Sprintf("%d", m.destChainIndex))
+}

--- a/core/services/synchronization/common.go
+++ b/core/services/synchronization/common.go
@@ -24,6 +24,7 @@ const (
 	OCR2VRF           TelemetryType = "ocr2-vrf"
 	AutomationCustom  TelemetryType = "automation-custom"
 	OCR3Automation    TelemetryType = "ocr3-automation"
+	OCR3Rebalancer    TelemetryType = "ocr3-rebalancer"
 )
 
 type TelemPayload struct {


### PR DESCRIPTION
## Motivation

The Lock/Unlock plugin will need an OCR3 transmitter that can transmit to many chains based upon the info being provided in the `ReportWithInfo` struct.

## Solution

In order to achieve this, we need to implement two things:

* A multi-chain contract config tracker implementation (OCR3 interface: https://github.com/smartcontractkit/libocr/blob/c5102a9c0fb776e79cc72d313a61543dc5d48ee2/offchainreporting2plus/types/types.go#L337) that coalesces all the different transmitter addresses on the many different chains into a single `ocrtypes.Account` object.
* A multi-chain contract transmitter implementation (OCR3 interface: https://github.com/smartcontractkit/libocr/blob/c5102a9c0fb776e79cc72d313a61543dc5d48ee2/offchainreporting2plus/types/types.go#L303) whose `FromAccount()` returns one big Account value formatted the same way as the one returned by the ContractConfigTracker in the previous bullet.

With this in mind, this PR:

* Creates a regular OCR3 contract transmitter that is based off of the OCR2 contract transmitter
* Creates a multi-chain contract config tracker which tracks config changes on a single ("master") chain and combines config updates from all chains into a single config using a parametrizable `CombinerFn`
	* A `CombinerFn` is implemented which groups all transmitters for a single signer into a single `types.Account` object. See `TransmitterCombiner` in the PR changes.
* Adds the OCR3Abstract, OCR3Base and NoOpOCR3 contracts to generate gethwrappers and use the associated ABI and ConfigSet event objects in the config tracker.
	* In theory, all OCR3 contracts should inherit OCR3Base and have the same exact ConfigSet event signature.
* Creates a multichain OCR3 contract transmitter that wraps many different OCR3 transmitters and implements `FromAccount` matching the `TransmitterCombiner` `CombinerFn` implementation. 
* In order to test the above, adds the base OCR3 contracts to the `shared` subdirectory of the contracts directory and adds a `NoOpOCR3.sol` implementation that does nothing in `_report` just to test the end-to-end of the transmitter.