### PR TITLE
Use "latest" tag instead of making lp query

### DIFF
--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/batchreader/token_pool_batch_reader.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/batchreader/token_pool_batch_reader.go
@@ -16,7 +16,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_2_0"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_4_0"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/rpclib"
-	"github.com/smartcontractkit/chainlink/v2/core/services/pg"
 )
 
 var (
@@ -85,7 +84,7 @@ func (br *EVMTokenPoolBatchedReader) GetInboundTokenPoolRateLimits(ctx context.C
 		}
 	}
 
-	return batchCallLatestBlockNumber[ccipdata.TokenBucketRateLimit](ctx, br.lp, br.evmBatchCaller, evmCalls)
+	return batchCallLatestBlockNumber[ccipdata.TokenBucketRateLimit](ctx, br.evmBatchCaller, evmCalls)
 }
 
 // loadTokenPoolReaders loads the token pools into the factory's cache
@@ -142,16 +141,11 @@ func getBatchedTypeAndVersion(ctx context.Context, lp logpoller.LogPoller, evmBa
 		))
 	}
 
-	return batchCallLatestBlockNumber[string](ctx, lp, evmBatchCaller, evmCalls)
+	return batchCallLatestBlockNumber[string](ctx, evmBatchCaller, evmCalls)
 }
 
