### PR TITLE
chore(actions): allow publishing images manually

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 name: publish
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - "v*"


### PR DESCRIPTION
## Motivation

Currently, we publish only Docker images built from the `ccip-develop` branch or release branches. This makes it hard to test changes from unmerged PRs in staging environments.

## Solution

This change allows running the publishing workflow manually from any branch.
GitHub requires write access to the repository for running manual job runs.
See https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow for more details.