### PR TITLE
offchain - json marshal fix for generic addresses

### DIFF
--- a/core/services/ocr2/plugins/ccip/cciptypes/models.go
+++ b/core/services/ocr2/plugins/ccip/cciptypes/models.go
@@ -2,9 +2,28 @@ package cciptypes
 
 import (
 	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
 )
 
 type Address string
+
+// TODO: make JSON marshal/unmarshal non-evm specific.
+// Make sure we have casing compatibility with old versions.
+func (a *Address) UnmarshalJSON(bytes []byte) error {
+	vStr := strings.Trim(string(bytes), `"`)
+	if !common.IsHexAddress(vStr) {
+		return fmt.Errorf("invalid address: %s", vStr)
+	}
+	*a = Address(common.HexToAddress(vStr).String())
+	return nil
+}
+
+func (a *Address) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + strings.ToLower(string(*a)) + `"`), nil
+}
 
 type Hash [32]byte
 

--- a/core/services/ocr2/plugins/ccip/cciptypes/models_test.go
+++ b/core/services/ocr2/plugins/ccip/cciptypes/models_test.go
@@ -1,7 +1,15 @@
 package cciptypes
 
 import (
+	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/utils"
 )
 
 func TestHash_String(t *testing.T) {
@@ -33,4 +41,29 @@ func TestHash_String(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAddress_JSON(t *testing.T) {
+	addr1 := utils.RandomAddress()
+
+	addrArr := []Address{Address(addr1.String())}
+	evmAddrArr := []common.Address{addr1}
+
+	b, err := json.Marshal(addrArr)
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf(`["%s"]`, strings.ToLower(addr1.String())), string(b))
+
+	b2, err := json.Marshal(evmAddrArr)
+	assert.NoError(t, err)
+	assert.Equal(t, string(b), string(b2), "marshal should produce the same result for common.Address and cciptypes.Address")
+
+	var unmarshalledAddr []Address
+	err = json.Unmarshal(b, &unmarshalledAddr)
+	assert.NoError(t, err)
+	assert.Equal(t, addrArr[0], unmarshalledAddr[0])
+
+	var unmarshalledEvmAddr []common.Address
+	err = json.Unmarshal(b, &unmarshalledEvmAddr)
+	assert.NoError(t, err)
+	assert.Equal(t, evmAddrArr[0], unmarshalledEvmAddr[0])
 }


### PR DESCRIPTION
# Motivation
The `common.Address` json representation is all in lower-case while the new `cciptypes.Address` is eip55.
This leads to some incompatibility issues and nodes not reaching consensus due to seeing different results.

# Solution
Make cciptypes.Address json marshal/unmarshal behave similar to common.ADdress