### PR TITLE
CCIP-1930 Fetching nonces in batch manner from chain

### DIFF
--- a/.changeset/cold-seals-listen.md
+++ b/.changeset/cold-seals-listen.md
@@ -1,0 +1,5 @@
+---
+"ccip": patch
+---
+
+Fetching nonces from chain instead of relying on inflight cache values

--- a/core/services/ocr2/plugins/ccip/ccipexec/helpers.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/helpers.go
@@ -1,0 +1,54 @@
+package ccipexec
+
+import (
+	"github.com/pkg/errors"
+
+	mapset "github.com/deckarep/golang-set/v2"
+
+	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccip"
+)
+
+// helper struct to hold the commitReport and the related send requests
+type commitReportWithSendRequests struct {
+	commitReport         cciptypes.CommitStoreReport
+	sendRequestsWithMeta []cciptypes.EVM2EVMOnRampCCIPSendRequestedWithMeta
+}
+
+func (r *commitReportWithSendRequests) validate() error {
+	// make sure that number of messages is the expected
+	if exp := int(r.commitReport.Interval.Max - r.commitReport.Interval.Min + 1); len(r.sendRequestsWithMeta) != exp {
+		return errors.Errorf(
+			"unexpected missing sendRequestsWithMeta in committed root %x have %d want %d", r.commitReport.MerkleRoot, len(r.sendRequestsWithMeta), exp)
+	}
+
+	return nil
+}
+
+// uniqueSenders returns slice of unique senders based on the send requests. Order is preserved based on the order of the send requests (by sequence number).
+func (r *commitReportWithSendRequests) uniqueSenders() []cciptypes.Address {
+	orderedUniqueSenders := make([]cciptypes.Address, 0, len(r.sendRequestsWithMeta))
+	visitedSenders := mapset.NewSet[cciptypes.Address]()
+
+	for _, req := range r.sendRequestsWithMeta {
+		if !visitedSenders.Contains(req.Sender) {
+			orderedUniqueSenders = append(orderedUniqueSenders, req.Sender)
+			visitedSenders.Add(req.Sender)
+		}
+	}
+	return orderedUniqueSenders
+}
+
+func (r *commitReportWithSendRequests) allRequestsAreExecutedAndFinalized() bool {
+	for _, req := range r.sendRequestsWithMeta {
+		if !req.Executed || !req.Finalized {
+			return false
+		}
+	}
+	return true
+}
+
+// checks if the send request fits the commit report interval
+func (r *commitReportWithSendRequests) sendReqFits(sendReq cciptypes.EVM2EVMOnRampCCIPSendRequestedWithMeta) bool {
+	return sendReq.SequenceNumber >= r.commitReport.Interval.Min &&
+		sendReq.SequenceNumber <= r.commitReport.Interval.Max
+}

--- a/core/services/ocr2/plugins/ccip/ccipexec/helpers_test.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/helpers_test.go
@@ -1,0 +1,96 @@
+package ccipexec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccip"
+
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/utils"
+)
+
+func Test_CommitReportWithSendRequests_uniqueSenders(t *testing.T) {
+	messageFn := func(address cciptypes.Address) cciptypes.EVM2EVMOnRampCCIPSendRequestedWithMeta {
+		return cciptypes.EVM2EVMOnRampCCIPSendRequestedWithMeta{EVM2EVMMessage: cciptypes.EVM2EVMMessage{Sender: address}}
+	}
+
+	tests := []struct {
+		name             string
+		sendRequests     []cciptypes.EVM2EVMOnRampCCIPSendRequestedWithMeta
+		expUniqueSenders int
+		expSendersOrder  []cciptypes.Address
+	}{
+		{
+			name: "all unique senders",
+			sendRequests: []cciptypes.EVM2EVMOnRampCCIPSendRequestedWithMeta{
+				messageFn(cciptypes.Address(utils.RandomAddress().String())),
+				messageFn(cciptypes.Address(utils.RandomAddress().String())),
+				messageFn(cciptypes.Address(utils.RandomAddress().String())),
+			},
+			expUniqueSenders: 3,
+		},
+		{
+			name: "some senders are the same",
+			sendRequests: []cciptypes.EVM2EVMOnRampCCIPSendRequestedWithMeta{
+				messageFn("0x1"),
+				messageFn("0x2"),
+				messageFn("0x1"),
+				messageFn("0x2"),
+				messageFn("0x3"),
+			},
+			expUniqueSenders: 3,
+			expSendersOrder: []cciptypes.Address{
+				cciptypes.Address("0x1"),
+				cciptypes.Address("0x2"),
+				cciptypes.Address("0x3"),
+			},
+		},
+		{
+			name: "all senders are the same",
+			sendRequests: []cciptypes.EVM2EVMOnRampCCIPSendRequestedWithMeta{
+				messageFn("0x1"),
+				messageFn("0x1"),
+				messageFn("0x1"),
+			},
+			expUniqueSenders: 1,
+			expSendersOrder: []cciptypes.Address{
+				cciptypes.Address("0x1"),
+			},
+		},
+		{
+			name: "order is preserved",
+			sendRequests: []cciptypes.EVM2EVMOnRampCCIPSendRequestedWithMeta{
+				messageFn("0x3"),
+				messageFn("0x1"),
+				messageFn("0x3"),
+				messageFn("0x2"),
+				messageFn("0x2"),
+				messageFn("0x1"),
+			},
+			expUniqueSenders: 3,
+			expSendersOrder: []cciptypes.Address{
+				cciptypes.Address("0x3"),
+				cciptypes.Address("0x1"),
+				cciptypes.Address("0x2"),
+			},
+		},
+		{
+			name:             "no senders",
+			sendRequests:     []cciptypes.EVM2EVMOnRampCCIPSendRequestedWithMeta{},
+			expUniqueSenders: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rep := commitReportWithSendRequests{sendRequestsWithMeta: tt.sendRequests}
+			uniqueSenders := rep.uniqueSenders()
+
+			assert.Len(t, uniqueSenders, tt.expUniqueSenders)
+			if tt.expSendersOrder != nil {
+				assert.Equal(t, tt.expSendersOrder, uniqueSenders)
+			}
+		})
+	}
+}

