### PR TITLE
Seqnum increase validation

### DIFF
--- a/integration-tests/ccip-tests/actions/ccip_helpers.go
+++ b/integration-tests/ccip-tests/actions/ccip_helpers.go
@@ -1771,9 +1771,8 @@ func (destCCIP *DestCCIPModule) AssertSeqNumberExecuted(
 			}
 			seqNumberAfter, err := destCCIP.CommitStore.Instance.GetExpectedNextSequenceNumber(nil)
 			if err != nil {
-				reqStat.UpdateState(lggr, seqNumberBefore, testreporters.Commit, time.Since(timeNow), testreporters.Failure)
-				return fmt.Errorf("error %w in GetNextExpectedSeqNumber by commitStore for seqNum %d lane %d-->%d",
-					err, seqNumberBefore+1, destCCIP.SourceChainId, destCCIP.Common.ChainClient.GetChainID())
+				// if we get error instead of returning error we continue, in case it's a temporary RPC failure .
+				continue
 			}
 			if seqNumberAfter > seqNumberBefore {
 				destCCIP.NextSeqNumToCommit.Store(seqNumberAfter)

--- a/integration-tests/ccip-tests/load/helper.go
+++ b/integration-tests/ccip-tests/load/helper.go
@@ -144,7 +144,7 @@ func (l *LoadArgs) TriggerLoadByLane() {
 			SharedData:            l.TestCfg.TestGroupInput.MsgType,
 			LokiConfig:            wasp.NewLokiConfig(lokiConfig.Endpoint, lokiConfig.TenantId, nil, nil),
 			Labels:                labels,
-			FailOnErr:             true,
+			FailOnErr:             pointer.GetBool(l.TestCfg.TestGroupInput.FailOnFirstErrorInLoad),
 		})
 		require.NoError(l.TestCfg.Test, err, "initiating loadgen for lane %s --> %s",
 			lane.SourceNetworkName, lane.DestNetworkName)
@@ -272,7 +272,7 @@ func (l *LoadArgs) TriggerLoadBySource() {
 				Logger:                multiCallGen.logger,
 				LokiConfig:            wasp.NewLokiConfig(lokiConfig.Endpoint, lokiConfig.TenantId, nil, nil),
 				Labels:                allLabels,
-				FailOnErr:             true,
+				FailOnErr:             pointer.GetBool(l.TestCfg.TestGroupInput.FailOnFirstErrorInLoad),
 			})
 			require.NoError(l.TestCfg.Test, err, "initiating loadgen for source %s", source)
 			loadRunner.Run(false)

--- a/integration-tests/ccip-tests/testconfig/ccip.go
+++ b/integration-tests/ccip-tests/testconfig/ccip.go
@@ -44,7 +44,7 @@ type CCIPTestConfig struct {
 	MaxNoOfLanes               int                `toml:",omitempty"`
 	ChaosDuration              *config.Duration   `toml:",omitempty"`
 	USDCMockDeployment         *bool              `toml:",omitempty"`
-	TimeoutForPriceUpdLate     *config.Duration   `toml:",omitempty"`
+	TimeoutForPriceUpdate      *config.Duration   `toml:",omitempty"`
 	FailOnFirstErrorInLoad     *bool              `toml:",omitempty"`
 }
 

--- a/integration-tests/ccip-tests/testconfig/ccip.go
+++ b/integration-tests/ccip-tests/testconfig/ccip.go
@@ -44,7 +44,8 @@ type CCIPTestConfig struct {
 	MaxNoOfLanes               int                `toml:",omitempty"`
 	ChaosDuration              *config.Duration   `toml:",omitempty"`
 	USDCMockDeployment         *bool              `toml:",omitempty"`
-	TimeoutForPriceUpdate      *config.Duration   `toml:",omitempty"`
+	TimeoutForPriceUpdLate     *config.Duration   `toml:",omitempty"`
+	FailOnFirstErrorInLoad     *bool              `toml:",omitempty"`
 }
 
 func (c *CCIPTestConfig) SetTestRunName(name string) {

--- a/integration-tests/ccip-tests/testconfig/override/mainnet.toml
+++ b/integration-tests/ccip-tests/testconfig/override/mainnet.toml
@@ -696,6 +696,7 @@ NoOfTokensPerChain = 1
 NoOfTokensInMsg = 1
 AmountPerToken = 1
 TestRunName = 'mainnet-2.7-ccip1.2'
+FailOnFirstErrorInLoad = true
 
 [CCIP.Groups.smoke]
 MsgType = 'WithoutToken'


### PR DESCRIPTION
## Motivation
There are momentary RPC errors for which at times `GetExpectedNextSequenceNumber` call fails. The test used to fail on such error.

## Solution

- Continue in for loop if there is an error received in  `GetExpectedNextSequenceNumber` call and fail the test only if GetExpectedNextSequenceNumber is not successful within set timeout.

- Configurable FailOnFirstErrorInLoad