### PR TITLE
chore: bump chain-selectors to v1.0.12

### DIFF
--- a/.changeset/thick-moles-behave.md
+++ b/.changeset/thick-moles-behave.md
@@ -1,0 +1,5 @@
+---
+"ccip": patch
+---
+
+chore: bump chain-selectors package to v1.0.12

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.1.1
 	github.com/pkg/errors v0.9.1
 	github.com/shopspring/decimal v1.3.1
-	github.com/smartcontractkit/chain-selectors v1.0.11
+	github.com/smartcontractkit/chain-selectors v1.0.12
 	github.com/smartcontractkit/chainlink-automation v1.0.2-0.20240311111125-22812a072c35
 	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240319231131-2d0d99220a04
 	github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1166,6 +1166,8 @@ github.com/smartcontractkit/caigo v0.0.0-20230621050857-b29a4ca8c704 h1:T3lFWumv
 github.com/smartcontractkit/caigo v0.0.0-20230621050857-b29a4ca8c704/go.mod h1:2QuJdEouTWjh5BDy5o/vgGXQtR4Gz8yH1IYB5eT7u4M=
 github.com/smartcontractkit/chain-selectors v1.0.11 h1:9MmMdUPoMmQnAxQM/iEX6ARXpyFlM4CrcYI8hyaHskY=
 github.com/smartcontractkit/chain-selectors v1.0.11/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
+github.com/smartcontractkit/chain-selectors v1.0.12 h1:Rq+mNaHEVPVDgI+SywhCt1iLEolxf8kER3wFlwJDrWc=
+github.com/smartcontractkit/chain-selectors v1.0.12/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.2-0.20240311111125-22812a072c35 h1:GNhRKD3izyzAoGMXDvVUAwEuzz4Atdj3U3RH7eak5Is=
 github.com/smartcontractkit/chainlink-automation v1.0.2-0.20240311111125-22812a072c35/go.mod h1:2I0dWdYdK6jHPnSYYy7Y7Xp7L0YTnJ3KZtkhLQflsTU=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240319231131-2d0d99220a04 h1:SmnFGUhzfyHS8WdekapbVypFCAXXRqiBdTp6I4oFCV0=

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1164,8 +1164,6 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smartcontractkit/caigo v0.0.0-20230621050857-b29a4ca8c704 h1:T3lFWumvbfM1u/etVq42Afwq/jtNSBSOA8n5jntnNPo=
 github.com/smartcontractkit/caigo v0.0.0-20230621050857-b29a4ca8c704/go.mod h1:2QuJdEouTWjh5BDy5o/vgGXQtR4Gz8yH1IYB5eT7u4M=
-github.com/smartcontractkit/chain-selectors v1.0.11 h1:9MmMdUPoMmQnAxQM/iEX6ARXpyFlM4CrcYI8hyaHskY=
-github.com/smartcontractkit/chain-selectors v1.0.11/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chain-selectors v1.0.12 h1:Rq+mNaHEVPVDgI+SywhCt1iLEolxf8kER3wFlwJDrWc=
 github.com/smartcontractkit/chain-selectors v1.0.12/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.2-0.20240311111125-22812a072c35 h1:GNhRKD3izyzAoGMXDvVUAwEuzz4Atdj3U3RH7eak5Is=

--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/shirou/gopsutil/v3 v3.23.11
 	github.com/shopspring/decimal v1.3.1
 	github.com/smartcontractkit/caigo v0.0.0-20230621050857-b29a4ca8c704
-	github.com/smartcontractkit/chain-selectors v1.0.11
+	github.com/smartcontractkit/chain-selectors v1.0.12
 	github.com/smartcontractkit/chainlink-automation v1.0.2-0.20240311111125-22812a072c35
 	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240319231131-2d0d99220a04
 	github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240213120401-01a23955f9f8

