### PR TITLE
Build devspace dockers with goreleaser

### DIFF
--- a/charts/chainlink-cluster/Chart.lock
+++ b/charts/chainlink-cluster/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: mockserver
+  repository: https://www.mock-server.com
+  version: 5.14.0
+digest: sha256:059ea904117893108a9e39e9c8506179847ab1a480658f4fc30f7cd4b03acd90
+generated: "2024-03-05T10:19:41.127258+01:00"

--- a/charts/chainlink-cluster/README.md
+++ b/charts/chainlink-cluster/README.md
@@ -23,7 +23,7 @@ Configure your `cluster` setup (one time setup, internal usage only)
 ```
 export DEVSPACE_IMAGE="..."
 cd charts/chainlink-cluster
-./setup.sh ${my-personal-namespace-name-crib}
+TBD
 ```
 
 Build and deploy current commit

--- a/charts/chainlink-cluster/devspace.yaml
+++ b/charts/chainlink-cluster/devspace.yaml
@@ -36,7 +36,7 @@ pipelines:
 
       run_dependencies --all
       ensure_pull_secrets --all
-      build_images ---var DOCKER_DEFAULT_PLATFORM=linux/amd64  --all -t $(git rev-parse --short HEAD)
+      build_images --all
       kubectl annotate namespace ${DEVSPACE_NAMESPACE} janitor/ttl=${NS_TTL} || true
       kubectl label namespace/${DEVSPACE_NAMESPACE} network=crib || true
       if [ -n "$1" ]; then
@@ -93,11 +93,25 @@ commands:
 images:
   app:
     image: ${DEVSPACE_IMAGE}
-    dockerfile: ../../core/chainlink.devspace.Dockerfile
-    context: ../..
-    docker:
-      disableFallback: true
+    tags:
+      - $(git rev-parse --short HEAD)
+    custom:
+      skipImageArg: true
+      command: |-
+        TOPLEVEL=$(git rev-parse --show-toplevel)
+        pushd $TOPLEVEL
+        pwd
+        goreleaser --version
+        GOARCH=amd64 MACOS_SDK_DIR=$(pwd)/tools/bin/MacOSX12.3.sdk ./tools/bin/goreleaser_wrapper release --snapshot --clean --config .goreleaser.develop.yaml
+        popd
+        BUILT_IMAGE=$(cat $TOPLEVEL/dist/artifacts.json | jq -r '.[] | select(.type == "Docker Image" and .goarch == "amd64" and (.name | contains("sha")) and ( .name | contains("root") | not) ) | .name')
 
+        echo "Tagging and pushing image"
+        tag=$(git rev-parse --short HEAD)
+        TAGGED_IMAGE=${DEVSPACE_IMAGE}:$tag
+        docker tag $BUILT_IMAGE ${runtime.images.app.image}:${runtime.images.app.tag}
+        echo "Tagged image: $TAGGED_IMAGE"
+        docker push $TAGGED_IMAGE
 hooks:
   - wait:
       running: true

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1709126324,
+        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
         "type": "github"
       },
       "original": {
@@ -17,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1666109165,
-        "narHash": "sha256-BMLyNVkr0oONuq3lKlFCRVuYqF75CO68Z8EoCh81Zdk=",
+        "lastModified": 1709479366,
+        "narHash": "sha256-n6F0n8UV6lnTZbYPl1A9q1BS0p4hduAv1mGAP17CVd0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "32096899af23d49010bd8cf6a91695888d9d9e73",
+        "rev": "b8697e57f10292a6165a20f03d2f42920dfaf973",
         "type": "github"
       },
       "original": {
@@ -35,6 +38,21 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/shell.nix
+++ b/shell.nix
@@ -1,15 +1,15 @@
 { pkgs ? import <nixpkgs> { } }:
 with pkgs;
 let
-  go = go_1_19;
+  go = go_1_21;
   postgresql = postgresql_14;
-  nodejs = nodejs-16_x;
+  nodejs = nodejs-18_x;
   nodePackages = pkgs.nodePackages.override { inherit nodejs; };
 in
 mkShell {
   nativeBuildInputs = [
     go
-
+    goreleaser
     postgresql
     python3
     python3Packages.pip
@@ -30,8 +30,10 @@ mkShell {
     delve
     golangci-lint
     github-cli
+    jq
 
     # deployment
+    awscli2
     devspace
     kubectl
     kubernetes-helm
@@ -48,8 +50,4 @@ mkShell {
 
   PGDATA = "db";
   CL_DATABASE_URL = "postgresql://chainlink:chainlink@localhost:5432/chainlink_test?sslmode=disable";
-  shellHook = ''
-    export GOPATH=$HOME/go
-    export PATH=$GOPATH/bin:$PATH
-  '';
 }


### PR DESCRIPTION
## Motivation
Porting the recent change from chainlink core: https://github.com/smartcontractkit/chainlink/pull/12166 to make cross platform build more reliable. It required to update nix flake dependencies, so we can use the latest version of goreleaser.