### PR TITLE
move tx gas limit to hard coded config

### DIFF
--- a/core/services/ocr2/plugins/ccip/ccipexec/factory.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/factory.go
@@ -59,7 +59,7 @@ func (rf *ExecutionReportingPluginFactory) UpdateDynamicReaders(newPriceRegAddr 
 }
 
 func (rf *ExecutionReportingPluginFactory) NewReportingPlugin(config types.ReportingPluginConfig) (types.ReportingPlugin, types.ReportingPluginInfo, error) {
-	destPriceRegistry, destWrappedNative, err := rf.config.offRampReader.ChangeConfig(config.OnchainConfig, config.OffchainConfig)
+	destPriceRegistry, destWrappedNative, err := rf.config.offRampReader.ChangeConfig(config.OnchainConfig, config.OffchainConfig, rf.config.destChainSelector)
 	if err != nil {
 		return nil, types.ReportingPluginInfo{}, err
 	}

--- a/core/services/ocr2/plugins/ccip/config/onchain_config.go
+++ b/core/services/ocr2/plugins/ccip/config/onchain_config.go
@@ -1,1 +1,0 @@
-package config

--- a/core/services/ocr2/plugins/ccip/evm/gas.go
+++ b/core/services/ocr2/plugins/ccip/evm/gas.go
@@ -1,0 +1,32 @@
+package evm
+
+const (
+	// DefaultExecTxGasOverhead is the default gas overhead for exec transactions. This value plus the offchainconfig.BatchGasLimit
+	// should be less than the gas limit of the chain. This is enforced by the offramp reader.
+	DefaultExecTxGasOverhead = 1_000_000
+)
+
+// GetDefaultCommitTransactionGasLimit returns the default gas limit for a transaction on a given chain.
+// Updating a price in the price registry costs <10k gas if the asset is already in the registry. If it's a new
+// asset it will be <25k gas. There will be an OCR overhead of ~50k gas and a calldata/tx overhead of at most 50k.
+// Given these values we would be able to handle about 36 price updates for new assets or 90 for existing assets.
+func GetDefaultCommitTransactionGasLimit(chainId uint64) uint32 {
+	switch chainId {
+	case 6101244977088475029, 3478487238524512106, 4949039107694359620:
+		return 15_000_000 // Arbitrum and its testnets
+	default:
+		return 1_000_000 // Default for all chains
+	}
+}
+
+// GetDefaultExecTransactionGasLimit returns the default gas limit for a transaction on a given chain.
+// The values defined here should be in sync with the offchainConfig.BatchGasLimit, which the value in
+// the offchain config always being lower than the value defined here + the gas overhead of the transaction.
+func GetDefaultExecTransactionGasLimit(chainId uint64) uint32 {
+	switch chainId {
+	case 6101244977088475029, 3478487238524512106, 4949039107694359620:
+		return 100_000_000 // Arbitrum and its testnets
+	default:
+		return 8_000_000 // Default for all chains
+	}
+}

--- a/core/services/ocr2/plugins/ccip/evm/gas.go
+++ b/core/services/ocr2/plugins/ccip/evm/gas.go
@@ -1,5 +1,7 @@
 package evm
 
+import chainselectors "github.com/smartcontractkit/chain-selectors"
+
 const (
 	// DefaultExecTxGasOverhead is the default gas overhead for exec transactions. This value plus the offchainconfig.BatchGasLimit
 	// should be less than the gas limit of the chain. This is enforced by the offramp reader.
@@ -10,10 +12,12 @@ const (
 // Updating a price in the price registry costs <10k gas if the asset is already in the registry. If it's a new
 // asset it will be <25k gas. There will be an OCR overhead of ~50k gas and a calldata/tx overhead of at most 50k.
 // Given these values we would be able to handle about 36 price updates for new assets or 90 for existing assets.
-func GetDefaultCommitTransactionGasLimit(chainId uint64) uint32 {
-	switch chainId {
-	case 6101244977088475029, 3478487238524512106, 4949039107694359620:
-		return 15_000_000 // Arbitrum and its testnets
+func GetDefaultCommitTransactionGasLimit(chainSelector uint64) uint32 {
+	switch chainSelector {
+	case chainselectors.ETHEREUM_MAINNET_ARBITRUM_1.Selector,
+		chainselectors.ETHEREUM_TESTNET_SEPOLIA_ARBITRUM_1.Selector,
+		chainselectors.ETHEREUM_TESTNET_GOERLI_ARBITRUM_1.Selector:
+		return 15_000_000
 	default:
 		return 1_000_000 // Default for all chains
 	}
@@ -22,11 +26,14 @@ func GetDefaultCommitTransactionGasLimit(chainId uint64) uint32 {
 // GetDefaultExecTransactionGasLimit returns the default gas limit for a transaction on a given chain.
 // The values defined here should be in sync with the offchainConfig.BatchGasLimit, which the value in
 // the offchain config always being lower than the value defined here + the gas overhead of the transaction.
-func GetDefaultExecTransactionGasLimit(chainId uint64) uint32 {
-	switch chainId {
-	case 6101244977088475029, 3478487238524512106, 4949039107694359620:
-		return 100_000_000 // Arbitrum and its testnets
+func GetDefaultExecTransactionGasLimit(chainSelector uint64) uint32 {
+	switch chainSelector {
+	case chainselectors.ETHEREUM_MAINNET_ARBITRUM_1.Selector,
+		chainselectors.ETHEREUM_TESTNET_SEPOLIA_ARBITRUM_1.Selector,
+		chainselectors.ETHEREUM_TESTNET_GOERLI_ARBITRUM_1.Selector:
+		return 100_000_000
 	default:
+
 		return 8_000_000 // Default for all chains
 	}
 }

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/mocks/offramp_reader_mock.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/mocks/offramp_reader_mock.go
@@ -38,9 +38,9 @@ func (_m *OffRampReader) Address() common.Address {
 	return r0
 }
 
-// ChangeConfig provides a mock function with given fields: onchainConfig, offchainConfig
-func (_m *OffRampReader) ChangeConfig(onchainConfig []byte, offchainConfig []byte) (common.Address, common.Address, error) {
-	ret := _m.Called(onchainConfig, offchainConfig)
+// ChangeConfig provides a mock function with given fields: onchainConfig, offchainConfig, chainSelector
+func (_m *OffRampReader) ChangeConfig(onchainConfig []byte, offchainConfig []byte, chainSelector uint64) (common.Address, common.Address, error) {
+	ret := _m.Called(onchainConfig, offchainConfig, chainSelector)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ChangeConfig")
@@ -49,27 +49,27 @@ func (_m *OffRampReader) ChangeConfig(onchainConfig []byte, offchainConfig []byt
 	var r0 common.Address
 	var r1 common.Address
 	var r2 error
-	if rf, ok := ret.Get(0).(func([]byte, []byte) (common.Address, common.Address, error)); ok {
-		return rf(onchainConfig, offchainConfig)
+	if rf, ok := ret.Get(0).(func([]byte, []byte, uint64) (common.Address, common.Address, error)); ok {
+		return rf(onchainConfig, offchainConfig, chainSelector)
 	}
-	if rf, ok := ret.Get(0).(func([]byte, []byte) common.Address); ok {
-		r0 = rf(onchainConfig, offchainConfig)
+	if rf, ok := ret.Get(0).(func([]byte, []byte, uint64) common.Address); ok {
+		r0 = rf(onchainConfig, offchainConfig, chainSelector)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(common.Address)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func([]byte, []byte) common.Address); ok {
-		r1 = rf(onchainConfig, offchainConfig)
+	if rf, ok := ret.Get(1).(func([]byte, []byte, uint64) common.Address); ok {
+		r1 = rf(onchainConfig, offchainConfig, chainSelector)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(common.Address)
 		}
 	}
 
-	if rf, ok := ret.Get(2).(func([]byte, []byte) error); ok {
-		r2 = rf(onchainConfig, offchainConfig)
+	if rf, ok := ret.Get(2).(func([]byte, []byte, uint64) error); ok {
+		r2 = rf(onchainConfig, offchainConfig, chainSelector)
 	} else {
 		r2 = ret.Error(2)
 	}

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/offramp_reader.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/offramp_reader.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/config"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/prices"
 )
@@ -91,7 +92,7 @@ type OffRampReader interface {
 	GetTokenPoolsRateLimits(ctx context.Context, poolAddresses []common.Address) ([]TokenBucketRateLimit, error)
 	Address() common.Address
 	// ChangeConfig notifies the reader that the config has changed onchain
-	ChangeConfig(onchainConfig []byte, offchainConfig []byte) (common.Address, common.Address, error)
+	ChangeConfig(onchainConfig []byte, offchainConfig []byte, chainSelector uint64) (common.Address, common.Address, error)
 	OffchainConfig() ExecOffchainConfig
 	OnchainConfig() ExecOnchainConfig
 	GasPriceEstimator() prices.GasPriceEstimatorExec

--- a/core/services/relay/evm/ccip.go
+++ b/core/services/relay/evm/ccip.go
@@ -2,6 +2,7 @@ package evm
 
 import (
 	"github.com/ethereum/go-ethereum/common"
+	chainselectors "github.com/smartcontractkit/chain-selectors"
 
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2/types"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/ccipcommit"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/ccipexec"
 	ccipconfig "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/config"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/evm"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/types"
 )
 
@@ -46,7 +48,14 @@ func NewCCIPCommitProvider(lggr logger.Logger, chainSet legacyevm.Chain, rargs c
 	if err != nil {
 		return nil, err
 	}
-	contractTransmitter, err := newContractTransmitter(lggr, rargs, transmitterID, ks, configWatcher, configTransmitterOpts{}, fn)
+	destChainSelector, err := chainselectors.SelectorFromChainId(chainSet.ID().Uint64())
+	if err != nil {
+		return nil, err
+	}
+	txGasLimit := evm.GetDefaultCommitTransactionGasLimit(destChainSelector)
+	contractTransmitter, err := newContractTransmitter(lggr, rargs, transmitterID, ks, configWatcher, configTransmitterOpts{
+		pluginGasLimit: &txGasLimit,
+	}, fn)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +100,14 @@ func NewCCIPExecutionProvider(lggr logger.Logger, chainSet legacyevm.Chain, rarg
 	if err != nil {
 		return nil, err
 	}
-	contractTransmitter, err := newContractTransmitter(lggr, rargs, transmitterID, ks, configWatcher, configTransmitterOpts{}, fn)
+	destChainSelector, err := chainselectors.SelectorFromChainId(chainSet.ID().Uint64())
+	if err != nil {
+		return nil, err
+	}
+	txGasLimit := evm.GetDefaultExecTransactionGasLimit(destChainSelector)
+	contractTransmitter, err := newContractTransmitter(lggr, rargs, transmitterID, ks, configWatcher, configTransmitterOpts{
+		pluginGasLimit: &txGasLimit,
+	}, fn)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Motivation
Reduced risk of misconfigs and allows us to properly validate the config before starting the plugin. It also allows us to specify the gas limit per plugin, meaning we have better uptime for the commit plugin when funds would run dry.

## Solution
Use static values equal to the current TOML config.