### PR TITLE
CCIP-1722: fix pipeline address comparison

### DIFF
--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/pipeline.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/pipeline.go
@@ -67,7 +67,7 @@ func (d *PipelineGetter) TokenPricesUSD(ctx context.Context, tokens []cciptypes.
 		return nil, errors.Errorf("expected map output of price pipeline, got %T", finalResult.Values[0])
 	}
 
-	providedTokensSet := mapset.NewSet[cciptypes.Address](tokens...)
+	providedTokensSet := mapset.NewSet(tokens...)
 	tokenPrices := make(map[cciptypes.Address]*big.Int)
 	for tokenAddressStr, rawPrice := range prices {
 		tokenAddressStr := ccipcalc.HexToAddress(tokenAddressStr)
@@ -76,8 +76,8 @@ func (d *PipelineGetter) TokenPricesUSD(ctx context.Context, tokens []cciptypes.
 			return nil, err
 		}
 
-		if providedTokensSet.Contains(cciptypes.Address(tokenAddressStr)) {
-			tokenPrices[cciptypes.Address(tokenAddressStr)] = castedPrice
+		if providedTokensSet.Contains(tokenAddressStr) {
+			tokenPrices[tokenAddressStr] = castedPrice
 		}
 	}
 

--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/pipeline.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/pipeline.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/cciptypes"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipcalc"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/parseutil"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pipeline"
 )
@@ -69,6 +70,7 @@ func (d *PipelineGetter) TokenPricesUSD(ctx context.Context, tokens []cciptypes.
 	providedTokensSet := mapset.NewSet[cciptypes.Address](tokens...)
 	tokenPrices := make(map[cciptypes.Address]*big.Int)
 	for tokenAddressStr, rawPrice := range prices {
+		tokenAddressStr := ccipcalc.HexToAddress(tokenAddressStr)
 		castedPrice, err := parseutil.ParseBigIntFromAny(rawPrice)
 		if err != nil {
 			return nil, err
@@ -83,7 +85,7 @@ func (d *PipelineGetter) TokenPricesUSD(ctx context.Context, tokens []cciptypes.
 	// Best we can do is sanity check that the token price spec covers all our desired execution token prices.
 	for _, token := range tokens {
 		if _, ok = tokenPrices[token]; !ok {
-			return nil, errors.Errorf("missing token %s from tokensForFeeCoin spec", token)
+			return nil, errors.Errorf("missing token %s from tokensForFeeCoin spec, got %v", token, prices)
 		}
 	}
 

--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/pipeline_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/pipeline_test.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -126,19 +127,19 @@ func TestParsingDifferentFormats(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			token := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				_, err := w.Write([]byte(fmt.Sprintf(`{"MyCoin": %s}`, tt.inputValue)))
+				_, err := fmt.Fprintf(w, `{"MyCoin": %s}`, tt.inputValue)
 				require.NoError(t, err)
 			}))
 			defer token.Close()
 
-			address := common.HexToAddress("0x1591690b8638f5fb2dbec82ac741805ac5da8b45dc5263f4875b0496fdce4e05")
+			address := common.HexToAddress("0x94025780a1aB58868D9B2dBBB775f44b32e8E6e5")
 			source := fmt.Sprintf(`
 			// Price 1
 			coin [type=http method=GET url="%s"];
 			coin_parse [type=jsonparse path="MyCoin"];
 			coin->coin_parse;
 			merge [type=merge left="{}" right="{\"%s\":$(coin_parse)}"];
-			`, token.URL, address)
+			`, token.URL, strings.ToLower(address.String()))
 
 			prices, err := newTestPipelineGetter(t, source).
 				TokenPricesUSD(context.Background(), []cciptypes.Address{ccipcalc.EvmAddrToGeneric(address)})


### PR DESCRIPTION
## Motivation
Stringy addresses comparison fail if pipeline returns non-checksummed addresses.

## Solution
Convert addresses keys received from pipeline to eip155 checksummed address before comparing