### PR TITLE
Adding more details to the observations parsing

### DIFF
--- a/core/services/ocr2/plugins/ccip/observations.go
+++ b/core/services/ocr2/plugins/ccip/observations.go
@@ -89,6 +89,13 @@ func GetParsableObservations[O CommitObservation | ExecutionObservation](l logge
 		parseableObservations = append(parseableObservations, ob)
 		observers = append(observers, ao.Observer)
 	}
-	l.Infow("Parsed observations", "observers", observers, "observations", parseableObservations)
+	l.Infow(
+		"Parsed observations",
+		"observers", observers,
+		"observersLength", len(observers),
+		"observations", parseableObservations,
+		"observationsLength", len(parseableObservations),
+		"rawObservationLength", len(observations),
+	)
 	return parseableObservations
 }


### PR DESCRIPTION
## Motivation

Added length of the observers and parsed observation to make querying simpler. Tracking also the length of observations before parsing for better visibility of the set that was transmitted via OCR