### PR TITLE
CCIP-1965 Add self rate limiting to the usdc attestation API.

### DIFF
--- a/.changeset/twelve-donuts-sell.md
+++ b/.changeset/twelve-donuts-sell.md
@@ -1,0 +1,5 @@
+---
+"ccip": minor
+---
+
+Proactive rate limiting for USDC attestation API.

--- a/core/services/ocr2/plugins/ccip/ccipexec/initializers.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/initializers.go
@@ -12,9 +12,10 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/pkg/errors"
+	"go.uber.org/multierr"
+
 	chainselectors "github.com/smartcontractkit/chain-selectors"
 	libocr2 "github.com/smartcontractkit/libocr/offchainreporting2plus"
-	"go.uber.org/multierr"
 
 	commonlogger "github.com/smartcontractkit/chainlink-common/pkg/logger"
 
@@ -160,6 +161,7 @@ func initTokenDataProviders(lggr logger.Logger, jobID string, pluginConfig ccipc
 				attestationURI,
 				pluginConfig.USDCConfig.AttestationAPITimeoutSeconds,
 				pluginConfig.USDCConfig.SourceTokenAddress,
+				usdc.RequestInterval,
 			)
 	}
 

--- a/core/services/ocr2/plugins/ccip/ccipexec/initializers.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/initializers.go
@@ -159,9 +159,9 @@ func initTokenDataProviders(lggr logger.Logger, jobID string, pluginConfig ccipc
 				lggr,
 				usdcReader,
 				attestationURI,
-				pluginConfig.USDCConfig.AttestationAPITimeoutSeconds,
+				int(pluginConfig.USDCConfig.AttestationAPITimeoutSeconds),
 				pluginConfig.USDCConfig.SourceTokenAddress,
-				usdc.RequestInterval,
+				time.Duration(pluginConfig.USDCConfig.AttestationAPIIntervalMilliseconds)*time.Millisecond,
 			)
 	}
 

