### PR TITLE
feat(ccipdata): introduce commit store reader v1.3 implementation

### DIFF
--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/commit_store_reader.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/commit_store_reader.go
@@ -49,13 +49,11 @@ func (d CommitOnchainConfig) Validate() error {
 }
 
 type CommitOffchainConfig struct {
-	SourceFinalityDepth    uint32
 	GasPriceDeviationPPB   uint32
 	GasPriceHeartBeat      time.Duration
 	TokenPriceDeviationPPB uint32
 	TokenPriceHeartBeat    time.Duration
 	InflightCacheExpiry    time.Duration
-	DestFinalityDepth      uint32
 }
 
 type CommitStoreStaticConfig struct {
@@ -66,22 +64,18 @@ type CommitStoreStaticConfig struct {
 }
 
 func NewCommitOffchainConfig(
-	sourceFinalityDepth uint32,
 	gasPriceDeviationPPB uint32,
 	gasPriceHeartBeat time.Duration,
 	tokenPriceDeviationPPB uint32,
 	tokenPriceHeartBeat time.Duration,
 	inflightCacheExpiry time.Duration,
-	destFinalityDepth uint32,
 ) CommitOffchainConfig {
 	return CommitOffchainConfig{
-		SourceFinalityDepth:    sourceFinalityDepth,
 		GasPriceDeviationPPB:   gasPriceDeviationPPB,
 		GasPriceHeartBeat:      gasPriceHeartBeat,
 		TokenPriceDeviationPPB: tokenPriceDeviationPPB,
 		TokenPriceHeartBeat:    tokenPriceHeartBeat,
 		InflightCacheExpiry:    inflightCacheExpiry,
-		DestFinalityDepth:      destFinalityDepth,
 	}
 }
 

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/factory/commit_store.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/factory/commit_store.go
@@ -17,6 +17,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipdata"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_0_0"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_2_0"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_3_0"
 )
 
 func NewCommitStoreReader(lggr logger.Logger, address common.Address, ec client.Client, lp logpoller.LogPoller, estimator gas.EvmFeeEstimator) (ccipdata.CommitStoreReader, error) {
@@ -31,8 +32,10 @@ func NewCommitStoreReader(lggr logger.Logger, address common.Address, ec client.
 	case ccipdata.V1_0_0, ccipdata.V1_1_0:
 		// Versions are identical
 		return v1_0_0.NewCommitStore(lggr, address, ec, lp, estimator)
-	case ccipdata.V1_2_0, ccipdata.V1_3_0:
+	case ccipdata.V1_2_0:
 		return v1_2_0.NewCommitStore(lggr, address, ec, lp, estimator)
+	case ccipdata.V1_3_0:
+		return v1_3_0.NewCommitStore(lggr, address, ec, lp, estimator)
 	default:
 		return nil, errors.Errorf("unsupported commit store version %v", version.String())
 	}

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_0_0/commit_store.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_0_0/commit_store.go
@@ -222,13 +222,12 @@ func (c *CommitStore) ChangeConfig(onchainConfig []byte, offchainConfig []byte) 
 		big.NewInt(int64(offchainConfigV1.MaxGasPrice)),
 		int64(offchainConfigV1.FeeUpdateDeviationPPB))
 	c.offchainConfig = ccipdata.NewCommitOffchainConfig(
-		offchainConfigV1.SourceFinalityDepth,
 		offchainConfigV1.FeeUpdateDeviationPPB,
 		offchainConfigV1.FeeUpdateHeartBeat.Duration(),
 		offchainConfigV1.FeeUpdateDeviationPPB,
 		offchainConfigV1.FeeUpdateHeartBeat.Duration(),
 		offchainConfigV1.InflightCacheExpiry.Duration(),
-		offchainConfigV1.DestFinalityDepth)
+	)
 	c.configMu.Unlock()
 	c.lggr.Infow("ChangeConfig",
 		"offchainConfig", offchainConfigV1,

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_3_0/commit_store.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_3_0/commit_store.go
@@ -1,0 +1,68 @@
+package v1_3_0
+
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/client"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/gas"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipdata"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_2_0"
+	"github.com/smartcontractkit/chainlink/v2/core/store/models"
+)
+
+var _ ccipdata.CommitStoreReader = &CommitStore{}
+
+type CommitStore struct {
+	*v1_2_0.CommitStore
+}
+
+// Do not change the JSON format of this struct without consulting with
+// the RDD people first.
+type CommitOffchainConfig struct {
+	GasPriceHeartBeat        models.Duration
+	DAGasPriceDeviationPPB   uint32
+	ExecGasPriceDeviationPPB uint32
+	TokenPriceHeartBeat      models.Duration
+	TokenPriceDeviationPPB   uint32
+	SourceMaxGasPrice        uint64
+	InflightCacheExpiry      models.Duration
+}
+
+func (c CommitOffchainConfig) Validate() error {
+	if c.GasPriceHeartBeat.Duration() == 0 {
+		return errors.New("must set GasPriceHeartBeat")
+	}
+	if c.ExecGasPriceDeviationPPB == 0 {
+		return errors.New("must set ExecGasPriceDeviationPPB")
+	}
+	if c.TokenPriceHeartBeat.Duration() == 0 {
+		return errors.New("must set TokenPriceHeartBeat")
+	}
+	if c.TokenPriceDeviationPPB == 0 {
+		return errors.New("must set TokenPriceDeviationPPB")
+	}
+	if c.SourceMaxGasPrice == 0 {
+		return errors.New("must set SourceMaxGasPrice")
+	}
+	if c.InflightCacheExpiry.Duration() == 0 {
+		return errors.New("must set InflightCacheExpiry")
+	}
+	// DAGasPriceDeviationPPB is not validated because it can be 0 on non-rollups
+
+	return nil
+}
+
+func NewCommitStore(lggr logger.Logger, addr common.Address, ec client.Client, lp logpoller.LogPoller, estimator gas.EvmFeeEstimator) (*CommitStore, error) {
+	commitStoreV120, err := v1_2_0.NewCommitStore(lggr, addr, ec, lp, estimator)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CommitStore{
+		CommitStore: commitStoreV120,
+	}, nil
+}

