### PR TITLE
getRouter func should be virtual

### DIFF
--- a/contracts/src/v0.8/ccip/applications/CCIPReceiver.sol
+++ b/contracts/src/v0.8/ccip/applications/CCIPReceiver.sol
@@ -45,7 +45,7 @@ abstract contract CCIPReceiver is IAny2EVMMessageReceiver, IERC165 {
 
   /// @notice Return the current router
   /// @return CCIP router address
-  function getRouter() public view returns (address) {
+  function getRouter() public virtual view returns (address) {
     return address(i_ccipRouter);
   }
 


### PR DESCRIPTION
## Motivation
CCIPReceiver Contract is an abstract contract, the getRouter function should be virtual.

## Solution
`function getRouter() public;` => `function getRouter() public virtual;`