### PR TITLE
Ccip 1908 configurable ocr params

### DIFF
--- a/integration-tests/ccip-tests/contracts/contract_deployer.go
+++ b/integration-tests/ccip-tests/contracts/contract_deployer.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"github.com/smartcontractkit/chainlink-common/pkg/config"
 	"golang.org/x/crypto/curve25519"
 
 	ocrconfighelper2 "github.com/smartcontractkit/libocr/offchainreporting2/confighelper"
@@ -725,27 +726,27 @@ func (e *CCIPContractsDeployer) NewMockAggregator(addr common.Address) (*MockAgg
 }
 
 var OCR2ParamsForCommit = contracts.OffChainAggregatorV2Config{
-	DeltaProgress:                           2 * time.Minute,
-	DeltaResend:                             5 * time.Second,
-	DeltaRound:                              75 * time.Second,
-	DeltaGrace:                              5 * time.Second,
-	MaxDurationQuery:                        100 * time.Millisecond,
-	MaxDurationObservation:                  35 * time.Second,
-	MaxDurationReport:                       10 * time.Second,
-	MaxDurationShouldAcceptFinalizedReport:  5 * time.Second,
-	MaxDurationShouldTransmitAcceptedReport: 10 * time.Second,
+	DeltaProgress:                           config.MustNewDuration(2 * time.Minute),
+	DeltaResend:                             config.MustNewDuration(5 * time.Second),
+	DeltaRound:                              config.MustNewDuration(75 * time.Second),
+	DeltaGrace:                              config.MustNewDuration(5 * time.Second),
+	MaxDurationQuery:                        config.MustNewDuration(100 * time.Millisecond),
+	MaxDurationObservation:                  config.MustNewDuration(35 * time.Second),
+	MaxDurationReport:                       config.MustNewDuration(10 * time.Second),
+	MaxDurationShouldAcceptFinalizedReport:  config.MustNewDuration(5 * time.Second),
+	MaxDurationShouldTransmitAcceptedReport: config.MustNewDuration(10 * time.Second),
 }
 
 var OCR2ParamsForExec = contracts.OffChainAggregatorV2Config{
-	DeltaProgress:                           100 * time.Second,
-	DeltaResend:                             5 * time.Second,
-	DeltaRound:                              40 * time.Second,
-	DeltaGrace:                              5 * time.Second,
-	MaxDurationQuery:                        100 * time.Millisecond,
-	MaxDurationObservation:                  20 * time.Second,
-	MaxDurationReport:                       8 * time.Second,
-	MaxDurationShouldAcceptFinalizedReport:  5 * time.Second,
-	MaxDurationShouldTransmitAcceptedReport: 8 * time.Second,
+	DeltaProgress:                           config.MustNewDuration(100 * time.Second),
+	DeltaResend:                             config.MustNewDuration(5 * time.Second),
+	DeltaRound:                              config.MustNewDuration(40 * time.Second),
+	DeltaGrace:                              config.MustNewDuration(5 * time.Second),
+	MaxDurationQuery:                        config.MustNewDuration(100 * time.Millisecond),
+	MaxDurationObservation:                  config.MustNewDuration(20 * time.Second),
+	MaxDurationReport:                       config.MustNewDuration(8 * time.Second),
+	MaxDurationShouldAcceptFinalizedReport:  config.MustNewDuration(5 * time.Second),
+	MaxDurationShouldTransmitAcceptedReport: config.MustNewDuration(8 * time.Second),
 }
 
 func OffChainAggregatorV2ConfigWithNodes(numberNodes int, inflightExpiry time.Duration, cfg contracts.OffChainAggregatorV2Config) contracts.OffChainAggregatorV2Config {
@@ -770,7 +771,7 @@ func OffChainAggregatorV2ConfigWithNodes(numberNodes int, inflightExpiry time.Du
 		DeltaResend:                             cfg.DeltaResend,
 		DeltaRound:                              cfg.DeltaRound,
 		DeltaGrace:                              cfg.DeltaGrace,
-		DeltaStage:                              inflightExpiry,
+		DeltaStage:                              config.MustNewDuration(inflightExpiry),
 		RMax:                                    3,
 		S:                                       s,
 		F:                                       faultyNodes,
@@ -855,20 +856,20 @@ func NewOffChainAggregatorV2ConfigForCCIPPlugin[T ccipconfig.OffchainConfig](
 	}
 
 	_, _, f_, onchainConfig_, offchainConfigVersion, offchainConfig, err = ocrconfighelper2.ContractSetConfigArgsForTests(
-		ocrConfig.DeltaProgress,
-		ocrConfig.DeltaResend,
-		ocrConfig.DeltaRound,
-		ocrConfig.DeltaGrace,
-		ocrConfig.DeltaStage,
+		ocrConfig.DeltaProgress.Duration(),
+		ocrConfig.DeltaResend.Duration(),
+		ocrConfig.DeltaRound.Duration(),
+		ocrConfig.DeltaGrace.Duration(),
+		ocrConfig.DeltaStage.Duration(),
 		ocrConfig.RMax,
 		ocrConfig.S,
 		ocrConfig.Oracles,
 		ocrConfig.ReportingPluginConfig,
-		ocrConfig.MaxDurationQuery,
-		ocrConfig.MaxDurationObservation,
-		ocrConfig.MaxDurationReport,
-		ocrConfig.MaxDurationShouldAcceptFinalizedReport,
-		ocrConfig.MaxDurationShouldTransmitAcceptedReport,
+		ocrConfig.MaxDurationQuery.Duration(),
+		ocrConfig.MaxDurationObservation.Duration(),
+		ocrConfig.MaxDurationReport.Duration(),
+		ocrConfig.MaxDurationShouldAcceptFinalizedReport.Duration(),
+		ocrConfig.MaxDurationShouldTransmitAcceptedReport.Duration(),
 		ocrConfig.F,
 		ocrConfig.OnchainConfig,
 	)

--- a/integration-tests/ccip-tests/contracts/contract_deployer.go
+++ b/integration-tests/ccip-tests/contracts/contract_deployer.go
@@ -15,8 +15,9 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
-	"github.com/smartcontractkit/chainlink-common/pkg/config"
 	"golang.org/x/crypto/curve25519"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/config"
 
 	ocrconfighelper2 "github.com/smartcontractkit/libocr/offchainreporting2/confighelper"
 	ocrtypes2 "github.com/smartcontractkit/libocr/offchainreporting2/types"

--- a/integration-tests/ccip-tests/testconfig/ccip.go
+++ b/integration-tests/ccip-tests/testconfig/ccip.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/config"
 
-	"github.com/smartcontractkit/ccip/integration-tests/contracts"
+	"github.com/smartcontractkit/chainlink/integration-tests/contracts"
 )
 
 type CCIPTestConfig struct {

--- a/integration-tests/ccip-tests/testconfig/ccip.go
+++ b/integration-tests/ccip-tests/testconfig/ccip.go
@@ -13,43 +13,49 @@ import (
 	ctfconfig "github.com/smartcontractkit/chainlink-testing-framework/config"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/config"
+
+	"github.com/smartcontractkit/ccip/integration-tests/contracts"
 )
 
 type CCIPTestConfig struct {
-	KeepEnvAlive               *bool              `toml:",omitempty"`
-	BiDirectionalLane          *bool              `toml:",omitempty"`
-	CommitAndExecuteOnSameDON  *bool              `toml:",omitempty"`
-	NoOfCommitNodes            int                `toml:",omitempty"`
-	MsgType                    string             `toml:",omitempty"`
-	DestGasLimit               *int64             `toml:",omitempty"`
-	MulticallInOneTx           *bool              `toml:",omitempty"`
-	NoOfSendsInMulticall       int                `toml:",omitempty"`
-	PhaseTimeout               *config.Duration   `toml:",omitempty"`
-	TestDuration               *config.Duration   `toml:",omitempty"`
-	LocalCluster               *bool              `toml:",omitempty"`
-	ExistingDeployment         *bool              `toml:",omitempty"`
-	TestRunName                string             `toml:",omitempty"`
-	ReuseContracts             *bool              `toml:",omitempty"`
-	NodeFunding                float64            `toml:",omitempty"`
-	RequestPerUnitTime         []int64            `toml:",omitempty"`
-	TimeUnit                   *config.Duration   `toml:",omitempty"`
-	StepDuration               []*config.Duration `toml:",omitempty"`
-	WaitBetweenChaosDuringLoad *config.Duration   `toml:",omitempty"`
-	NetworkPairs               []string           `toml:",omitempty"`
-	NoOfNetworks               int                `toml:",omitempty"`
-	NoOfRoutersPerPair         int                `toml:",omitempty"`
-	Blockscout                 bool               `toml:",omitempty"`
-	NoOfTokensPerChain         int                `toml:",omitempty"`
-	NoOfTokensInMsg            int                `toml:",omitempty"`
-	AmountPerToken             int64              `toml:",omitempty"`
-	MaxNoOfLanes               int                `toml:",omitempty"`
-	ChaosDuration              *config.Duration   `toml:",omitempty"`
-	USDCMockDeployment         *bool              `toml:",omitempty"`
-	TimeoutForPriceUpdate      *config.Duration   `toml:",omitempty"`
-	WithPipeline               *bool              `toml:",omitempty"`
-	FailOnFirstErrorInLoad     *bool              `toml:",omitempty"`
-	DynamicPriceUpdateInterval *config.Duration   `toml:",omitempty"`
-	SendMaxDataInEveryMsgCount *int64             `toml:",omitempty"`
+	KeepEnvAlive               *bool                                 `toml:",omitempty"`
+	BiDirectionalLane          *bool                                 `toml:",omitempty"`
+	CommitAndExecuteOnSameDON  *bool                                 `toml:",omitempty"`
+	NoOfCommitNodes            int                                   `toml:",omitempty"`
+	MsgType                    string                                `toml:",omitempty"`
+	DestGasLimit               *int64                                `toml:",omitempty"`
+	MulticallInOneTx           *bool                                 `toml:",omitempty"`
+	NoOfSendsInMulticall       int                                   `toml:",omitempty"`
+	PhaseTimeout               *config.Duration                      `toml:",omitempty"`
+	TestDuration               *config.Duration                      `toml:",omitempty"`
+	LocalCluster               *bool                                 `toml:",omitempty"`
+	ExistingDeployment         *bool                                 `toml:",omitempty"`
+	TestRunName                string                                `toml:",omitempty"`
+	ReuseContracts             *bool                                 `toml:",omitempty"`
+	NodeFunding                float64                               `toml:",omitempty"`
+	RequestPerUnitTime         []int64                               `toml:",omitempty"`
+	TimeUnit                   *config.Duration                      `toml:",omitempty"`
+	StepDuration               []*config.Duration                    `toml:",omitempty"`
+	WaitBetweenChaosDuringLoad *config.Duration                      `toml:",omitempty"`
+	NetworkPairs               []string                              `toml:",omitempty"`
+	NoOfNetworks               int                                   `toml:",omitempty"`
+	NoOfRoutersPerPair         int                                   `toml:",omitempty"`
+	Blockscout                 bool                                  `toml:",omitempty"`
+	NoOfTokensPerChain         int                                   `toml:",omitempty"`
+	NoOfTokensInMsg            int                                   `toml:",omitempty"`
+	AmountPerToken             int64                                 `toml:",omitempty"`
+	MaxNoOfLanes               int                                   `toml:",omitempty"`
+	ChaosDuration              *config.Duration                      `toml:",omitempty"`
+	USDCMockDeployment         *bool                                 `toml:",omitempty"`
+	TimeoutForPriceUpdate      *config.Duration                      `toml:",omitempty"`
+	WithPipeline               *bool                                 `toml:",omitempty"`
+	FailOnFirstErrorInLoad     *bool                                 `toml:",omitempty"`
+	DynamicPriceUpdateInterval *config.Duration                      `toml:",omitempty"`
+	SendMaxDataInEveryMsgCount *int64                                `toml:",omitempty"`
+	CommitOCRParams            *contracts.OffChainAggregatorV2Config `toml:",omitempty"`
+	ExecOCRParams              *contracts.OffChainAggregatorV2Config `toml:",omitempty"`
+	CommitInflightExpiry       *config.Duration                      `toml:",omitempty"`
+	ExecInflightExpiry         *config.Duration                      `toml:",omitempty"`
 }
 
 func (c *CCIPTestConfig) SetTestRunName(name string) {

--- a/integration-tests/ccip-tests/testconfig/tomls/ccip-default.toml
+++ b/integration-tests/ccip-tests/testconfig/tomls/ccip-default.toml
@@ -252,6 +252,32 @@ TimeoutForPriceUpdate = '15m'          # Duration to wait for the price update t
 # Could be removed once the pipeline is completely removed.
 WithPipeline = false
 
+# OCR Params
+CommitInflightExpiry = '2m'
+ExecInflightExpiry = '2m'
+
+[CCIP.Groups.smoke.CommitOCRParams]
+DeltaProgress = '2m'
+DeltaResend = '5s'
+DeltaRound = '75s'
+DeltaGrace = '5s'
+MaxDurationQuery = '100ms'
+MaxDurationObservation = '35s'
+MaxDurationReport = '10s'
+MaxDurationShouldAcceptFinalizedReport = '5s'
+MaxDurationShouldTransmitAcceptedReport = '10s'
+
+[CCIP.Groups.smoke.ExecOCRParams]
+DeltaProgress = '100s'
+DeltaResend = '5s'
+DeltaRound = '40s'
+DeltaGrace = '5s'
+MaxDurationQuery = '100ms'
+MaxDurationObservation = '20s'
+MaxDurationReport = '8s'
+MaxDurationShouldAcceptFinalizedReport = '5s'
+MaxDurationShouldTransmitAcceptedReport = '8s'
+
 # uncomment the following if you want to run your tests with specific number of lanes;
 # in this case out of all the possible lane combinations, only the ones with the specified number of lanes will be considered
 # for example, if you have provided CCIP.Env.Networks = ['SIMULATED_1', 'SIMULATED_2', 'SIMULATED_3'] and CCIP.Groups.<test_type>.MaxNoOfLanes = 2,

--- a/integration-tests/ccip-tests/testsetups/ccip.go
+++ b/integration-tests/ccip-tests/testsetups/ccip.go
@@ -37,6 +37,7 @@ import (
 	"github.com/smartcontractkit/chainlink-testing-framework/networks"
 
 	"github.com/smartcontractkit/ccip/integration-tests/ccip-tests/contracts"
+
 	integrationactions "github.com/smartcontractkit/chainlink/integration-tests/actions"
 	"github.com/smartcontractkit/chainlink/integration-tests/ccip-tests/actions"
 	"github.com/smartcontractkit/chainlink/integration-tests/ccip-tests/contracts/laneconfig"

--- a/integration-tests/ccip-tests/testsetups/ccip.go
+++ b/integration-tests/ccip-tests/testsetups/ccip.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"dario.cat/mergo"
 	"github.com/AlekSi/pointer"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
@@ -35,6 +36,7 @@ import (
 	"github.com/smartcontractkit/chainlink-testing-framework/k8s/environment"
 	"github.com/smartcontractkit/chainlink-testing-framework/networks"
 
+	"github.com/smartcontractkit/ccip/integration-tests/ccip-tests/contracts"
 	integrationactions "github.com/smartcontractkit/chainlink/integration-tests/actions"
 	"github.com/smartcontractkit/chainlink/integration-tests/ccip-tests/actions"
 	"github.com/smartcontractkit/chainlink/integration-tests/ccip-tests/contracts/laneconfig"
@@ -198,6 +200,10 @@ func (c *CCIPTestConfig) SetNetworkPairs(lggr zerolog.Logger) error {
 		}
 		for i := 0; i < c.TestGroupInput.NoOfNetworks-actualNoOfNetworks; i++ {
 			chainID := chainIDs[i]
+			// if i is greater than the number of simulated pvt keys, rotate the keys
+			if i > len(networks.AdditionalSimulatedPvtKeys)-1 {
+				networks.AdditionalSimulatedPvtKeys = append(networks.AdditionalSimulatedPvtKeys, networks.AdditionalSimulatedPvtKeys...)
+			}
 			c.SelectedNetworks = append(c.SelectedNetworks, blockchain.EVMNetwork{
 				Name:                      fmt.Sprintf("simulated-non-dev%d", len(c.SelectedNetworks)+1),
 				ChainID:                   chainID,
@@ -259,6 +265,28 @@ func (c *CCIPTestConfig) FormNetworkPairCombinations() {
 	}
 }
 
+func (c *CCIPTestConfig) SetOCRParams() error {
+	if c.TestGroupInput.CommitOCRParams != nil {
+		err := mergo.Merge(contracts.OCR2ParamsForCommit, c.TestGroupInput.CommitOCRParams, mergo.WithOverride)
+		if err != nil {
+			return err
+		}
+	}
+	if c.TestGroupInput.ExecOCRParams != nil {
+		err := mergo.Merge(contracts.OCR2ParamsForExec, c.TestGroupInput.ExecOCRParams, mergo.WithOverride)
+		if err != nil {
+			return err
+		}
+	}
+	if c.TestGroupInput.ExecInflightExpiry != nil && c.TestGroupInput.ExecInflightExpiry.Duration() > 0 {
+		actions.InflightExpiryExec = c.TestGroupInput.ExecInflightExpiry.Duration()
+	}
+	if c.TestGroupInput.CommitInflightExpiry != nil && c.TestGroupInput.CommitInflightExpiry.Duration() > 0 {
+		actions.InflightExpiryCommit = c.TestGroupInput.CommitInflightExpiry.Duration()
+	}
+	return nil
+}
+
 func NewCCIPTestConfig(t *testing.T, lggr zerolog.Logger, tType string) *CCIPTestConfig {
 	testCfg := testconfig.GlobalTestConfig()
 	groupCfg, exists := testCfg.CCIP.Groups[tType]
@@ -280,7 +308,11 @@ func NewCCIPTestConfig(t *testing.T, lggr zerolog.Logger, tType string) *CCIPTes
 		TestGroupInput:      groupCfg,
 		GethResourceProfile: GethResourceProfile,
 	}
-	err := ccipTestConfig.SetNetworkPairs(lggr)
+	err := ccipTestConfig.SetOCRParams()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ccipTestConfig.SetNetworkPairs(lggr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -926,11 +958,11 @@ func (o *CCIPTestSetUpOutputs) CreateEnvironment(
 	if pointer.GetBool(testConfig.TestGroupInput.LocalCluster) {
 		require.NotNil(t, ccipEnv.LocalCluster, "Local cluster shouldn't be nil")
 		for _, n := range ccipEnv.LocalCluster.EVMNetworks {
-			if evmClient, err := ccipEnv.LocalCluster.GetEVMClient(n.ChainID); err == nil {
+			if evmClient, err := blockchain.NewEVMClientFromNetwork(*n, lggr); err == nil {
 				chainByChainID[evmClient.GetChainID().Int64()] = evmClient
 				chains = append(chains, evmClient)
 			} else {
-				lggr.Error().Msgf("EVMClient for chainID %d not found", n.ChainID)
+				lggr.Error().Err(err).Msgf("EVMClient for chainID %d not found", n.ChainID)
 			}
 		}
 	} else {

--- a/integration-tests/ccip-tests/testsetups/ccip.go
+++ b/integration-tests/ccip-tests/testsetups/ccip.go
@@ -267,13 +267,13 @@ func (c *CCIPTestConfig) FormNetworkPairCombinations() {
 
 func (c *CCIPTestConfig) SetOCRParams() error {
 	if c.TestGroupInput.CommitOCRParams != nil {
-		err := mergo.Merge(contracts.OCR2ParamsForCommit, c.TestGroupInput.CommitOCRParams, mergo.WithOverride)
+		err := mergo.Merge(&contracts.OCR2ParamsForCommit, c.TestGroupInput.CommitOCRParams, mergo.WithOverride)
 		if err != nil {
 			return err
 		}
 	}
 	if c.TestGroupInput.ExecOCRParams != nil {
-		err := mergo.Merge(contracts.OCR2ParamsForExec, c.TestGroupInput.ExecOCRParams, mergo.WithOverride)
+		err := mergo.Merge(&contracts.OCR2ParamsForExec, c.TestGroupInput.ExecOCRParams, mergo.WithOverride)
 		if err != nil {
 			return err
 		}

--- a/integration-tests/ccip-tests/testsetups/test_env.go
+++ b/integration-tests/ccip-tests/testsetups/test_env.go
@@ -229,6 +229,10 @@ func DeployLocalCluster(
 		require.NoError(t, err, "Error getting rpc provider")
 		selectedNetworks[i].URLs = rpcProvider.PrivateWsUrsl()
 		selectedNetworks[i].HTTPURLs = rpcProvider.PrivateHttpUrls()
+		newNetwork := networkCfg
+		newNetwork.URLs = rpcProvider.PublicWsUrls()
+		newNetwork.HTTPURLs = rpcProvider.PublicHttpUrls()
+		env.EVMNetworks = append(env.EVMNetworks, &newNetwork)
 	}
 	testInputs.SelectedNetworks = selectedNetworks
 

--- a/integration-tests/contracts/contract_models.go
+++ b/integration-tests/contracts/contract_models.go
@@ -8,11 +8,12 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/smartcontractkit/chainlink-common/pkg/config"
 	"github.com/smartcontractkit/libocr/gethwrappers/offchainaggregator"
 	"github.com/smartcontractkit/libocr/gethwrappers2/ocr2aggregator"
 	ocrConfigHelper "github.com/smartcontractkit/libocr/offchainreporting/confighelper"
 	ocrConfigHelper2 "github.com/smartcontractkit/libocr/offchainreporting2plus/confighelper"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/config"
 
 	"github.com/smartcontractkit/chainlink/integration-tests/client"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/flux_aggregator_wrapper"

--- a/integration-tests/contracts/contract_models.go
+++ b/integration-tests/contracts/contract_models.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/config"
 	"github.com/smartcontractkit/libocr/gethwrappers/offchainaggregator"
 	"github.com/smartcontractkit/libocr/gethwrappers2/ocr2aggregator"
 	ocrConfigHelper "github.com/smartcontractkit/libocr/offchainreporting/confighelper"
@@ -112,22 +113,22 @@ type OffChainAggregatorConfig struct {
 }
 
 type OffChainAggregatorV2Config struct {
-	DeltaProgress                           time.Duration
-	DeltaResend                             time.Duration
-	DeltaRound                              time.Duration
-	DeltaGrace                              time.Duration
-	DeltaStage                              time.Duration
-	RMax                                    uint8
-	S                                       []int
-	Oracles                                 []ocrConfigHelper2.OracleIdentityExtra
-	ReportingPluginConfig                   []byte
-	MaxDurationQuery                        time.Duration
-	MaxDurationObservation                  time.Duration
-	MaxDurationReport                       time.Duration
-	MaxDurationShouldAcceptFinalizedReport  time.Duration
-	MaxDurationShouldTransmitAcceptedReport time.Duration
-	F                                       int
-	OnchainConfig                           []byte
+	DeltaProgress                           *config.Duration                       `toml:",omitempty"`
+	DeltaResend                             *config.Duration                       `toml:",omitempty"`
+	DeltaRound                              *config.Duration                       `toml:",omitempty"`
+	DeltaGrace                              *config.Duration                       `toml:",omitempty"`
+	DeltaStage                              *config.Duration                       `toml:",omitempty"`
+	RMax                                    uint8                                  `toml:"-"`
+	S                                       []int                                  `toml:"-"`
+	Oracles                                 []ocrConfigHelper2.OracleIdentityExtra `toml:"-"`
+	ReportingPluginConfig                   []byte                                 `toml:"-"`
+	MaxDurationQuery                        *config.Duration                       `toml:",omitempty"`
+	MaxDurationObservation                  *config.Duration                       `toml:",omitempty"`
+	MaxDurationReport                       *config.Duration                       `toml:",omitempty"`
+	MaxDurationShouldAcceptFinalizedReport  *config.Duration                       `toml:",omitempty"`
+	MaxDurationShouldTransmitAcceptedReport *config.Duration                       `toml:",omitempty"`
+	F                                       int                                    `toml:"-"`
+	OnchainConfig                           []byte                                 `toml:"-"`
 }
 
 type OffchainAggregatorData struct {

--- a/integration-tests/docker/test_env/test_env.go
+++ b/integration-tests/docker/test_env/test_env.go
@@ -18,6 +18,7 @@ import (
 	"github.com/smartcontractkit/chainlink-testing-framework/logging"
 	"github.com/smartcontractkit/chainlink-testing-framework/logstream"
 	"github.com/smartcontractkit/chainlink-testing-framework/utils/runid"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 
 	actions_seth "github.com/smartcontractkit/chainlink/integration-tests/actions/seth"

--- a/integration-tests/docker/test_env/test_env_builder.go
+++ b/integration-tests/docker/test_env/test_env_builder.go
@@ -293,23 +293,12 @@ func (b *CLTestEnvBuilder) Build() (*CLClusterTestEnv, error) {
 		b.te.evmClients = make(map[int64]blockchain.EVMClient)
 		for _, en := range b.privateEthereumNetworks {
 			en.DockerNetworkNames = []string{b.te.DockerNetwork.Name}
-			networkConfig, rpcProvider, err := b.te.StartEthereumNetwork(en)
+			_, rpcProvider, err := b.te.StartEthereumNetwork(en)
 			if err != nil {
 				return nil, err
 			}
 
-			//TODO remove after fixing in CTF
-			networkConfig.ChainID = int64(en.EthereumChainConfig.ChainID)
-
-			evmClient, err := blockchain.NewEVMClientFromNetwork(networkConfig, b.l)
-			if err != nil {
-				return nil, err
-			}
-
-			b.te.rpcProviders[networkConfig.ChainID] = &rpcProvider
-			b.te.EVMNetworks = append(b.te.EVMNetworks, &networkConfig)
-			b.te.evmClients[networkConfig.ChainID] = evmClient
-
+			b.te.rpcProviders[int64(en.EthereumChainConfig.ChainID)] = &rpcProvider
 		}
 		err = b.te.StartClCluster(b.clNodeConfig, b.clNodesCount, b.secretsConfig, b.testConfig, b.clNodesOpts...)
 		if err != nil {

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -6,6 +6,7 @@ go 1.21.7
 replace github.com/smartcontractkit/chainlink/v2 => ../
 
 require (
+	dario.cat/mergo v1.0.0
 	github.com/AlekSi/pointer v1.1.0
 	github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df
 	github.com/cli/go-gh/v2 v2.0.0
@@ -67,7 +68,6 @@ require (
 	cosmossdk.io/depinject v1.0.0-alpha.3 // indirect
 	cosmossdk.io/errors v1.0.0 // indirect
 	cosmossdk.io/math v1.0.1 // indirect
-	dario.cat/mergo v1.0.0 // indirect
 	filippo.io/edwards25519 v1.0.0 // indirect
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
 	github.com/99designs/keyring v1.2.1 // indirect


### PR DESCRIPTION
## Motivation
Need to tweak OCR Params to test load on diff OCR value combo

## Solution

This should make a way to update the OCR Params through test input toml - 
If you don't provide anything - default values are - 
[OCRForCommit](https://github.com/smartcontractkit/ccip/blob/ccip-1908-configurable-OCR-Params/integration-tests/ccip-tests/contracts/contract_deployer.go#L728) 
[OCRForExec](https://github.com/smartcontractkit/ccip/blob/ccip-1908-configurable-OCR-Params/integration-tests/ccip-tests/contracts/contract_deployer.go#L740)
[InflightExec
InflightCommit](https://github.com/smartcontractkit/ccip/blob/ccip-1908-configurable-OCR-Params/integration-tests/ccip-tests/actions/ccip_helpers.go#L96-L97)