--- a/core/services/ocr2/plugins/ccip/testhelpers/config.go
+++ b/core/services/ocr2/plugins/ccip/testhelpers/config.go
@@ -31,17 +31,17 @@ func (c *CCIPContracts) CreateDefaultCommitOffchainConfig(t *testing.T) []byte {
 }
 
 func (c *CCIPContracts) createCommitOffchainConfig(t *testing.T, feeUpdateHearBeat time.Duration, inflightCacheExpiry time.Duration) []byte {
-	config, err := ccipconfig.EncodeOffchainConfig(v1_2_0.CommitOffchainConfig{
-		SourceFinalityDepth:      1,
-		DestFinalityDepth:        1,
-		GasPriceHeartBeat:        models.MustMakeDuration(feeUpdateHearBeat),
-		DAGasPriceDeviationPPB:   1,
-		ExecGasPriceDeviationPPB: 1,
-		TokenPriceHeartBeat:      models.MustMakeDuration(feeUpdateHearBeat),
-		TokenPriceDeviationPPB:   1,
-		MaxGasPrice:              200e9,
-		InflightCacheExpiry:      models.MustMakeDuration(inflightCacheExpiry),
-	})
+	config, err := NewCommitOffchainConfig(
+		/*SourceFinalityDepth:*/ 1,
+		/*DestFinalityDepth:*/ 1,
+		/*GasPriceHeartBeat:*/ models.MustMakeDuration(feeUpdateHearBeat),
+		/*DAGasPriceDeviationPPB:*/ 1,
+		/*ExecGasPriceDeviationPPB:*/ 1,
+		/*TokenPriceHeartBeat:*/ models.MustMakeDuration(feeUpdateHearBeat),
+		/*TokenPriceDeviationPPB:*/ 1,
+		/*MaxGasPrice:*/ 200e9,
+		/*InflightCacheExpiry:*/ models.MustMakeDuration(inflightCacheExpiry),
+	).Encode()
 	require.NoError(t, err)
 	return config
 }


### PR DESCRIPTION
## Motivation

The CCIP team decided to change the commit store off-chain config format:
- Rename `MaxGasPrice` in the offramp config to `SourceMaxGasPrice` to avoid confusion with the offramp configuration (which will become `DestMaxGasPrice`).
- Remove unused `SourceFinalityDepth` and `DestFinalityDepth` fields.

## Solution

This change introduces the v1.3 implementation of `CommitStoreReader`. It's the same as the v1.2 implementation except for the off-chain config format.