--- a/core/services/ocr2/plugins/ccip/config/config.go
+++ b/core/services/ocr2/plugins/ccip/config/config.go
@@ -98,16 +98,20 @@ type ExecutionPluginJobSpecConfig struct {
 }
 
 type USDCConfig struct {
-	SourceTokenAddress                 common.Address
-	SourceMessageTransmitterAddress    common.Address
-	AttestationAPI                     string
-	AttestationAPITimeoutSeconds       uint
-	AttestationAPIIntervalMilliseconds uint
+	SourceTokenAddress              common.Address
+	SourceMessageTransmitterAddress common.Address
+	AttestationAPI                  string
+	AttestationAPITimeoutSeconds    uint
+	// AttestationAPIIntervalMilliseconds can be set to -1 to disable or 0 to use a default interval.
+	AttestationAPIIntervalMilliseconds int
 }
 
 func (uc *USDCConfig) ValidateUSDCConfig() error {
 	if uc.AttestationAPI == "" {
 		return errors.New("AttestationAPI is required")
+	}
+	if uc.AttestationAPIIntervalMilliseconds < -1 {
+		return errors.New("AttestationAPIIntervalMilliseconds must be -1 to disable, 0 for default or greater to define the exact interval")
 	}
 	if uc.SourceTokenAddress == utils.ZeroAddress {
 		return errors.New("SourceTokenAddress is required")

--- a/core/services/ocr2/plugins/ccip/config/config.go
+++ b/core/services/ocr2/plugins/ccip/config/config.go
@@ -98,18 +98,16 @@ type ExecutionPluginJobSpecConfig struct {
 }
 
 type USDCConfig struct {
-	SourceTokenAddress              common.Address
-	SourceMessageTransmitterAddress common.Address
-	AttestationAPI                  string
-	AttestationAPITimeoutSeconds    int
+	SourceTokenAddress                 common.Address
+	SourceMessageTransmitterAddress    common.Address
+	AttestationAPI                     string
+	AttestationAPITimeoutSeconds       uint
+	AttestationAPIIntervalMilliseconds uint
 }
 
 func (uc *USDCConfig) ValidateUSDCConfig() error {
 	if uc.AttestationAPI == "" {
 		return errors.New("AttestationAPI is required")
-	}
-	if uc.AttestationAPITimeoutSeconds < 0 {
-		return errors.New("AttestationAPITimeoutSeconds must be non-negative")
 	}
 	if uc.SourceTokenAddress == utils.ZeroAddress {
 		return errors.New("SourceTokenAddress is required")

--- a/core/services/ocr2/plugins/ccip/config/config_test.go
+++ b/core/services/ocr2/plugins/ccip/config/config_test.go
@@ -189,15 +189,6 @@ func TestUSDCValidate(t *testing.T) {
 			},
 			err: "",
 		},
-		{
-			config: USDCConfig{
-				AttestationAPI:                  "api",
-				SourceTokenAddress:              utils.RandomAddress(),
-				SourceMessageTransmitterAddress: utils.RandomAddress(),
-				AttestationAPITimeoutSeconds:    -1,
-			},
-			err: "AttestationAPITimeoutSeconds must be non-negative",
-		},
 	}
 
 	for _, tc := range testcases {

--- a/core/services/ocr2/plugins/ccip/tokendata/observability/usdc_client_test.go
+++ b/core/services/ocr2/plugins/ccip/tokendata/observability/usdc_client_test.go
@@ -89,7 +89,7 @@ func testMonitoring(t *testing.T, name string, server *httptest.Server, requests
 	// Service with monitored http client.
 	usdcTokenAddr := utils.RandomAddress()
 	observedHttpClient := http2.NewObservedIHttpClientWithMetric(&http2.HttpClient{}, histogram)
-	tokenDataReaderDefault := usdc.NewUSDCTokenDataReader(log, usdcReader, attestationURI, 0, usdcTokenAddr)
+	tokenDataReaderDefault := usdc.NewUSDCTokenDataReader(log, usdcReader, attestationURI, 0, usdcTokenAddr, 0)
 	tokenDataReader := usdc.NewUSDCTokenDataReaderWithHttpClient(*tokenDataReaderDefault, observedHttpClient, usdcTokenAddr)
 	require.NotNil(t, tokenDataReader)
 

--- a/core/services/ocr2/plugins/ccip/tokendata/observability/usdc_client_test.go
+++ b/core/services/ocr2/plugins/ccip/tokendata/observability/usdc_client_test.go
@@ -89,8 +89,8 @@ func testMonitoring(t *testing.T, name string, server *httptest.Server, requests
 	// Service with monitored http client.
 	usdcTokenAddr := utils.RandomAddress()
 	observedHttpClient := http2.NewObservedIHttpClientWithMetric(&http2.HttpClient{}, histogram)
-	tokenDataReaderDefault := usdc.NewUSDCTokenDataReader(log, usdcReader, attestationURI, 0, usdcTokenAddr, 0)
-	tokenDataReader := usdc.NewUSDCTokenDataReaderWithHttpClient(*tokenDataReaderDefault, observedHttpClient, usdcTokenAddr, 0)
+	tokenDataReaderDefault := usdc.NewUSDCTokenDataReader(log, usdcReader, attestationURI, 0, usdcTokenAddr, -1)
+	tokenDataReader := usdc.NewUSDCTokenDataReaderWithHttpClient(*tokenDataReaderDefault, observedHttpClient, usdcTokenAddr, -1)
 	require.NotNil(t, tokenDataReader)
 
 	for i := 0; i < requests; i++ {

--- a/core/services/ocr2/plugins/ccip/tokendata/observability/usdc_client_test.go
+++ b/core/services/ocr2/plugins/ccip/tokendata/observability/usdc_client_test.go
@@ -90,7 +90,7 @@ func testMonitoring(t *testing.T, name string, server *httptest.Server, requests
 	usdcTokenAddr := utils.RandomAddress()
 	observedHttpClient := http2.NewObservedIHttpClientWithMetric(&http2.HttpClient{}, histogram)
 	tokenDataReaderDefault := usdc.NewUSDCTokenDataReader(log, usdcReader, attestationURI, 0, usdcTokenAddr, 0)
-	tokenDataReader := usdc.NewUSDCTokenDataReaderWithHttpClient(*tokenDataReaderDefault, observedHttpClient, usdcTokenAddr)
+	tokenDataReader := usdc.NewUSDCTokenDataReaderWithHttpClient(*tokenDataReaderDefault, observedHttpClient, usdcTokenAddr, 0)
 	require.NotNil(t, tokenDataReader)
 
 	for i := 0; i < requests; i++ {

--- a/core/services/ocr2/plugins/ccip/tokendata/observability/usdc_client_test.go
+++ b/core/services/ocr2/plugins/ccip/tokendata/observability/usdc_client_test.go
@@ -89,8 +89,8 @@ func testMonitoring(t *testing.T, name string, server *httptest.Server, requests
 	// Service with monitored http client.
 	usdcTokenAddr := utils.RandomAddress()
 	observedHttpClient := http2.NewObservedIHttpClientWithMetric(&http2.HttpClient{}, histogram)
-	tokenDataReaderDefault := usdc.NewUSDCTokenDataReader(log, usdcReader, attestationURI, 0, usdcTokenAddr, -1)
-	tokenDataReader := usdc.NewUSDCTokenDataReaderWithHttpClient(*tokenDataReaderDefault, observedHttpClient, usdcTokenAddr, -1)
+	tokenDataReaderDefault := usdc.NewUSDCTokenDataReader(log, usdcReader, attestationURI, 0, usdcTokenAddr, usdc.APIIntervalRateLimitDisabled)
+	tokenDataReader := usdc.NewUSDCTokenDataReaderWithHttpClient(*tokenDataReaderDefault, observedHttpClient, usdcTokenAddr, usdc.APIIntervalRateLimitDisabled)
 	require.NotNil(t, tokenDataReader)
 
 	for i := 0; i < requests; i++ {

--- a/core/services/ocr2/plugins/ccip/tokendata/reader.go
+++ b/core/services/ocr2/plugins/ccip/tokendata/reader.go
@@ -9,6 +9,7 @@ import (
 var (
 	ErrNotReady        = errors.New("token data not ready")
 	ErrRateLimit       = errors.New("token data API is being rate limited")
+	ErrSelfRateLimit   = errors.New("token data API is being self rate limited")
 	ErrTimeout         = errors.New("token data API timed out")
 	ErrRequestsBlocked = errors.New("requests are currently blocked")
 )

--- a/core/services/ocr2/plugins/ccip/tokendata/reader.go
+++ b/core/services/ocr2/plugins/ccip/tokendata/reader.go
@@ -9,7 +9,6 @@ import (
 var (
 	ErrNotReady        = errors.New("token data not ready")
 	ErrRateLimit       = errors.New("token data API is being rate limited")
-	ErrSelfRateLimit   = errors.New("token data API is being self rate limited")
 	ErrTimeout         = errors.New("token data API timed out")
 	ErrRequestsBlocked = errors.New("requests are currently blocked")
 )

--- a/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc.go
+++ b/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc.go
@@ -43,8 +43,10 @@ const (
 	// this is set according to the APIs documentated 10 requests per second rate limit.
 	defaultRequestInterval = 100 * time.Millisecond
 
+	// APIIntervalRateLimitDisabled is a special value to disable the rate limiting.
 	APIIntervalRateLimitDisabled = -1
-	APIIntervalRateLimitDefault  = 0
+	// APIIntervalRateLimitDefault is a special value to select the default rate limit interval.
+	APIIntervalRateLimitDefault = 0
 )
 
 type attestationStatus string
@@ -121,10 +123,9 @@ func NewUSDCTokenDataReader(
 		timeout = defaultAttestationTimeout
 	}
 
-	switch requestInterval {
-	case APIIntervalRateLimitDisabled:
+	if requestInterval == APIIntervalRateLimitDisabled {
 		requestInterval = 0
-	case APIIntervalRateLimitDefault:
+	} else if requestInterval == APIIntervalRateLimitDefault {
 		requestInterval = defaultRequestInterval
 	}
 

--- a/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc.go
+++ b/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc.go
@@ -42,6 +42,9 @@ const (
 	// defaultRequestInterval defines the rate in requests per second that the attestation API can be called.
 	// this is set according to the APIs documentated 10 requests per second rate limit.
 	defaultRequestInterval = 100 * time.Millisecond
+
+	APIIntervalRateLimitDisabled = -1
+	APIIntervalRateLimitDefault  = 0
 )
 
 type attestationStatus string
@@ -117,9 +120,14 @@ func NewUSDCTokenDataReader(
 	if usdcAttestationApiTimeoutSeconds == 0 {
 		timeout = defaultAttestationTimeout
 	}
-	if requestInterval == 0 {
+
+	switch requestInterval {
+	case APIIntervalRateLimitDisabled:
+		requestInterval = 0
+	case APIIntervalRateLimitDefault:
 		requestInterval = defaultRequestInterval
 	}
+
 	return &TokenDataReader{
 		lggr:                  lggr,
 		usdcReader:            usdcReader,

--- a/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc.go
+++ b/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc.go
@@ -39,8 +39,9 @@ const (
 	// maxCoolDownDuration defines the maximum duration we can wait till firing the next request
 	maxCoolDownDuration = 10 * time.Minute
 
-	// USDCRequestInterval defines the rate in requests per second that the attestation API can be called
-	RequestInterval = 100 * time.Millisecond
+	// defaultRequestInterval defines the rate in requests per second that the attestation API can be called.
+	// this is set according to the APIs documentated 10 requests per second rate limit.
+	defaultRequestInterval = 100 * time.Millisecond
 )
 
 type attestationStatus string
@@ -115,6 +116,9 @@ func NewUSDCTokenDataReader(
 	timeout := time.Duration(usdcAttestationApiTimeoutSeconds) * time.Second
 	if usdcAttestationApiTimeoutSeconds == 0 {
 		timeout = defaultAttestationTimeout
+	}
+	if requestInterval == 0 {
+		requestInterval = defaultRequestInterval
 	}
 	return &TokenDataReader{
 		lggr:                  lggr,

--- a/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc.go
+++ b/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc.go
@@ -163,8 +163,8 @@ func (s *TokenDataReader) ReadTokenData(ctx context.Context, msg cciptypes.EVM2E
 	if s.rate != nil {
 		// Wait blocks until it the attestation API can be called or the
 		// context is Done.
-		if err := s.rate.Wait(ctx); err != nil {
-			return nil, fmt.Errorf("usdc rate limiting error: %w", err)
+		if waitErr := s.rate.Wait(ctx); err != nil {
+			return nil, fmt.Errorf("usdc rate limiting error: %w", waitErr)
 		}
 	}
 

--- a/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc_blackbox_test.go
+++ b/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc_blackbox_test.go
@@ -97,7 +97,7 @@ func TestUSDCReader_ReadTokenData(t *testing.T) {
 			require.NoError(t, err)
 
 			addr := utils.RandomAddress()
-			usdcService := usdc.NewUSDCTokenDataReader(lggr, &usdcReader, attestationURI, 0, addr)
+			usdcService := usdc.NewUSDCTokenDataReader(lggr, &usdcReader, attestationURI, 0, addr, 0)
 			msgAndAttestation, err := usdcService.ReadTokenData(context.Background(), cciptypes.EVM2EVMOnRampCCIPSendRequestedWithMeta{
 				EVM2EVMMessage: cciptypes.EVM2EVMMessage{
 					SequenceNumber: seqNum,

--- a/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc_blackbox_test.go
+++ b/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc_blackbox_test.go
@@ -97,7 +97,7 @@ func TestUSDCReader_ReadTokenData(t *testing.T) {
 			require.NoError(t, err)
 
 			addr := utils.RandomAddress()
-			usdcService := usdc.NewUSDCTokenDataReader(lggr, &usdcReader, attestationURI, 0, addr, -1)
+			usdcService := usdc.NewUSDCTokenDataReader(lggr, &usdcReader, attestationURI, 0, addr, usdc.APIIntervalRateLimitDisabled)
 			msgAndAttestation, err := usdcService.ReadTokenData(context.Background(), cciptypes.EVM2EVMOnRampCCIPSendRequestedWithMeta{
 				EVM2EVMMessage: cciptypes.EVM2EVMMessage{
 					SequenceNumber: seqNum,

--- a/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc_blackbox_test.go
+++ b/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc_blackbox_test.go
@@ -97,7 +97,7 @@ func TestUSDCReader_ReadTokenData(t *testing.T) {
 			require.NoError(t, err)
 
 			addr := utils.RandomAddress()
-			usdcService := usdc.NewUSDCTokenDataReader(lggr, &usdcReader, attestationURI, 0, addr, 0)
+			usdcService := usdc.NewUSDCTokenDataReader(lggr, &usdcReader, attestationURI, 0, addr, -1)
 			msgAndAttestation, err := usdcService.ReadTokenData(context.Background(), cciptypes.EVM2EVMOnRampCCIPSendRequestedWithMeta{
 				EVM2EVMMessage: cciptypes.EVM2EVMMessage{
 					SequenceNumber: seqNum,

--- a/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc_test.go
+++ b/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc_test.go
@@ -40,7 +40,7 @@ func TestUSDCReader_callAttestationApi(t *testing.T) {
 	require.NoError(t, err)
 	lggr := logger.TestLogger(t)
 	usdcReader, _ := ccipdata.NewUSDCReader(lggr, "job_123", mockMsgTransmitter, nil, false)
-	usdcService := NewUSDCTokenDataReader(lggr, usdcReader, attestationURI, 0, common.Address{}, -1)
+	usdcService := NewUSDCTokenDataReader(lggr, usdcReader, attestationURI, 0, common.Address{}, APIIntervalRateLimitDisabled)
 
 	attestation, err := usdcService.callAttestationApi(context.Background(), [32]byte(common.FromHex(usdcMessageHash)))
 	require.NoError(t, err)
@@ -63,7 +63,7 @@ func TestUSDCReader_callAttestationApiMock(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	lp := mocks.NewLogPoller(t)
 	usdcReader, _ := ccipdata.NewUSDCReader(lggr, "job_123", mockMsgTransmitter, lp, false)
-	usdcService := NewUSDCTokenDataReader(lggr, usdcReader, attestationURI, 0, common.Address{}, -1)
+	usdcService := NewUSDCTokenDataReader(lggr, usdcReader, attestationURI, 0, common.Address{}, APIIntervalRateLimitDisabled)
 	attestation, err := usdcService.callAttestationApi(context.Background(), utils.RandomBytes32())
 	require.NoError(t, err)
 
@@ -198,7 +198,7 @@ func TestUSDCReader_callAttestationApiMockError(t *testing.T) {
 			lggr := logger.TestLogger(t)
 			lp := mocks.NewLogPoller(t)
 			usdcReader, _ := ccipdata.NewUSDCReader(lggr, "job_123", mockMsgTransmitter, lp, false)
-			usdcService := NewUSDCTokenDataReader(lggr, usdcReader, attestationURI, test.customTimeoutSeconds, common.Address{}, -1)
+			usdcService := NewUSDCTokenDataReader(lggr, usdcReader, attestationURI, test.customTimeoutSeconds, common.Address{}, APIIntervalRateLimitDisabled)
 			lp.On("RegisterFilter", mock.Anything).Return(nil)
 			require.NoError(t, usdcReader.RegisterFilters())
 
@@ -234,7 +234,7 @@ func TestGetUSDCMessageBody(t *testing.T) {
 
 	usdcTokenAddr := utils.RandomAddress()
 	lggr := logger.TestLogger(t)
-	usdcService := NewUSDCTokenDataReader(lggr, &usdcReader, nil, 0, usdcTokenAddr, -1)
+	usdcService := NewUSDCTokenDataReader(lggr, &usdcReader, nil, 0, usdcTokenAddr, APIIntervalRateLimitDisabled)
 
 	// Make the first call and assert the underlying function is called
 	body, err := usdcService.getUSDCMessageBody(context.Background(), cciptypes.EVM2EVMOnRampCCIPSendRequestedWithMeta{
@@ -317,13 +317,13 @@ func TestUSDCReader_rateLimiting(t *testing.T) {
 		{
 			name:         "no rate limit when disabled",
 			requests:     10,
-			rateConfig:   -1,
+			rateConfig:   APIIntervalRateLimitDisabled,
 			testDuration: 1 * time.Millisecond,
 		},
 		{
 			name:         "yes rate limited with default config",
 			requests:     5,
-			rateConfig:   0,
+			rateConfig:   APIIntervalRateLimitDefault,
 			testDuration: 4 * defaultRequestInterval,
 		},
 		{

--- a/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc_test.go
+++ b/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc_test.go
@@ -40,7 +40,7 @@ func TestUSDCReader_callAttestationApi(t *testing.T) {
 	require.NoError(t, err)
 	lggr := logger.TestLogger(t)
 	usdcReader, _ := ccipdata.NewUSDCReader(lggr, "job_123", mockMsgTransmitter, nil, false)
-	usdcService := NewUSDCTokenDataReader(lggr, usdcReader, attestationURI, 0, common.Address{}, 0)
+	usdcService := NewUSDCTokenDataReader(lggr, usdcReader, attestationURI, 0, common.Address{}, -1)
 
 	attestation, err := usdcService.callAttestationApi(context.Background(), [32]byte(common.FromHex(usdcMessageHash)))
 	require.NoError(t, err)
@@ -63,7 +63,7 @@ func TestUSDCReader_callAttestationApiMock(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	lp := mocks.NewLogPoller(t)
 	usdcReader, _ := ccipdata.NewUSDCReader(lggr, "job_123", mockMsgTransmitter, lp, false)
-	usdcService := NewUSDCTokenDataReader(lggr, usdcReader, attestationURI, 0, common.Address{}, 0)
+	usdcService := NewUSDCTokenDataReader(lggr, usdcReader, attestationURI, 0, common.Address{}, -1)
 	attestation, err := usdcService.callAttestationApi(context.Background(), utils.RandomBytes32())
 	require.NoError(t, err)
 
@@ -198,7 +198,7 @@ func TestUSDCReader_callAttestationApiMockError(t *testing.T) {
 			lggr := logger.TestLogger(t)
 			lp := mocks.NewLogPoller(t)
 			usdcReader, _ := ccipdata.NewUSDCReader(lggr, "job_123", mockMsgTransmitter, lp, false)
-			usdcService := NewUSDCTokenDataReader(lggr, usdcReader, attestationURI, test.customTimeoutSeconds, common.Address{}, 0)
+			usdcService := NewUSDCTokenDataReader(lggr, usdcReader, attestationURI, test.customTimeoutSeconds, common.Address{}, -1)
 			lp.On("RegisterFilter", mock.Anything).Return(nil)
 			require.NoError(t, usdcReader.RegisterFilters())
 
@@ -234,7 +234,7 @@ func TestGetUSDCMessageBody(t *testing.T) {
 
 	usdcTokenAddr := utils.RandomAddress()
 	lggr := logger.TestLogger(t)
-	usdcService := NewUSDCTokenDataReader(lggr, &usdcReader, nil, 0, usdcTokenAddr, 0)
+	usdcService := NewUSDCTokenDataReader(lggr, &usdcReader, nil, 0, usdcTokenAddr, -1)
 
 	// Make the first call and assert the underlying function is called
 	body, err := usdcService.getUSDCMessageBody(context.Background(), cciptypes.EVM2EVMOnRampCCIPSendRequestedWithMeta{
@@ -317,14 +317,20 @@ func TestUSDCReader_rateLimiting(t *testing.T) {
 		{
 			name:         "no rate limit when disabled",
 			requests:     10,
-			rateConfig:   0,
+			rateConfig:   -1,
 			testDuration: 1 * time.Millisecond,
 		},
 		{
-			name:         "yes rate limit when not disabled",
+			name:         "yes rate limited with default config",
 			requests:     5,
-			rateConfig:   100 * time.Millisecond,
-			testDuration: 4 * 100 * time.Millisecond,
+			rateConfig:   0,
+			testDuration: 4 * defaultRequestInterval,
+		},
+		{
+			name:         "yes rate limited with config",
+			requests:     10,
+			rateConfig:   50 * time.Millisecond,
+			testDuration: 9 * 50 * time.Millisecond,
 		},
 		{
 			name:         "timeout after first request",

--- a/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc_test.go
+++ b/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc_test.go
@@ -338,7 +338,7 @@ func TestUSDCReader_rateLimiting(t *testing.T) {
 			name:         "timeout after second request",
 			requests:     5,
 			rateConfig:   100 * time.Millisecond,
-			testDuration: 150 * time.Millisecond,
+			testDuration: 100 * time.Millisecond,
 			timeout:      150 * time.Millisecond,
 			err:          "usdc rate limiting error: rate: Wait(n=1) would exceed context deadline",
 		},
@@ -400,15 +400,13 @@ func TestUSDCReader_rateLimiting(t *testing.T) {
 			close(errorChan)
 
 			// Collect errors
-			var errs []error
 			errorFound := false
 			for err := range errorChan {
-				errs = append(errs, err)
 				if tc.err != "" && !strings.Contains(err.Error(), tc.err) {
 					errorFound = true
-				} else if !strings.Contains(err.Error(), "failed getting USDC message body") {
-					// ignore this error, it's expected because of how mocking is used.
-				} else {
+				} else if err != nil && !strings.Contains(err.Error(), "get usdc token 0 end offset") {
+					// Ignore that one error, it's expected because of how mocking is used.
+					// Anything else is unexpected.
 					require.Fail(t, "unexpected error", err)
 				}
 			}

--- a/core/services/ocr2/validate/validate_test.go
+++ b/core/services/ocr2/validate/validate_test.go
@@ -604,6 +604,7 @@ USDCConfig.SourceTokenAddress = "0x1234567890123456789012345678901234567890"
 USDCConfig.SourceMessageTransmitterAddress = "0x0987654321098765432109876543210987654321"
 USDCConfig.AttestationAPI = "some api"
 USDCConfig.AttestationAPITimeoutSeconds = 12
+USDCConfig.AttestationAPIIntervalMilliseconds = 100
 `,
 			assertion: func(t *testing.T, os job.Job, err error) {
 				require.NoError(t, err)
@@ -611,10 +612,11 @@ USDCConfig.AttestationAPITimeoutSeconds = 12
 					SourceStartBlock: 1,
 					DestStartBlock:   2,
 					USDCConfig: config.USDCConfig{
-						SourceTokenAddress:              common.HexToAddress("0x1234567890123456789012345678901234567890"),
-						SourceMessageTransmitterAddress: common.HexToAddress("0x0987654321098765432109876543210987654321"),
-						AttestationAPI:                  "some api",
-						AttestationAPITimeoutSeconds:    12,
+						SourceTokenAddress:                 common.HexToAddress("0x1234567890123456789012345678901234567890"),
+						SourceMessageTransmitterAddress:    common.HexToAddress("0x0987654321098765432109876543210987654321"),
+						AttestationAPI:                     "some api",
+						AttestationAPITimeoutSeconds:       12,
+						AttestationAPIIntervalMilliseconds: 100,
 					},
 				}
 				var cfg config.ExecutionPluginJobSpecConfig
@@ -666,6 +668,7 @@ DestStartBlock = 2
 USDCConfig.SourceTokenAddress = "0x1234567890123456789012345678901234567890"
 USDCConfig.SourceMessageTransmitterAddress = "0x0987654321098765432109876543210987654321"
 USDCConfig.AttestationAPI = "some api"
+USDCConfig.AttestationAPIIntervalMilliseconds = 100
 USDCConfig.AttestationAPITimeoutSeconds = -12
 `,
 			assertion: func(t *testing.T, os job.Job, err error) {

--- a/core/services/ocr2/validate/validate_test.go
+++ b/core/services/ocr2/validate/validate_test.go
@@ -670,7 +670,7 @@ USDCConfig.AttestationAPITimeoutSeconds = -12
 `,
 			assertion: func(t *testing.T, os job.Job, err error) {
 				require.Error(t, err)
-				require.Contains(t, err.Error(), "AttestationAPITimeoutSeconds must be non-negative")
+				require.Contains(t, err.Error(), "error while unmarshalling plugin config: json: cannot unmarshal number -12 into Go struct field USDCConfig.USDCConfig.AttestationAPITimeoutSeconds of type uint")
 			},
 		},
 		{


### PR DESCRIPTION
## Motivation

Circle's USDC attestation API has a 5 minute IP ban if rate limits are exceeded. In order to avoid the 5 minute ban we should proactively limit our requests to make sure this doesn't happen.

## Solution

Use `golang.org/x/time/rate` to add rate limit calls to the USDC TokenDataReader.

This PR makes the following changes to behavior:
* If a 429 occurs and there is no Retry-After header, a 5 minute cooldown is triggered. This is to match the circle documentation.
* If `usdc.ReadTokenData` is called back to back or concurrently, the first call will execute and the rest will delay according to an interval. The interval between calls is configurable.

A new Json Spec parameter is introduced named `USDCConfig.AttestationAPIIntervalMilliseconds`