### PR TITLE
offchain - address backwards compatibility without json overrides

### DIFF
--- a/core/services/ocr2/plugins/ccip/ccipcommit/initializers.go
+++ b/core/services/ocr2/plugins/ccip/ccipcommit/initializers.go
@@ -267,6 +267,7 @@ func extractJobSpecParams(jb job.Job, chainSet legacyevm.LegacyChainContainer) (
 	if err != nil {
 		return nil, err
 	}
+	pluginConfig.OffRamp = ccipcalc.HexToAddress(string(pluginConfig.OffRamp))
 
 	destChain, _, err := ccipconfig.GetChainFromSpec(spec, chainSet)
 	if err != nil {

--- a/core/services/ocr2/plugins/ccip/ccipcommit/initializers.go
+++ b/core/services/ocr2/plugins/ccip/ccipcommit/initializers.go
@@ -267,6 +267,7 @@ func extractJobSpecParams(jb job.Job, chainSet legacyevm.LegacyChainContainer) (
 	if err != nil {
 		return nil, err
 	}
+	// ensure addresses are formatted properly - (lowercase to eip55 for evm)
 	pluginConfig.OffRamp = ccipcalc.HexToAddress(string(pluginConfig.OffRamp))
 
 	destChain, _, err := ccipconfig.GetChainFromSpec(spec, chainSet)

--- a/core/services/ocr2/plugins/ccip/ccipcommit/ocr2_test.go
+++ b/core/services/ocr2/plugins/ccip/ccipcommit/ocr2_test.go
@@ -2,7 +2,6 @@ package ccipcommit
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"math/big"
 	"math/rand"
@@ -659,9 +658,14 @@ func TestCommitReportingPlugin_validateObservations(t *testing.T) {
 	}
 	ob1Bytes, err := ob1.Marshal()
 	assert.NoError(t, err)
-	var ob2, ob3 ccip.CommitObservation
-	_ = json.Unmarshal(ob1Bytes, &ob2)
-	_ = json.Unmarshal(ob1Bytes, &ob3)
+	lggr := logger.TestLogger(t)
+	observations := ccip.GetParsableObservations[ccip.CommitObservation](lggr, []types.AttributedObservation{
+		{Observation: ob1Bytes},
+		{Observation: ob1Bytes},
+	})
+	assert.Len(t, observations, 2)
+	ob2 := observations[0]
+	ob3 := observations[1]
 
 	obWithNilGasPrice := ccip.CommitObservation{
 		Interval: cciptypes.CommitStoreInterval{Min: 0, Max: 0},

--- a/core/services/ocr2/plugins/ccip/cciptypes/models.go
+++ b/core/services/ocr2/plugins/ccip/cciptypes/models.go
@@ -2,39 +2,9 @@ package cciptypes
 
 import (
 	"encoding/hex"
-	"fmt"
-	"strings"
-
-	"github.com/ethereum/go-ethereum/common"
 )
 
 type Address string
-
-func (a *Address) UnmarshalJSON(b []byte) error {
-	vStr := strings.Trim(string(b), `"`)
-	if !common.IsHexAddress(vStr) {
-		return fmt.Errorf("invalid address: %s", vStr)
-	}
-	*a = Address(common.HexToAddress(vStr).String())
-	return nil
-}
-
-func (a Address) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + strings.ToLower(string(a)) + `"`), nil
-}
-
-func (a Address) MarshalText() (text []byte, err error) {
-	return []byte(strings.ToLower(string(a))), nil
-}
-
-func (a *Address) UnmarshalText(text []byte) error {
-	vStr := string(text)
-	if !common.IsHexAddress(vStr) {
-		return fmt.Errorf("invalid address: %s", vStr)
-	}
-	*a = Address(common.HexToAddress(vStr).String())
-	return nil
-}
 
 type Hash [32]byte
 

--- a/core/services/ocr2/plugins/ccip/cciptypes/models_test.go
+++ b/core/services/ocr2/plugins/ccip/cciptypes/models_test.go
@@ -1,12 +1,7 @@
 package cciptypes
 
 import (
-	"fmt"
 	"testing"
-
-	"github.com/ethereum/go-ethereum/common"
-	json2 "github.com/goccy/go-json"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestHash_String(t *testing.T) {
@@ -38,33 +33,4 @@ func TestHash_String(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestAddress_JSON(t *testing.T) {
-	addrLower := "0xe8bade28e08b469b4eeec35b9e48b2ce49fb3fc9"
-	addrEIP55 := "0xE8BAde28E08B469B4EeeC35b9E48B2Ce49FB3FC9"
-
-	t.Run("arrays", func(t *testing.T) {
-		addrArr := []Address{Address(addrLower), Address(addrEIP55)}
-		b, err := json2.Marshal(addrArr)
-		assert.NoError(t, err)
-		assert.Equal(t, fmt.Sprintf(`["%s","%s"]`, addrLower, addrLower), string(b))
-
-		evmAddrArr := []common.Address{common.HexToAddress(addrLower), common.HexToAddress(addrEIP55)}
-		bEvm, err := json2.Marshal(evmAddrArr)
-		assert.NoError(t, err)
-		assert.Equal(t, b, bEvm)
-	})
-
-	t.Run("maps", func(t *testing.T) {
-		m := map[Address]int{Address(addrEIP55): 14}
-		b, err := json2.Marshal(m)
-		assert.NoError(t, err)
-		assert.Equal(t, fmt.Sprintf(`{"%s":14}`, addrLower), string(b), "should be lower when marshalled")
-
-		m2 := map[Address]int{}
-		err = json2.Unmarshal(b, &m2)
-		assert.NoError(t, err)
-		assert.Equal(t, m, m2, "should be eip55 when unmarshalled")
-	})
 }

--- a/core/services/ocr2/plugins/ccip/observations.go
+++ b/core/services/ocr2/plugins/ccip/observations.go
@@ -24,6 +24,7 @@ type CommitObservation struct {
 	SourceGasPriceUSD *big.Int                       `json:"sourceGasPrice"`
 }
 
+// Marshal MUST be used instead of raw json.Marshal(o) since it contains backwards compatibility related changes.
 func (o CommitObservation) Marshal() ([]byte, error) {
 	// Similar to: commitObservationJSONBackComp but for commit observation marshaling.
 	tokenPricesUSD := make(map[cciptypes.Address]*big.Int, len(o.TokenPricesUSD))
@@ -80,6 +81,8 @@ func (o ExecutionObservation) Marshal() ([]byte, error) {
 // GetParsableObservations checks the given observations for formatting and value errors.
 // It returns all valid observations, potentially being an empty list. It will log
 // malformed observations but never error.
+//
+// GetParsableObservations MUST be used instead of raw json.Unmarshal(o) since it contains backwards compatibility changes.
 func GetParsableObservations[O CommitObservation | ExecutionObservation](l logger.Logger, observations []types.AttributedObservation) []O {
 	var parseableObservations []O
 	var observers []commontypes.OracleID

--- a/core/services/ocr2/plugins/ccip/observations_test.go
+++ b/core/services/ocr2/plugins/ccip/observations_test.go
@@ -18,7 +18,9 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/commit_store_1_0_0"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/cciptypes"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/config"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipcalc"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/testhelpers"
 )
 
 func TestObservationFilter(t *testing.T) {
@@ -238,4 +240,28 @@ func TestCommitObservationJsonSerializationDeserialization(t *testing.T) {
 	})
 	assert.Equal(t, 1, len(observations))
 	assert.Equal(t, expectedObservation, observations[0])
+}
+
+func TestAddressEncodingBackwardsCompatibility(t *testing.T) {
+	// The intention of this test is to remind including proper formatting of addresses after config is updated.
+	//
+	// The following tests will fail when a new cciptypes.Address field is added or removed.
+	// If you notice that the test is failing, make sure to apply proper address formatting
+	// after the struct is marshalled/unmarshalled and then include your new field in the expected fields slice to
+	// make this test pass or if you removed a field, remove it from the expected fields slice.
+
+	t.Run("job spec config", func(t *testing.T) {
+		exp := []string{"cciptypes.Address OffRamp"}
+
+		fields := testhelpers.FindStructFieldsOfCertainType("cciptypes.Address", config.CommitPluginJobSpecConfig{PriceGetterConfig: &config.DynamicPriceGetterConfig{}})
+		assert.Equal(t, exp, fields)
+	})
+
+	t.Run("commit observation", func(t *testing.T) {
+		exp := []string{"map[cciptypes.Address]*big.Int TokenPricesUSD"}
+
+		fields := testhelpers.FindStructFieldsOfCertainType("cciptypes.Address", CommitObservation{SourceGasPriceUSD: big.NewInt(0)})
+		assert.Equal(t, exp, fields)
+	})
+
 }

--- a/core/services/ocr2/plugins/ccip/testhelpers/structfields.go
+++ b/core/services/ocr2/plugins/ccip/testhelpers/structfields.go
@@ -1,0 +1,44 @@
+package testhelpers
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// FindStructFieldsOfCertainType recursively iterates over struct fields and returns all the fields of the provided type.
+func FindStructFieldsOfCertainType(targetType string, v any) []string {
+	typesAndFields := TypesAndFields("", reflect.ValueOf(v))
+	results := make([]string, 0)
+	for _, field := range typesAndFields {
+		if strings.Contains(field, targetType) {
+			results = append(results, field)
+		}
+	}
+	return results
+}
+
+// TypesAndFields will find and return all the fields and their types of the provided value.
+// NOTE: This is not intended for production use, it's a helper method for tests.
+func TypesAndFields(prefix string, v reflect.Value) []string {
+	results := make([]string, 0)
+
+	s := v
+	typeOfT := s.Type()
+	for i := 0; i < s.NumField(); i++ {
+		f := s.Field(i)
+		typeAndName := fmt.Sprintf("%s%s %v", prefix, f.Type(), typeOfT.Field(i).Name)
+		results = append(results, typeAndName)
+
+		if f.Kind().String() == "ptr" {
+			results = append(results, TypesAndFields(typeOfT.Field(i).Name, f.Elem())...)
+		}
+
+		if f.Kind().String() == "struct" {
+			x1 := reflect.ValueOf(f.Interface())
+			results = append(results, TypesAndFields(typeOfT.Field(i).Name, x1)...)
+		}
+	}
+
+	return results
+}

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/gin-gonic/gin v1.9.1
 	github.com/go-ldap/ldap/v3 v3.4.6
 	github.com/go-webauthn/webauthn v0.9.4
-	github.com/goccy/go-json v0.10.2
 	github.com/google/pprof v0.0.0-20231023181126-ff6d637d2a7b
 	github.com/google/uuid v1.4.0
 	github.com/gorilla/securecookie v1.1.2
@@ -195,6 +194,7 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.15.5 // indirect
 	github.com/go-webauthn/x v0.1.5 // indirect
+	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/gofrs/flock v0.8.1 // indirect
 	github.com/gofrs/uuid v4.3.1+incompatible // indirect


### PR DESCRIPTION
## Motivation

Based on the guidelines of chainlink-common repo it's not allowed to have chain-specific logic for the common types.
There are multiple places where addresses are identified by CCIP or where JSON is used, we assume that this addresses will be checksummed.

## Solution

Apply backwards compatibility logic in the plugin.

## About Beta Testing

This change should be tested on a beta cluster with different nodes running different ccip version to make sure they come in consensus without any other errors.

## Risks

I analyzed our source code and it seems that this change is sufficient (should be e2e tested though) but future changes should use the relevant methods for json encoding/decoding instead of raw json function calls.
