### PR TITLE
Log params before plugin init completes

### DIFF
--- a/core/services/ocr2/plugins/ccip/ccipcommit/initializers.go
+++ b/core/services/ocr2/plugins/ccip/ccipcommit/initializers.go
@@ -124,7 +124,7 @@ func jobSpecToCommitPluginConfig(lggr logger.Logger, jb job.Job, pr pipeline.Run
 	if err != nil {
 		return nil, nil, err
 	}
-	commitLggr := lggr.Named("CCIPCommit").With("sourceChain", sourceChainName, "destChain", destChainName)
+	commitLggr := lggr.Named("CCIPCommit").With("sourceChain", sourceChainName, "destChain", destChainName, "initParams", params)
 
 	var priceGetter pricegetter.PriceGetter
 	withPipeline := strings.Trim(params.pluginConfig.TokenPricesUSDPipeline, "\n\t ") != ""

--- a/core/services/ocr2/plugins/ccip/ccipcommit/initializers.go
+++ b/core/services/ocr2/plugins/ccip/ccipcommit/initializers.go
@@ -113,7 +113,12 @@ func jobSpecToCommitPluginConfig(lggr logger.Logger, jb job.Job, pr pipeline.Run
 		return nil, nil, err
 	}
 
-	lggr.Infow("Initializing commit plugin", "params", params)
+	lggr.Infow("Initializing commit plugin",
+		"CommitStore", params.commitStoreAddress,
+		"OnRamp", params.commitStoreStaticCfg.OnRamp,
+		"ArmProxy", params.commitStoreStaticCfg.ArmProxy,
+		"SourceChainSelector", params.commitStoreStaticCfg.SourceChainSelector,
+		"DestChainSelector", params.commitStoreStaticCfg.ChainSelector)
 
 	versionFinder := factory.NewEvmVersionFinder()
 	commitStoreReader, err := factory.NewCommitStoreReader(lggr, versionFinder, params.commitStoreAddress, params.destChain.Client(), params.destChain.LogPoller(), params.sourceChain.GasEstimator(), qopts...)

--- a/core/services/ocr2/plugins/ccip/ccipcommit/initializers.go
+++ b/core/services/ocr2/plugins/ccip/ccipcommit/initializers.go
@@ -124,7 +124,7 @@ func jobSpecToCommitPluginConfig(lggr logger.Logger, jb job.Job, pr pipeline.Run
 	if err != nil {
 		return nil, nil, err
 	}
-	commitLggr := lggr.Named("CCIPCommit").With("sourceChain", sourceChainName, "destChain", destChainName, "initParams", params)
+	commitLggr := lggr.Named("CCIPCommit").With("sourceChain", sourceChainName, "destChain", destChainName)
 
 	var priceGetter pricegetter.PriceGetter
 	withPipeline := strings.Trim(params.pluginConfig.TokenPricesUSDPipeline, "\n\t ") != ""

--- a/core/services/ocr2/plugins/ccip/ccipcommit/initializers.go
+++ b/core/services/ocr2/plugins/ccip/ccipcommit/initializers.go
@@ -15,6 +15,7 @@ import (
 	"go.uber.org/multierr"
 
 	commonlogger "github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/cciptypes"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipcalc"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipdata/ccipdataprovider"
@@ -112,6 +113,8 @@ func jobSpecToCommitPluginConfig(lggr logger.Logger, jb job.Job, pr pipeline.Run
 		return nil, nil, err
 	}
 
+	lggr.Infow("Initializing commit plugin", "params", params)
+
 	versionFinder := factory.NewEvmVersionFinder()
 	commitStoreReader, err := factory.NewCommitStoreReader(lggr, versionFinder, params.commitStoreAddress, params.destChain.Client(), params.destChain.LogPoller(), params.sourceChain.GasEstimator(), qopts...)
 	if err != nil {
@@ -193,7 +196,7 @@ func jobSpecToCommitPluginConfig(lggr logger.Logger, jb job.Job, pr pipeline.Run
 	commitStoreReader = observability.NewObservedCommitStoreReader(commitStoreReader, params.destChain.ID().Int64(), ccip.CommitPluginLabel)
 	metricsCollector := ccip.NewPluginMetricsCollector(ccip.CommitPluginLabel, params.sourceChain.ID().Int64(), params.destChain.ID().Int64())
 
-	lggr.Infow("NewCommitServices",
+	commitLggr.Infow("NewCommitServices",
 		"pluginConfig", params.pluginConfig,
 		"staticConfig", params.commitStoreStaticCfg,
 		// TODO bring back

--- a/core/services/ocr2/plugins/ccip/ccipexec/initializers.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/initializers.go
@@ -17,7 +17,6 @@ import (
 	"go.uber.org/multierr"
 
 	commonlogger "github.com/smartcontractkit/chainlink-common/pkg/logger"
-
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/cciptypes"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipcalc"
 
@@ -169,7 +168,7 @@ func jobSpecToExecPluginConfig(ctx context.Context, lggr logger.Logger, jb job.J
 	if err != nil {
 		return nil, nil, err
 	}
-	execLggr := lggr.Named("CCIPExecution").With("sourceChain", sourceChainName, "destChain", destChainName, "initParams", params)
+	execLggr := lggr.Named("CCIPExecution").With("sourceChain", sourceChainName, "destChain", destChainName)
 	onRampReader, err := factory.NewOnRampReader(execLggr, versionFinder, params.offRampConfig.SourceChainSelector, params.offRampConfig.ChainSelector, params.offRampConfig.OnRamp, params.sourceChain.LogPoller(), params.sourceChain.Client(), qopts...)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "create onramp reader")

--- a/core/services/ocr2/plugins/ccip/ccipexec/initializers.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/initializers.go
@@ -17,6 +17,7 @@ import (
 	"go.uber.org/multierr"
 
 	commonlogger "github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/cciptypes"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipcalc"
 
@@ -158,7 +159,12 @@ func jobSpecToExecPluginConfig(ctx context.Context, lggr logger.Logger, jb job.J
 		return nil, nil, err
 	}
 
-	lggr.Infow("Initializing exec plugin", "params", params)
+	lggr.Infow("Initializing exec plugin",
+		"CommitStore", params.offRampConfig.CommitStore,
+		"OnRamp", params.offRampConfig.OnRamp,
+		"ArmProxy", params.offRampConfig.ArmProxy,
+		"SourceChainSelector", params.offRampConfig.SourceChainSelector,
+		"DestChainSelector", params.offRampConfig.ChainSelector)
 
 	sourceChainID := params.sourceChain.ID().Int64()
 	destChainID := params.destChain.ID().Int64()

--- a/core/services/ocr2/plugins/ccip/ccipexec/initializers.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/initializers.go
@@ -158,6 +158,8 @@ func jobSpecToExecPluginConfig(ctx context.Context, lggr logger.Logger, jb job.J
 		return nil, nil, err
 	}
 
+	lggr.Infow("Initializing exec plugin", "params", params)
+
 	sourceChainID := params.sourceChain.ID().Int64()
 	destChainID := params.destChain.ID().Int64()
 	versionFinder := factory.NewEvmVersionFinder()

--- a/core/services/ocr2/plugins/ccip/ccipexec/initializers.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/initializers.go
@@ -17,6 +17,7 @@ import (
 	"go.uber.org/multierr"
 
 	commonlogger "github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/cciptypes"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipcalc"
 
@@ -168,7 +169,7 @@ func jobSpecToExecPluginConfig(ctx context.Context, lggr logger.Logger, jb job.J
 	if err != nil {
 		return nil, nil, err
 	}
-	execLggr := lggr.Named("CCIPExecution").With("sourceChain", sourceChainName, "destChain", destChainName)
+	execLggr := lggr.Named("CCIPExecution").With("sourceChain", sourceChainName, "destChain", destChainName, "initParams", params)
 	onRampReader, err := factory.NewOnRampReader(execLggr, versionFinder, params.offRampConfig.SourceChainSelector, params.offRampConfig.ChainSelector, params.offRampConfig.OnRamp, params.sourceChain.LogPoller(), params.sourceChain.Client(), qopts...)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "create onramp reader")

--- a/core/services/ocr2/plugins/ccip/config/type_and_version.go
+++ b/core/services/ocr2/plugins/ccip/config/type_and_version.go
@@ -1,13 +1,13 @@
 package config
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/pkg/errors"
 
 	type_and_version "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/type_and_version_interface_wrapper"
 )
@@ -30,10 +30,10 @@ var (
 func VerifyTypeAndVersion(addr common.Address, client bind.ContractBackend, expectedType ContractType) (semver.Version, error) {
 	contractType, version, err := TypeAndVersion(addr, client)
 	if err != nil {
-		return semver.Version{}, errors.Errorf("failed getting type and version %v", err)
+		return semver.Version{}, fmt.Errorf("failed getting type and version %w", err)
 	}
 	if contractType != expectedType {
-		return semver.Version{}, errors.Errorf("Wrong contract type %s", contractType)
+		return semver.Version{}, fmt.Errorf("wrong contract type %s", contractType)
 	}
 	return version, nil
 }
@@ -54,11 +54,11 @@ func TypeAndVersion(addr common.Address, client bind.ContractBackend) (ContractT
 	}
 	v, err := semver.NewVersion(versionStr)
 	if err != nil {
-		return "", semver.Version{}, errors.Wrapf(err, "failed parsing version %s", versionStr)
+		return "", semver.Version{}, fmt.Errorf("failed parsing version %s: %w", versionStr, err)
 	}
 
 	if !ContractTypes.Contains(ContractType(contractType)) {
-		return "", semver.Version{}, errors.Errorf("unrecognized contract type %v", contractType)
+		return "", semver.Version{}, fmt.Errorf("unrecognized contract type %v", contractType)
 	}
 	return ContractType(contractType), *v, nil
 }
@@ -67,7 +67,7 @@ func ParseTypeAndVersion(tvStr string) (string, string, error) {
 	typeAndVersionValues := strings.Split(tvStr, " ")
 
 	if len(typeAndVersionValues) < 2 {
-		return "", "", errors.Errorf("invalid type and version %s", tvStr)
+		return "", "", fmt.Errorf("invalid type and version %s", tvStr)
 	}
 	return typeAndVersionValues[0], typeAndVersionValues[1], nil
 }

--- a/core/services/ocr2/plugins/ccip/config/type_and_version.go
+++ b/core/services/ocr2/plugins/ccip/config/type_and_version.go
@@ -45,7 +45,7 @@ func TypeAndVersion(addr common.Address, client bind.ContractBackend) (ContractT
 	}
 	tvStr, err := tv.TypeAndVersion(nil)
 	if err != nil {
-		return "", semver.Version{}, err
+		return "", semver.Version{}, fmt.Errorf("error calling typeAndVersion on addr: %s %w", addr.Hex(), err)
 	}
 
 	contractType, versionStr, err := ParseTypeAndVersion(tvStr)

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/onramp_reader_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/onramp_reader_test.go
@@ -1,6 +1,7 @@
 package ccipdata_test
 
 import (
+	"fmt"
 	"math/big"
 	"testing"
 	"time"
@@ -38,7 +39,7 @@ func TestNewOnRampReader_noContractAtAddress(t *testing.T) {
 	_, bc := ccipdata.NewSimulation(t)
 	addr := ccipcalc.EvmAddrToGeneric(utils.RandomAddress())
 	_, err := factory.NewOnRampReader(logger.TestLogger(t), factory.NewEvmVersionFinder(), testutils.SimulatedChainID.Uint64(), testutils.SimulatedChainID.Uint64(), addr, lpmocks.NewLogPoller(t), bc)
-	assert.EqualError(t, err, "unable to read type and version: no contract code at given address")
+	assert.EqualError(t, err, fmt.Sprintf("unable to read type and version: error calling typeAndVersion on addr: %s no contract code at given address", addr))
 }
 
 func TestOnRampReaderInit(t *testing.T) {


### PR DESCRIPTION
## Motivation
If plugin init errors, e.g. due to misconfig, it's hard to debug because config is only logged at end of successful init.

## Solution