--- a/go.sum
+++ b/go.sum
@@ -1159,8 +1159,6 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smartcontractkit/caigo v0.0.0-20230621050857-b29a4ca8c704 h1:T3lFWumvbfM1u/etVq42Afwq/jtNSBSOA8n5jntnNPo=
 github.com/smartcontractkit/caigo v0.0.0-20230621050857-b29a4ca8c704/go.mod h1:2QuJdEouTWjh5BDy5o/vgGXQtR4Gz8yH1IYB5eT7u4M=
-github.com/smartcontractkit/chain-selectors v1.0.11 h1:9MmMdUPoMmQnAxQM/iEX6ARXpyFlM4CrcYI8hyaHskY=
-github.com/smartcontractkit/chain-selectors v1.0.11/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chain-selectors v1.0.12 h1:Rq+mNaHEVPVDgI+SywhCt1iLEolxf8kER3wFlwJDrWc=
 github.com/smartcontractkit/chain-selectors v1.0.12/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.2-0.20240311111125-22812a072c35 h1:GNhRKD3izyzAoGMXDvVUAwEuzz4Atdj3U3RH7eak5Is=

--- a/go.sum
+++ b/go.sum
@@ -1161,6 +1161,8 @@ github.com/smartcontractkit/caigo v0.0.0-20230621050857-b29a4ca8c704 h1:T3lFWumv
 github.com/smartcontractkit/caigo v0.0.0-20230621050857-b29a4ca8c704/go.mod h1:2QuJdEouTWjh5BDy5o/vgGXQtR4Gz8yH1IYB5eT7u4M=
 github.com/smartcontractkit/chain-selectors v1.0.11 h1:9MmMdUPoMmQnAxQM/iEX6ARXpyFlM4CrcYI8hyaHskY=
 github.com/smartcontractkit/chain-selectors v1.0.11/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
+github.com/smartcontractkit/chain-selectors v1.0.12 h1:Rq+mNaHEVPVDgI+SywhCt1iLEolxf8kER3wFlwJDrWc=
+github.com/smartcontractkit/chain-selectors v1.0.12/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.2-0.20240311111125-22812a072c35 h1:GNhRKD3izyzAoGMXDvVUAwEuzz4Atdj3U3RH7eak5Is=
 github.com/smartcontractkit/chainlink-automation v1.0.2-0.20240311111125-22812a072c35/go.mod h1:2I0dWdYdK6jHPnSYYy7Y7Xp7L0YTnJ3KZtkhLQflsTU=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240319231131-2d0d99220a04 h1:SmnFGUhzfyHS8WdekapbVypFCAXXRqiBdTp6I4oFCV0=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/scylladb/go-reflectx v1.0.1
 	github.com/segmentio/ksuid v1.0.4
 	github.com/slack-go/slack v0.12.2
-	github.com/smartcontractkit/chain-selectors v1.0.11
+	github.com/smartcontractkit/chain-selectors v1.0.12
 	github.com/smartcontractkit/chainlink-automation v1.0.2-0.20240311111125-22812a072c35
 	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240319231131-2d0d99220a04
 	github.com/smartcontractkit/chainlink-testing-framework v1.27.0

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1508,8 +1508,6 @@ github.com/slack-go/slack v0.12.2 h1:x3OppyMyGIbbiyFhsBmpf9pwkUzMhthJMRNmNlA4LaQ
 github.com/slack-go/slack v0.12.2/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQdlMQKOw=
 github.com/smartcontractkit/caigo v0.0.0-20230621050857-b29a4ca8c704 h1:T3lFWumvbfM1u/etVq42Afwq/jtNSBSOA8n5jntnNPo=
 github.com/smartcontractkit/caigo v0.0.0-20230621050857-b29a4ca8c704/go.mod h1:2QuJdEouTWjh5BDy5o/vgGXQtR4Gz8yH1IYB5eT7u4M=
