### PR TITLE
Return error instead of overriding that with "unhealthy" in readers 

### DIFF
--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_0_0/commit_store.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_0_0/commit_store.go
@@ -352,9 +352,7 @@ func (c *CommitStore) IsDestChainHealthy(context.Context) (bool, error) {
 func (c *CommitStore) IsDown(ctx context.Context) (bool, error) {
 	unPausedAndHealthy, err := c.commitStore.IsUnpausedAndARMHealthy(&bind.CallOpts{Context: ctx})
 	if err != nil {
-		// If we cannot read the state, assume the worst
-		c.lggr.Errorw("Unable to read CommitStore IsUnpausedAndARMHealthy", "err", err)
-		return true, nil
+		return true, err
 	}
 	return !unPausedAndHealthy, nil
 }

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_2_0/commit_store.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_2_0/commit_store.go
@@ -378,9 +378,7 @@ func (c *CommitStore) IsDestChainHealthy(context.Context) (bool, error) {
 func (c *CommitStore) IsDown(ctx context.Context) (bool, error) {
 	unPausedAndHealthy, err := c.commitStore.IsUnpausedAndARMHealthy(&bind.CallOpts{Context: ctx})
 	if err != nil {
-		// If we cannot read the state, assume the worst
-		c.lggr.Errorw("Unable to read CommitStore IsUnpausedAndARMHealthy", "err", err)
-		return true, nil
+		return true, err
 	}
 	return !unPausedAndHealthy, nil
 }


### PR DESCRIPTION
Downstream functions should return errors when errors are returned when calling RPC. 
Otherwise, ChainHealthcheck will mark incorrectly chain as unhealthy.