--- a/core/services/ocr2/plugins/ccip/ccipexec/ocr2_test.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/ocr2_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccip"
+
 	lpMocks "github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/utils"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
@@ -172,7 +173,10 @@ func TestExecutionReportingPlugin_Observation(t *testing.T) {
 				Return(executionEvents, nil).Maybe()
 			mockOffRampReader.On("CurrentRateLimiterState", mock.Anything).Return(tc.rateLimiterState, nil).Maybe()
 			mockOffRampReader.On("Address", ctx).Return(cciptypes.Address(offRamp.Address().String()), nil).Maybe()
-			mockOffRampReader.On("GetSenderNonce", mock.Anything, mock.Anything).Return(offRamp.GetSenderNonce(nil, utils.RandomAddress())).Maybe()
+			senderNonces := map[cciptypes.Address]uint64{
+				cciptypes.Address(utils.RandomAddress().String()): tc.senderNonce,
+			}
+			mockOffRampReader.On("GetSendersNonce", mock.Anything, mock.Anything).Return(senderNonces, nil).Maybe()
 			mockOffRampReader.On("GetTokenPoolsRateLimits", ctx, []ccipdata.TokenPoolReader{}).
 				Return([]cciptypes.TokenBucketRateLimit{}, nil).Maybe()
 
@@ -680,7 +684,7 @@ func TestExecutionReportingPlugin_buildBatch(t *testing.T) {
 
 			// Mock calls to reader.
 			mockOffRampReader := ccipdatamocks.NewOffRampReader(t)
-			mockOffRampReader.On("GetSenderNonce", mock.Anything, sender1).Return(uint64(0), nil).Maybe()
+			mockOffRampReader.On("GetSendersNonce", mock.Anything, mock.Anything).Return(tc.offRampNoncesBySender, nil).Maybe()
 
 			plugin := ExecutionReportingPlugin{
 				tokenDataWorker:   tokendata.NewBackgroundWorker(map[cciptypes.Address]tokendata.Reader{}, 10, 5*time.Second, time.Hour),
@@ -1511,7 +1515,7 @@ func Test_inflightAggregates(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			inflightSeqNrs, inflightAggrVal, maxInflightSenderNonces, inflightTokenAmounts, err := inflightAggregates(
+			inflightAggrVal, inflightTokenAmounts, err := inflightAggregates(
 				tc.inflight, tc.destTokenPrices, tc.sourceToDest)
 
 			if tc.expErr {
@@ -1519,9 +1523,7 @@ func Test_inflightAggregates(t *testing.T) {
 				return
 			}
 			assert.NoError(t, err)
-			assert.True(t, tc.expInflightSeqNrs.Equal(inflightSeqNrs))
 			assert.True(t, reflect.DeepEqual(tc.expInflightAggrVal, inflightAggrVal))
-			assert.True(t, reflect.DeepEqual(tc.expMaxInflightSenderNonces, maxInflightSenderNonces))
 			assert.True(t, reflect.DeepEqual(tc.expInflightTokenAmounts, inflightTokenAmounts))
 		})
 	}

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/mocks/offramp_reader_mock.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/mocks/offramp_reader_mock.go
@@ -326,6 +326,36 @@ func (_m *OffRampReader) GetSenderNonce(ctx context.Context, sender ccip.Address
 	return r0, r1
 }
 
+// GetSendersNonce provides a mock function with given fields: ctx, senders
+func (_m *OffRampReader) GetSendersNonce(ctx context.Context, senders []ccip.Address) (map[ccip.Address]uint64, error) {
+	ret := _m.Called(ctx, senders)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetSendersNonce")
+	}
+
+	var r0 map[ccip.Address]uint64
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, []ccip.Address) (map[ccip.Address]uint64, error)); ok {
+		return rf(ctx, senders)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, []ccip.Address) map[ccip.Address]uint64); ok {
+		r0 = rf(ctx, senders)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[ccip.Address]uint64)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, []ccip.Address) error); ok {
+		r1 = rf(ctx, senders)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetSourceToDestTokensMapping provides a mock function with given fields: ctx
 func (_m *OffRampReader) GetSourceToDestTokensMapping(ctx context.Context) (map[ccip.Address]ccip.Address, error) {
 	ret := _m.Called(ctx)

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/offramp_reader.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/offramp_reader.go
@@ -1,6 +1,10 @@
 package ccipdata
 
-import cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccip"
+import (
+	"context"
+
+	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccip"
+)
 
 const (
 	ManuallyExecute = "manuallyExecute"
@@ -9,4 +13,6 @@ const (
 //go:generate mockery --quiet --name OffRampReader --filename offramp_reader_mock.go --case=underscore
 type OffRampReader interface {
 	cciptypes.OffRampReader
+	//TODO Move to chainlink-common
+	GetSendersNonce(ctx context.Context, senders []cciptypes.Address) (map[cciptypes.Address]uint64, error)
 }

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_0_0/offramp.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_0_0/offramp.go
@@ -17,6 +17,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/config"
 
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccip"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipcalc"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/logpollerutil"
 
@@ -191,6 +192,40 @@ func (o *OffRamp) GetSenderNonce(ctx context.Context, sender cciptypes.Address) 
 		return 0, err
 	}
 	return o.offRampV100.GetSenderNonce(&bind.CallOpts{Context: ctx}, evmAddr)
+}
+
+func (o *OffRamp) GetSendersNonce(ctx context.Context, senders []cciptypes.Address) (map[cciptypes.Address]uint64, error) {
+	evmSenders, err := ccipcalc.GenericAddrsToEvm(senders...)
+	if err != nil {
+		return nil, err
+	}
+
+	evmCalls := make([]rpclib.EvmCall, 0, len(evmSenders))
+	for _, evmAddr := range evmSenders {
+		evmCalls = append(evmCalls, rpclib.NewEvmCall(
+			abiOffRamp,
+			"GetSenderNonce",
+			evmAddr,
+		))
+	}
+
+	results, err := o.evmBatchCaller.BatchCall(ctx, 0, evmCalls)
+	if err != nil {
+		return nil, err
+	}
+
+	nonces, err := rpclib.ParseOutputs[uint64](results, func(d rpclib.DataAndErr) (uint64, error) {
+		return rpclib.ParseOutput[uint64](d, 0)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	senderNonce := make(map[cciptypes.Address]uint64, len(senders))
+	for i, sender := range senders {
+		senderNonce[sender] = nonces[i]
+	}
+	return senderNonce, nil
 }
 
 func (o *OffRamp) CurrentRateLimiterState(ctx context.Context) (cciptypes.TokenBucketRateLimit, error) {

--- a/core/services/ocr2/plugins/ccip/internal/observability/offramp.go
+++ b/core/services/ocr2/plugins/ccip/internal/observability/offramp.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccip"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipdata"
 )
 
@@ -64,5 +65,11 @@ func (o *ObservedOffRampReader) GetSourceToDestTokensMapping(ctx context.Context
 func (o *ObservedOffRampReader) GetTokens(ctx context.Context) (cciptypes.OffRampTokens, error) {
 	return withObservedInteraction(o.metric, "GetTokens", func() (cciptypes.OffRampTokens, error) {
 		return o.OffRampReader.GetTokens(ctx)
+	})
+}
+
+func (o *ObservedOffRampReader) GetSendersNonce(ctx context.Context, senders []cciptypes.Address) (map[cciptypes.Address]uint64, error) {
+	return withObservedInteraction(o.metric, "GetSendersNonce", func() (map[cciptypes.Address]uint64, error) {
+		return o.OffRampReader.GetSendersNonce(ctx, senders)
 	})
 }


### PR DESCRIPTION
## Motivation

Increasing reliability of exec processing by enforcing getting fresh nonce per sender during Exec.

## Solution

Fetch nonces when building batch instead of relying on cache.
We increase reliability by executing on fresh data, which should reduce `IncorrectNonceSkip` errors. The drawback of this approach is increased RPC traffic because every observation always fetches nonces.

Nonces are fetched using `EvmBatchCaller`. Worst case scenario would be:
* 256 messages within a single Commit Root
* each message has a unique sender
`EvmBatchCaller` uses 100 request batches, so in this case it would fire 3 sequential RPC calls. (This could be further optimized by making EvmBatchCaller executing pages in parallel)
