### PR TITLE
Log observations in report

### DIFF
--- a/core/services/ocr2/plugins/ccip/observations.go
+++ b/core/services/ocr2/plugins/ccip/observations.go
@@ -2,8 +2,9 @@ package ccip
 
 import (
 	"encoding/json"
-	"github.com/smartcontractkit/libocr/commontypes"
 	"math/big"
+
+	"github.com/smartcontractkit/libocr/commontypes"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"


### PR DESCRIPTION
## Motivation
Improve debugging report build failures

## Solution
By logging received observations in Report we can see what other nops are observing with only a single telemetry node. Can probably be replaced with real OCR telemetry when thats available.