-func batchCallLatestBlockNumber[T any](ctx context.Context, lp logpoller.LogPoller, evmBatchCaller rpclib.EvmBatchCaller, evmCalls []rpclib.EvmCall) ([]T, error) {
-	latestBlock, err := lp.LatestBlock(pg.WithParentCtx(ctx))
-	if err != nil {
-		return nil, fmt.Errorf("get latest block: %w", err)
-	}
-
-	results, err := evmBatchCaller.BatchCall(ctx, uint64(latestBlock.BlockNumber), evmCalls)
+func batchCallLatestBlockNumber[T any](ctx context.Context, evmBatchCaller rpclib.EvmBatchCaller, evmCalls []rpclib.EvmCall) ([]T, error) {
+	results, err := evmBatchCaller.BatchCall(ctx, 0, evmCalls)
 	if err != nil {
 		return nil, fmt.Errorf("batch call limit: %w", err)
 	}

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/batchreader/token_pool_batch_reader_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/batchreader/token_pool_batch_reader_test.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"math/big"
 	"testing"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
 	mocks2 "github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/utils"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
@@ -21,18 +19,9 @@ import (
 )
 
 func TestTokenPoolFactory(t *testing.T) {
-	latestBlock := logpoller.LogPollerBlock{
-		BlockNumber:          1231230,
-		BlockTimestamp:       time.Now(),
-		FinalizedBlockNumber: 1231231,
-		CreatedAt:            time.Now(),
-	}
-
 	lggr := logger.TestLogger(t)
 	offRamp := utils.RandomAddress()
 	lp := mocks2.NewLogPoller(t)
-	lp.On("LatestBlock", mock.Anything).Return(latestBlock, nil)
-
 	ctx := context.Background()
 	remoteChainSelector := uint64(2000)
 	batchCallerMock := rpclibmocks.NewEvmBatchCaller(t)
@@ -62,8 +51,8 @@ func TestTokenPoolFactory(t *testing.T) {
 			})
 		}
 
-		batchCallerMock.On("BatchCall", ctx, uint64(latestBlock.BlockNumber), mock.Anything).Return(batchCallResult, nil).Once()
-		batchCallerMock.On("BatchCall", ctx, uint64(latestBlock.BlockNumber), mock.Anything).Return([]rpclib.DataAndErr{{
+		batchCallerMock.On("BatchCall", ctx, uint64(0), mock.Anything).Return(batchCallResult, nil).Once()
+		batchCallerMock.On("BatchCall", ctx, uint64(0), mock.Anything).Return([]rpclib.DataAndErr{{
 			Outputs: []any{rateLimits},
 			Err:     nil,
 		}, {

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_0_0/offramp.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_0_0/offramp.go
@@ -234,12 +234,7 @@ func (o *OffRamp) getDestinationTokensFromSourceTokens(ctx context.Context, toke
 		}
 	}
 
-	latestBlock, err := o.lp.LatestBlock(pg.WithParentCtx(ctx))
-	if err != nil {
-		return nil, fmt.Errorf("get latest block: %w", err)
-	}
-
-	results, err := o.evmBatchCaller.BatchCall(ctx, uint64(latestBlock.BlockNumber), evmCalls)
+	results, err := o.evmBatchCaller.BatchCall(ctx, 0, evmCalls)
 	if err != nil {
 		return nil, fmt.Errorf("batch call limit: %w", err)
 	}
@@ -327,12 +322,7 @@ func (o *OffRamp) getPoolsByDestTokens(ctx context.Context, tokenAddrs []common.
 		))
 	}
 
-	latestBlock, err := o.lp.LatestBlock(pg.WithParentCtx(ctx))
-	if err != nil {
-		return nil, fmt.Errorf("get latest block: %w", err)
-	}
-
-	results, err := o.evmBatchCaller.BatchCall(ctx, uint64(latestBlock.FinalizedBlockNumber), evmCalls)
+	results, err := o.evmBatchCaller.BatchCall(ctx, 0, evmCalls)
 	if err != nil {
 		return nil, fmt.Errorf("batch call limit: %w", err)
 	}

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_0_0/offramp_reader_unit_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_0_0/offramp_reader_unit_test.go
@@ -72,8 +72,6 @@ func TestOffRampGetDestinationTokensFromSourceTokens(t *testing.T) {
 	}
 
 	lp := mocks.NewLogPoller(t)
-	lp.On("LatestBlock", mock.Anything).Return(logpoller.LogPollerBlock{BlockNumber: rand.Int63()}, nil)
-
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			batchCaller := rpclibmocks.NewEvmBatchCaller(t)

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_0_0/price_registry.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_0_0/price_registry.go
@@ -227,12 +227,7 @@ func (p *PriceRegistry) GetTokensDecimals(ctx context.Context, tokenAddresses []
 		}
 	}
 
-	latestBlock, err := p.lp.LatestBlock(pg.WithParentCtx(ctx))
-	if err != nil {
-		return nil, fmt.Errorf("get latest block: %w", err)
-	}
-
-	results, err := p.evmBatchCaller.BatchCall(ctx, uint64(latestBlock.BlockNumber), evmCalls)
+	results, err := p.evmBatchCaller.BatchCall(ctx, 0, evmCalls)
 	if err != nil {
 		return nil, fmt.Errorf("batch call limit: %w", err)
 	}

--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/evm.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/evm.go
@@ -14,7 +14,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/internal/gethwrappers2/generated/offchainaggregator"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/config"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/rpclib"
-	"github.com/smartcontractkit/chainlink/v2/core/services/pg"
 )
 
 const latestRoundDataMethodName = "latestRoundData"
@@ -109,15 +108,9 @@ func (d *DynamicPriceGetter) TokenPricesUSD(ctx context.Context, tokens []common
 		}
 
 		evmCaller := client.BatchCaller
-		lp := client.LP
-
 		tokensOrder := batchCallsTokensOrder[chainID]
-		latestBlock, err := lp.LatestBlock(pg.WithParentCtx(ctx))
-		if err != nil {
-			return nil, fmt.Errorf("get latest block: %w", err)
-		}
 
-		resultsPerChain, err := evmCaller.BatchCall(ctx, uint64(latestBlock.BlockNumber), batchCalls)
+		resultsPerChain, err := evmCaller.BatchCall(ctx, 0, batchCalls)
 		if err != nil {
 			return nil, fmt.Errorf("batch call: %w", err)
 		}

--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/evm_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/evm_test.go
@@ -348,7 +348,7 @@ func mockClientFromRound(t *testing.T, round aggregator_v3_interface.LatestRound
 
 func mockCallerFromRound(t *testing.T, round aggregator_v3_interface.LatestRoundData) *rpclibmocks.EvmBatchCaller {
 	caller := rpclibmocks.NewEvmBatchCaller(t)
-	caller.On("BatchCall", mock.Anything, round.RoundId.Uint64(), mock.Anything).Return(
+	caller.On("BatchCall", mock.Anything, uint64(0), mock.Anything).Return(
 		[]rpclib.DataAndErr{
 			{
 				Outputs: []any{round.RoundId, round.Answer, round.StartedAt, round.UpdatedAt, round.AnsweredInRound},

--- a/core/services/ocr2/plugins/ccip/internal/rpclib/evm.go
+++ b/core/services/ocr2/plugins/ccip/internal/rpclib/evm.go
@@ -93,7 +93,10 @@ func (c *defaultEvmBatchCaller) batchCall(ctx context.Context, blockNumber uint6
 			return nil, fmt.Errorf("pack %s(%+v): %w", call.methodName, call.args, err)
 		}
 
-		bn := big.NewInt(0).SetUint64(blockNumber)
+		blockNumStr := "latest"
+		if blockNumber > 0 {
+			blockNumStr = hexutil.EncodeBig(big.NewInt(0).SetUint64(blockNumber))
+		}
 
 		rpcBatchCalls[i] = rpc.BatchElem{
 			Method: "eth_call",
@@ -103,7 +106,7 @@ func (c *defaultEvmBatchCaller) batchCall(ctx context.Context, blockNumber uint6
 					"to":   call.contractAddress,
 					"data": hexutil.Bytes(packedInputs),
 				},
-				hexutil.EncodeBig(bn),
+				blockNumStr,
 			},
 			Result: &packedOutputs[i],
 		}


### PR DESCRIPTION
So far we were making `lp.LatestBlock()` query for passing it as the "latest" block number.
This sometimes leads to error because the latest block of the log poller might not be in sync with the rpc.
Also it adds one extra db query.