### PR TITLE
Removing checks from Query because of the latency requirements for that OCR phase

### DIFF
--- a/core/services/ocr2/plugins/ccip/ccipcommit/ocr2.go
+++ b/core/services/ocr2/plugins/ccip/ccipcommit/ocr2.go
@@ -92,12 +92,7 @@ type CommitReportingPlugin struct {
 }
 
 // Query is not used by the CCIP Commit plugin.
-func (r *CommitReportingPlugin) Query(ctx context.Context, _ types.ReportTimestamp) (types.Query, error) {
-	if healthy, err := r.chainHealthcheck.IsHealthy(ctx, false); err != nil {
-		return nil, err
-	} else if !healthy {
-		return nil, ccip.ErrChainIsNotHealthy
-	}
+func (r *CommitReportingPlugin) Query(context.Context, types.ReportTimestamp) (types.Query, error) {
 	return types.Query{}, nil
 }
 

--- a/core/services/ocr2/plugins/ccip/ccipexec/ocr2.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/ocr2.go
@@ -93,12 +93,7 @@ type ExecutionReportingPlugin struct {
 	chainHealthcheck cache.ChainHealthcheck
 }
 
-func (r *ExecutionReportingPlugin) Query(ctx context.Context, _ types.ReportTimestamp) (types.Query, error) {
-	if healthy, err := r.chainHealthcheck.IsHealthy(ctx, false); err != nil {
-		return nil, err
-	} else if !healthy {
-		return nil, ccip.ErrChainIsNotHealthy
-	}
+func (r *ExecutionReportingPlugin) Query(context.Context, types.ReportTimestamp) (types.Query, error) {
 	return types.Query{}, nil
 }
 


### PR DESCRIPTION
`Query` has not been used so far, so its timeout is set to very low values - usually 100 millis. That makes querying blockchain not doable in that OCR2 phase 