### PR TITLE
Make deviation PPB calc based on smaller value

### DIFF
--- a/core/services/ocr2/plugins/ccip/ccipcommit/ocr2_test.go
+++ b/core/services/ocr2/plugins/ccip/ccipcommit/ocr2_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/config"
+
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/gas/mocks"
 	mocks2 "github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/utils"
@@ -726,8 +727,8 @@ func TestCommitReportingPlugin_calculatePriceUpdates(t *testing.T) {
 		{
 			name: "gas price update skipped because the latest is similar and was updated recently",
 			commitObservations: []ccip.CommitObservation{
-				{SourceGasPriceUSD: val1e18(10)},
 				{SourceGasPriceUSD: val1e18(11)},
+				{SourceGasPriceUSD: val1e18(12)},
 			},
 			gasPriceHeartBeat:        *config.MustNewDuration(time.Hour),
 			daGasPriceDeviationPPB:   20e7,
@@ -736,7 +737,7 @@ func TestCommitReportingPlugin_calculatePriceUpdates(t *testing.T) {
 			tokenPriceDeviationPPB:   20e7,
 			latestGasPrice: update{
 				timestamp: time.Now().Add(-30 * time.Minute), // recent
-				value:     val1e18(9),                        // latest value close to the update
+				value:     val1e18(10),                       // latest value close to the update
 			},
 			f:             1,
 			expGasUpdates: nil,
@@ -808,8 +809,8 @@ func TestCommitReportingPlugin_calculatePriceUpdates(t *testing.T) {
 		{
 			name: "token price update skipped because it is close to the latest",
 			commitObservations: []ccip.CommitObservation{
-				{TokenPricesUSD: map[common.Address]*big.Int{feeToken1: val1e18(10)}, SourceGasPriceUSD: val1e18(0)},
 				{TokenPricesUSD: map[common.Address]*big.Int{feeToken1: val1e18(11)}, SourceGasPriceUSD: val1e18(0)},
+				{TokenPricesUSD: map[common.Address]*big.Int{feeToken1: val1e18(12)}, SourceGasPriceUSD: val1e18(0)},
 			},
 			f:                        1,
 			gasPriceHeartBeat:        *config.MustNewDuration(time.Hour),
@@ -820,7 +821,7 @@ func TestCommitReportingPlugin_calculatePriceUpdates(t *testing.T) {
 			latestTokenPrices: map[common.Address]update{
 				feeToken1: {
 					timestamp: time.Now().Add(-30 * time.Minute),
-					value:     val1e18(9),
+					value:     val1e18(10),
 				},
 			},
 			// We expect a gas update because no latest

--- a/core/services/ocr2/plugins/ccip/internal/ccipcalc/calc.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipcalc/calc.go
@@ -45,16 +45,22 @@ func BigIntSortedMiddle(vals []*big.Int) *big.Int {
 	return valsCopy[len(valsCopy)/2]
 }
 
-// Deviates checks if x1 deviates x2 based on the provided ppb (parts per billion)
-// deviation_parts_per_billion = ((x2 - x1) / x1) * 1e9
+// Deviates checks if x1 and x2 deviates based on the provided ppb (parts per billion)
+// ppb is calculated based on the smaller value of the two
+// e.g, if x1 > x2, deviation_parts_per_billion = ((x1 - x2) / x2) * 1e9
 func Deviates(x1, x2 *big.Int, ppb int64) bool {
-	// if x1 == 0, deviates if x2 != x1, to avoid the relative division by 0 error
-	if x1.BitLen() == 0 {
+	// if x1 == 0 or x2 == 0, deviates if x2 != x1, to avoid the relative division by 0 error
+	if x1.BitLen() == 0 || x2.BitLen() == 0 {
 		return x1.Cmp(x2) != 0
 	}
-	diff := big.NewInt(0).Sub(x1, x2)       // diff = x1-x2
-	diff.Mul(diff, big.NewInt(1e9))         // diff = diff * 1e9
-	diff.Div(diff, x1)                      // diff = diff / x1
+	diff := big.NewInt(0).Sub(x1, x2) // diff = x1-x2
+	diff.Mul(diff, big.NewInt(1e9))   // diff = diff * 1e9
+	// dividing by the smaller value gives consistent ppb regardless of input order, and supports >100% deviation.
+	if x1.Cmp(x2) > 0 {
+		diff.Div(diff, x2)
+	} else {
+		diff.Div(diff, x1)
+	}
 	return diff.CmpAbs(big.NewInt(ppb)) > 0 // abs(diff) > ppb
 }
 

--- a/core/services/ocr2/plugins/ccip/internal/ccipcalc/calc_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipcalc/calc_test.go
@@ -157,23 +157,58 @@ func TestDeviates(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "x2 is zero and x1 neq x2",
+			args: args{x1: big.NewInt(1), x2: big.NewInt(0), ppb: 999},
+			want: true,
+		},
+		{
 			name: "x1 and x2 are both zero",
 			args: args{x1: big.NewInt(0), x2: big.NewInt(0), ppb: 999},
 			want: false,
 		},
 		{
-			name: "does not deviate",
-			args: args{x1: big.NewInt(10), x2: big.NewInt(5), ppb: 500e6},
-			want: false,
-		},
-		{
-			name: "near deviation limit but deviates",
-			args: args{x1: big.NewInt(10), x2: big.NewInt(5), ppb: 500e6 - 1},
+			name: "deviates when ppb is 0",
+			args: args{x1: big.NewInt(0), x2: big.NewInt(1), ppb: 0},
 			want: true,
 		},
 		{
+			name: "does not deviate when x1 eq x2",
+			args: args{x1: big.NewInt(5), x2: big.NewInt(5), ppb: 1},
+			want: false,
+		},
+		{
+			name: "does not deviate with high ppb when x2 is greater",
+			args: args{x1: big.NewInt(5), x2: big.NewInt(10), ppb: 2e9},
+			want: false,
+		},
+		{
+			name: "does not deviate with high ppb when x1 is greater",
+			args: args{x1: big.NewInt(10), x2: big.NewInt(5), ppb: 2e9},
+			want: false,
+		},
+		{
+			name: "deviates with low ppb when x2 is greater",
+			args: args{x1: big.NewInt(5), x2: big.NewInt(10), ppb: 9e8},
+			want: true,
+		},
+		{
+			name: "deviates with low ppb when x1 is greater",
+			args: args{x1: big.NewInt(10), x2: big.NewInt(5), ppb: 9e8},
+			want: true,
+		},
+		{
+			name: "near deviation limit but deviates",
+			args: args{x1: big.NewInt(10), x2: big.NewInt(5), ppb: 1e9 - 1},
+			want: true,
+		},
+		{
+			name: "at deviation limit but does not deviate",
+			args: args{x1: big.NewInt(10), x2: big.NewInt(5), ppb: 1e9},
+			want: false,
+		},
+		{
 			name: "near deviation limit but does not deviate",
-			args: args{x1: big.NewInt(10), x2: big.NewInt(5), ppb: 500e6 + 1},
+			args: args{x1: big.NewInt(10), x2: big.NewInt(5), ppb: 1e9 + 1},
 			want: false,
 		},
 	}


### PR DESCRIPTION
## Motivation
We typically check deviation by `deviates(newPrice, lastPrice)`, `deviates` function used the 1st param, i.e. newPrice, as the denominator, making deviation >100% impossible if price is increasing.
E.g., newPrice = 1000, lastPrice is 1, then deviation is calculated as (1000-1)/1000 = 99.9%. This means if we have deviations threshold set to > 100%, like we have on mainnet, then it will never deviate if price is increasing.

## Solution
make deviation calculation always be based on the smaller value, so that deviation result is consistent whether price is increasing or decreasing.

## Impact
If price is increasing, fixes the issue when threshold is >100%, and makes price update more frequent
If price is decreasing, no behavior change