### PR TITLE
Fix usdPerToken comment

### DIFF
--- a/contracts/src/v0.8/ccip/libraries/Internal.sol
+++ b/contracts/src/v0.8/ccip/libraries/Internal.sol
@@ -26,7 +26,7 @@ library Internal {
   /// @dev RMN depends on this struct, if changing, please notify the RMN maintainers.
   struct TokenPriceUpdate {
     address sourceToken; // Source token
-    uint224 usdPerToken; // 1e18 USD per smallest unit of token
+    uint224 usdPerToken; // 1e18 USD per 1e18 of the smallest token denomination.
   }
 
   /// @notice Gas price for a given chain in USD, its value may contain tightly packed fields.

--- a/core/chains/evm/config/toml/defaults/fallback.toml
+++ b/core/chains/evm/config/toml/defaults/fallback.toml
@@ -37,7 +37,7 @@ BumpMin = '5 gwei'
 BumpPercent = 20
 BumpThreshold = 3
 EIP1559DynamicFees = false
-FeeCapDefaFeeCapDefaultult = '100 gwei'
+FeeCapDefault = '100 gwei'
 TipCapDefault = '1'
 TipCapMin = '1'
 

--- a/core/chains/evm/config/toml/defaults/fallback.toml
+++ b/core/chains/evm/config/toml/defaults/fallback.toml
@@ -37,7 +37,7 @@ BumpMin = '5 gwei'
 BumpPercent = 20
 BumpThreshold = 3
 EIP1559DynamicFees = false
-FeeCapDefault = '100 gwei'
+FeeCapDefaFeeCapDefaultult = '100 gwei'
 TipCapDefault = '1'
 TipCapMin = '1'
 


### PR DESCRIPTION
## Motivation
update `usdPerToken` comment to `1e18 USD per 1e18 of the smallest token denomination.`

reason we are not doing 1e18 USD per smallest token denon is, smallest token denon can be less than 1e^-18 USD, e.g. some meme coins