-github.com/smartcontractkit/chain-selectors v1.0.11 h1:9MmMdUPoMmQnAxQM/iEX6ARXpyFlM4CrcYI8hyaHskY=
-github.com/smartcontractkit/chain-selectors v1.0.11/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chain-selectors v1.0.12 h1:Rq+mNaHEVPVDgI+SywhCt1iLEolxf8kER3wFlwJDrWc=
 github.com/smartcontractkit/chain-selectors v1.0.12/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.2-0.20240311111125-22812a072c35 h1:GNhRKD3izyzAoGMXDvVUAwEuzz4Atdj3U3RH7eak5Is=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1510,6 +1510,8 @@ github.com/smartcontractkit/caigo v0.0.0-20230621050857-b29a4ca8c704 h1:T3lFWumv
 github.com/smartcontractkit/caigo v0.0.0-20230621050857-b29a4ca8c704/go.mod h1:2QuJdEouTWjh5BDy5o/vgGXQtR4Gz8yH1IYB5eT7u4M=
 github.com/smartcontractkit/chain-selectors v1.0.11 h1:9MmMdUPoMmQnAxQM/iEX6ARXpyFlM4CrcYI8hyaHskY=
 github.com/smartcontractkit/chain-selectors v1.0.11/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
+github.com/smartcontractkit/chain-selectors v1.0.12 h1:Rq+mNaHEVPVDgI+SywhCt1iLEolxf8kER3wFlwJDrWc=
+github.com/smartcontractkit/chain-selectors v1.0.12/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.2-0.20240311111125-22812a072c35 h1:GNhRKD3izyzAoGMXDvVUAwEuzz4Atdj3U3RH7eak5Is=
 github.com/smartcontractkit/chainlink-automation v1.0.2-0.20240311111125-22812a072c35/go.mod h1:2I0dWdYdK6jHPnSYYy7Y7Xp7L0YTnJ3KZtkhLQflsTU=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240319231131-2d0d99220a04 h1:SmnFGUhzfyHS8WdekapbVypFCAXXRqiBdTp6I4oFCV0=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -362,7 +362,7 @@ require (
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/smartcontractkit/caigo v0.0.0-20230621050857-b29a4ca8c704 // indirect
-	github.com/smartcontractkit/chain-selectors v1.0.11 // indirect
+	github.com/smartcontractkit/chain-selectors v1.0.12 // indirect
 	github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240213120401-01a23955f9f8 // indirect
 	github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 // indirect
 	github.com/smartcontractkit/chainlink-feeds v0.0.0-20240119021347-3c541a78cdb8 // indirect

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1491,8 +1491,8 @@ github.com/slack-go/slack v0.12.2 h1:x3OppyMyGIbbiyFhsBmpf9pwkUzMhthJMRNmNlA4LaQ
 github.com/slack-go/slack v0.12.2/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQdlMQKOw=
 github.com/smartcontractkit/caigo v0.0.0-20230621050857-b29a4ca8c704 h1:T3lFWumvbfM1u/etVq42Afwq/jtNSBSOA8n5jntnNPo=
 github.com/smartcontractkit/caigo v0.0.0-20230621050857-b29a4ca8c704/go.mod h1:2QuJdEouTWjh5BDy5o/vgGXQtR4Gz8yH1IYB5eT7u4M=
-github.com/smartcontractkit/chain-selectors v1.0.11 h1:9MmMdUPoMmQnAxQM/iEX6ARXpyFlM4CrcYI8hyaHskY=
-github.com/smartcontractkit/chain-selectors v1.0.11/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
+github.com/smartcontractkit/chain-selectors v1.0.12 h1:Rq+mNaHEVPVDgI+SywhCt1iLEolxf8kER3wFlwJDrWc=
+github.com/smartcontractkit/chain-selectors v1.0.12/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.2-0.20240311111125-22812a072c35 h1:GNhRKD3izyzAoGMXDvVUAwEuzz4Atdj3U3RH7eak5Is=
 github.com/smartcontractkit/chainlink-automation v1.0.2-0.20240311111125-22812a072c35/go.mod h1:2I0dWdYdK6jHPnSYYy7Y7Xp7L0YTnJ3KZtkhLQflsTU=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240319231131-2d0d99220a04 h1:SmnFGUhzfyHS8WdekapbVypFCAXXRqiBdTp6I4oFCV0=


### PR DESCRIPTION
## Motivation

To include latest selectors

## Solution