### PR TITLE
Changing defaults to have max 20 open connections and 10 idle

### DIFF
--- a/integration-tests/ccip-tests/testconfig/tomls/ccip-default.toml
+++ b/integration-tests/ccip-tests/testconfig/tomls/ccip-default.toml
@@ -72,8 +72,8 @@ Unauthenticated = 1000
 HTTPSPort = 0
 
 [Database]
-MaxIdleConns = 50
-MaxOpenConns = 50
+MaxIdleConns = 10
+MaxOpenConns = 20
 MigrateOnStartup = true
 
 [OCR2]


### PR DESCRIPTION
This is aligned with the defaults for the Core node. Also opening 50 connections to a single db small/medium instance doesn't really make sense at this point. 