### PR TITLE
Ccip 1917 db storage class through test config

### DIFF
--- a/.github/workflows/client-compatibility-tests.yml
+++ b/.github/workflows/client-compatibility-tests.yml
@@ -1,4 +1,4 @@
-name: Client Compatibility Tests
+name: CCIP Client Compatibility Tests
 on:
   merge_group:
   pull_request:
@@ -54,7 +54,7 @@ jobs:
 
   build-chainlink:
     if: needs.changes.outputs.src == 'true' || github.event_name == 'workflow_dispatch'
-    needs: [changes]
+    needs: [ changes ]
     environment: integration
     permissions:
       id-token: write
@@ -87,7 +87,7 @@ jobs:
 
   get-latest-available-images:
     if: needs.changes.outputs.src == 'true' || github.event_name == 'workflow_dispatch'
-    needs: [changes]
+    needs: [ changes ]
     environment: integration
     runs-on: ubuntu-latest
     permissions:
@@ -138,7 +138,7 @@ jobs:
       pull-requests: write
       id-token: write
       contents: read
-    needs: [build-chainlink, changes, get-latest-available-images]
+    needs: [ build-chainlink, changes, get-latest-available-images ]
     if: needs.changes.outputs.src == 'true' || github.event_name == 'workflow_dispatch'
     env:
       SELECTED_NETWORKS: SIMULATED_1,SIMULATED_2
@@ -156,12 +156,13 @@ jobs:
             timeout: 30m
             pyroscope_env: ci-ccip-bidirectionallane-geth
             chainConfig: "1337=ethereum/client-go:${{ needs.get-latest-available-images.outputs.geth_tag }},2337=ethereum/client-go:${{ needs.get-latest-available-images.outputs.geth_tag }}"
-          - name: bidirectionallane-nethermind
-            test: TestSmokeCCIPForBidirectionalLane
-            client: nethermind
-            timeout: 30m
-            pyroscope_env: ci-ccip-bidirectionallane-nethermind
-            chainConfig: "1337=nethermind/nethermind:${{ needs.get-latest-available-images.outputs.nethermind_tag }},2337=nethermind/nethermind:${{ needs.get-latest-available-images.outputs.nethermind_tag }}"
+          # uncomment when nethermind flake reason is addressed
+          # - name: bidirectionallane-nethermind
+          #            test: TestSmokeCCIPForBidirectionalLane
+          #            client: nethermind
+          #            timeout: 30m
+          #            pyroscope_env: ci-ccip-bidirectionallane-nethermind
+          #         chainConfig: "1337=nethermind/nethermind:${{ needs.get-latest-available-images.outputs.nethermind_tag }},2337=nethermind/nethermind:${{ needs.get-latest-available-images.outputs.nethermind_tag }}"
           # uncomment when 24.4.0  is released with our data/input fix
           # - name: bidirectionallane-besu
           #   test: TestSmokeCCIPForBidirectionalLane
@@ -263,7 +264,7 @@ jobs:
       id-token: write
       contents: read
     runs-on: ubuntu-latest
-    needs: [evm-compatibility-matrix, changes]
+    needs: [ evm-compatibility-matrix, changes ]
     steps:
       - name: Debug Result
         run: echo ${{ join(needs.*.result, ',') }}
@@ -320,7 +321,7 @@ jobs:
       id-token: write
       contents: read
     runs-on: ubuntu-latest
-    needs: [start-slack-thread]
+    needs: [ start-slack-thread ]
     steps:
       - name: Checkout the repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/integration-tests/ccip-tests/Makefile
+++ b/integration-tests/ccip-tests/Makefile
@@ -1,5 +1,5 @@
 ## To Override the default config, and secret config:
-# example usage: make set_config override_toml=../config/config.toml secret_toml=../config/secret.toml
+# example usage: make set_config override_toml=../config/config.toml secret_toml=../config/secret.toml network_config_toml=../config/network.toml
 .PHONY: set_config
 set_config:
 	if [ -s "$(override_toml)" ]; then \
@@ -10,13 +10,17 @@ set_config:
       		echo "No override config found, using default config"; \
         	echo  > ./testconfig/override/.env; \
 	fi
+	if [ -s "$(network_config_toml)" ]; then \
+  	  echo "Overriding network config with $(network_config_toml)"; \
+      echo "export BASE64_NETWORK_CONFIG=$$(base64 -i $(network_config_toml))" >> ./testconfig/override/.env; \
+    fi
 
 	@echo "setting secret config with $(secret_toml)"
 	@echo "export BASE64_CCIP_SECRETS_CONFIG=$$(base64 -i $(secret_toml))" >> ./testconfig/override/.env
 	@echo "export TEST_BASE64_CCIP_SECRETS_CONFIG=$$(base64 -i $(secret_toml))" >> ./testconfig/override/.env
 
 
-# example usage: make test_load_ccip testimage=chainlink-ccip-tests:latest testname=TestLoadCCIPStableRPS override_toml=./testconfig/override/config.toml secret_toml=./testconfig/tomls/secrets.toml
+# example usage: make test_load_ccip testimage=chainlink-ccip-tests:latest testname=TestLoadCCIPStableRPS override_toml=./testconfig/override/config.toml secret_toml=./testconfig/tomls/secrets.toml network_config_toml=../config/network.toml
 .PHONY: test_load_ccip
 test_load_ccip: set_config
 	source ./testconfig/override/.env && \
@@ -30,7 +34,7 @@ test_load_ccip: set_config
 	go test -timeout 24h -count=1 -v -run ^$(testname)$$ ./load
 
 
-# example usage: make test_smoke_ccip testimage=chainlink-ccip-tests:latest testname=TestSmokeCCIPForBidirectionalLane override_toml=../testconfig/override/config.toml secret_toml=./testconfig/tomls/secrets.toml
+# example usage: make test_smoke_ccip testimage=chainlink-ccip-tests:latest testname=TestSmokeCCIPForBidirectionalLane override_toml=../testconfig/override/config.toml secret_toml=./testconfig/tomls/secrets.toml network_config_toml=../config/network.toml
 .PHONY: test_smoke_ccip
 test_smoke_ccip: set_config
 	source ./testconfig/override/.env && \

--- a/integration-tests/ccip-tests/actions/ccip_helpers.go
+++ b/integration-tests/ccip-tests/actions/ccip_helpers.go
@@ -157,11 +157,8 @@ func (ccipModule *CCIPCommon) FreeUpUnusedSpace() {
 	ccipModule.PriceAggregators = nil
 	ccipModule.BridgeTokenPools = []*contracts.TokenPool{}
 	ccipModule.RemoteChains = nil
-	ccipModule.gasUpdateWatcher = nil
-	ccipModule.gasUpdateWatcherMu = nil
 	ccipModule.TokenMessenger = nil
 	ccipModule.TokenTransmitter = nil
-	ccipModule.PriceRegistry = nil
 	runtime.GC()
 }
 

--- a/integration-tests/ccip-tests/actions/ccip_helpers.go
+++ b/integration-tests/ccip-tests/actions/ccip_helpers.go
@@ -1478,7 +1478,7 @@ func (sourceCCIP *SourceCCIPModule) SendRequest(
 	timeNow := time.Now()
 	feeToken := common.HexToAddress(sourceCCIP.Common.FeeToken.Address())
 	// initiate the transfer
-	// if the token address is 0x0 it will use Native as fee token and the fee amount should be mentioned in bind.TransactOpts's value
+	// if the fee token address is 0x0 it will use Native as fee token and the fee amount should be mentioned in bind.TransactOpts's value
 	if feeToken != (common.Address{}) {
 		sendTx, err = sourceCCIP.Common.Router.CCIPSendAndProcessTx(destChainSelector, msg, nil)
 		if err != nil {

--- a/integration-tests/ccip-tests/actions/ccip_helpers.go
+++ b/integration-tests/ccip-tests/actions/ccip_helpers.go
@@ -2343,13 +2343,13 @@ func (lane *CCIPLane) AddToSentReqs(txHash common.Hash, reqStats []*testreporter
 	for _, stat := range reqStats {
 		allRequests = append(allRequests, CCIPRequest{
 			ReqNo:                   stat.ReqNo,
-			txHash:                  request.txHash,
+			txHash:                  rcpt.TxHash.Hex(),
 			txConfirmationTimestamp: request.txConfirmationTimestamp,
 			RequestStat:             stat,
 		})
 		lane.NumberOfReq++
 	}
-	lane.SentReqs[txHash] = allRequests
+	lane.SentReqs[rcpt.TxHash] = allRequests
 	return rcpt, nil
 }
 
@@ -2489,7 +2489,7 @@ func (lane *CCIPLane) SendRequests(noOfRequests int, msgType string, gasLimit *b
 			testreporters.TX, txConfirmationDur, testreporters.Success, testreporters.TransactionStats{
 				Fee:                fee.String(),
 				GasUsed:            gasUsed,
-				TxHash:             txHash.Hex(),
+				TxHash:             rcpt.TxHash.Hex(),
 				NoOfTokensSent:     noOfTokens,
 				MessageBytesLength: len([]byte(msg)),
 			})

--- a/integration-tests/ccip-tests/contracts/laneconfig/parse_contracts.go
+++ b/integration-tests/ccip-tests/contracts/laneconfig/parse_contracts.go
@@ -18,18 +18,19 @@ var (
 )
 
 type CommonContracts struct {
-	IsNativeFeeToken bool     `json:"is_native_fee_token,omitempty"`
-	IsMockARM        bool     `json:"is_mock_arm,omitempty"`
-	FeeToken         string   `json:"fee_token"`
-	BridgeTokens     []string `json:"bridge_tokens"`
-	BridgeTokenPools []string `json:"bridge_tokens_pools"`
-	ARM              string   `json:"arm"`
-	Router           string   `json:"router"`
-	PriceRegistry    string   `json:"price_registry"`
-	WrappedNative    string   `json:"wrapped_native"`
-	Multicall        string   `json:"multicall,omitempty"`
-	TokenTransmitter string   `json:"token_transmitter,omitempty"`
-	TokenMessenger   string   `json:"token_messenger,omitempty"`
+	IsNativeFeeToken bool              `json:"is_native_fee_token,omitempty"`
+	IsMockARM        bool              `json:"is_mock_arm,omitempty"`
+	FeeToken         string            `json:"fee_token"`
+	BridgeTokens     []string          `json:"bridge_tokens"`
+	BridgeTokenPools []string          `json:"bridge_tokens_pools"`
+	PriceAggregators map[string]string `json:"price_aggregators"`
+	ARM              string            `json:"arm"`
+	Router           string            `json:"router"`
+	PriceRegistry    string            `json:"price_registry"`
+	WrappedNative    string            `json:"wrapped_native"`
+	Multicall        string            `json:"multicall,omitempty"`
+	TokenTransmitter string            `json:"token_transmitter,omitempty"`
+	TokenMessenger   string            `json:"token_messenger,omitempty"`
 }
 
 type SourceContracts struct {

--- a/integration-tests/ccip-tests/load/ccip_loadgen.go
+++ b/integration-tests/ccip-tests/load/ccip_loadgen.go
@@ -60,8 +60,7 @@ func NewCCIPLoad(t *testing.T, lane *actions.CCIPLane, timeout time.Duration, no
 		Dest:              lane.Dest,
 		Reports:           lane.Reports,
 	}
-	// This is to optimize memory space for load tests with high number of networks, lanes, tokens
-	lane.OptimizeStorage()
+
 	return &CCIPE2ELoad{
 		t:                                   t,
 		Lane:                                loadLane,

--- a/integration-tests/ccip-tests/load/ccip_loadgen.go
+++ b/integration-tests/ccip-tests/load/ccip_loadgen.go
@@ -205,7 +205,8 @@ func (c *CCIPE2ELoad) Call(_ *wasp.Generator) *wasp.Response {
 	if feeToken != common.HexToAddress("0x0") {
 		sendTx, err = sourceCCIP.Common.Router.CCIPSend(destChainSelector, msg, nil)
 	} else {
-		sendTx, err = sourceCCIP.Common.Router.CCIPSend(destChainSelector, msg, fee)
+		// add a bit buffer to fee
+		sendTx, err = sourceCCIP.Common.Router.CCIPSend(destChainSelector, msg, new(big.Int).Add(big.NewInt(1e2), fee))
 	}
 	if err != nil {
 		stats.UpdateState(lggr, 0, testreporters.TX, time.Since(startTime), testreporters.Failure)

--- a/integration-tests/ccip-tests/load/helper.go
+++ b/integration-tests/ccip-tests/load/helper.go
@@ -210,12 +210,12 @@ func (l *LoadArgs) ValidateCurseFollowedByUncurse() {
 		errGrp.Go(func() error {
 			lane.Logger.Info().Msg("Validating no CommitReportAccepted event is received for 29 minutes")
 			// we allow additional 1 minute after curse timestamp for curse to be visible by plugin
-			return lane.Dest.AssertNoReportAcceptedEventReceived(lane.Logger, 29*time.Minute, curseTimeStamp.Add(1*time.Minute))
+			return lane.Dest.AssertNoReportAcceptedEventReceived(lane.Logger, 25*time.Minute, curseTimeStamp.Add(1*time.Minute))
 		})
 		errGrp.Go(func() error {
 			lane.Logger.Info().Msg("Validating no ExecutionStateChanged event is received for 29 minutes")
 			// we allow additional 1 minute after curse timestamp for curse to be visible by plugin
-			return lane.Dest.AssertNoExecutionStateChangedEventReceived(lane.Logger, 29*time.Minute, curseTimeStamp.Add(1*time.Minute))
+			return lane.Dest.AssertNoExecutionStateChangedEventReceived(lane.Logger, 25*time.Minute, curseTimeStamp.Add(1*time.Minute))
 		})
 	}
 	l.lggr.Info().Msg("waiting for no commit/execution validation")

--- a/integration-tests/ccip-tests/load/helper.go
+++ b/integration-tests/ccip-tests/load/helper.go
@@ -213,7 +213,7 @@ func (l *LoadArgs) ValidateCurseFollowedByUncurse() {
 			return lane.Dest.AssertNoReportAcceptedEventReceived(lane.Logger, 25*time.Minute, curseTimeStamp.Add(1*time.Minute))
 		})
 		errGrp.Go(func() error {
-			lane.Logger.Info().Msg("Validating no ExecutionStateChanged event is received for 29 minutes")
+			lane.Logger.Info().Msg("Validating no ExecutionStateChanged event is received for 25 minutes")
 			// we allow additional 1 minute after curse timestamp for curse to be visible by plugin
 			return lane.Dest.AssertNoExecutionStateChangedEventReceived(lane.Logger, 25*time.Minute, curseTimeStamp.Add(1*time.Minute))
 		})

--- a/integration-tests/ccip-tests/testconfig/ccip.go
+++ b/integration-tests/ccip-tests/testconfig/ccip.go
@@ -56,6 +56,7 @@ type CCIPTestConfig struct {
 	ExecOCRParams              *contracts.OffChainAggregatorV2Config `toml:",omitempty"`
 	CommitInflightExpiry       *config.Duration                      `toml:",omitempty"`
 	ExecInflightExpiry         *config.Duration                      `toml:",omitempty"`
+	OptimizeSpace              *bool                                 `toml:",omitempty"`
 }
 
 func (c *CCIPTestConfig) SetTestRunName(name string) {

--- a/integration-tests/ccip-tests/testconfig/global.go
+++ b/integration-tests/ccip-tests/testconfig/global.go
@@ -303,16 +303,17 @@ func (c *CLCluster) Validate() error {
 }
 
 type ChainlinkDeployment struct {
-	Common     *Node    `toml:",omitempty"`
-	NodeMemory string   `toml:",omitempty"`
-	NodeCPU    string   `toml:",omitempty"`
-	DBMemory   string   `toml:",omitempty"`
-	DBCPU      string   `toml:",omitempty"`
-	DBCapacity string   `toml:",omitempty"`
-	IsStateful *bool    `toml:",omitempty"`
-	DBArgs     []string `toml:",omitempty"`
-	NoOfNodes  *int     `toml:",omitempty"`
-	Nodes      []*Node  `toml:",omitempty"` // to be mentioned only if diff nodes follow diff configs; not required if all nodes follow CommonConfig
+	Common         *Node    `toml:",omitempty"`
+	NodeMemory     string   `toml:",omitempty"`
+	NodeCPU        string   `toml:",omitempty"`
+	DBMemory       string   `toml:",omitempty"`
+	DBCPU          string   `toml:",omitempty"`
+	DBCapacity     string   `toml:",omitempty"`
+	DBStorageClass *string  `toml:",omitempty"`
+	IsStateful     *bool    `toml:",omitempty"`
+	DBArgs         []string `toml:",omitempty"`
+	NoOfNodes      *int     `toml:",omitempty"`
+	Nodes          []*Node  `toml:",omitempty"` // to be mentioned only if diff nodes follow diff configs; not required if all nodes follow CommonConfig
 }
 
 func (c *ChainlinkDeployment) Validate() error {

--- a/integration-tests/ccip-tests/testconfig/global.go
+++ b/integration-tests/ccip-tests/testconfig/global.go
@@ -310,6 +310,7 @@ type ChainlinkDeployment struct {
 	DBCPU          string   `toml:",omitempty"`
 	DBCapacity     string   `toml:",omitempty"`
 	DBStorageClass *string  `toml:",omitempty"`
+	PromPgExporter *bool    `toml:",omitempty"`
 	IsStateful     *bool    `toml:",omitempty"`
 	DBArgs         []string `toml:",omitempty"`
 	NoOfNodes      *int     `toml:",omitempty"`

--- a/integration-tests/ccip-tests/testconfig/tomls/ccip-crib.toml
+++ b/integration-tests/ccip-tests/testconfig/tomls/ccip-crib.toml
@@ -5,57 +5,61 @@ Data = """
   "lane_configs": {
     "geth_1337": {
       "is_mock_arm": true,
-      "fee_token": "0x5fbdb2315678afecb367f032d93f642f64180aa3",
+      "fee_token": "0xf5059a5D33d5853360D16C683c16e67980206f36",
       "bridge_tokens": [
-        "0x5fbdb2315678afecb367f032d93f642f64180aa3"
+        "0x70e0bA845a1A0F2DA3359C97E0285013525FFC49",
+        "0x0E801D84Fa97b50751Dbf25036d067dCf18858bF"
       ],
       "bridge_tokens_pools": [
-        "0xa513e6e4b8f2a923d98304ec87f64353c4d5c853"
+        "0x9d4454B023096f34B160D6B654540c56A1F81688",
+        "0x1291Be112d480055DaFd8a610b7d1e203891C274"
       ],
-      "arm": "0xdc64a140aa3e981100a9beca4e685f962f0cf6c9",
-      "router": "0x0165878a594ca255338adfa4d48449f69242eb8f",
-      "price_registry": "0x8a791620dd6260079bf849dc5567adc3f2fdc318",
-      "wrapped_native": "0xcf7ed3acca5a467e9e704c703e8d87f634fb0fc9",
+      "arm": "0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690",
+      "router": "0x1613beB3B2C4f22Ee086B2b38C1476A3cE7f78E8",
+      "price_registry": "0x82e01223d51Eb87e16A03E24687EDF0F294da6f1",
+      "wrapped_native": "0x84eA74d481Ee0A5332c457a4d796187F6Ba67fEB",
       "multicall": "0x0000000000000000000000000000000000000000",
       "src_contracts": {
         "geth_2337": {
-          "on_ramp": "0x610178da211fef7d417bc0e6fed39f05609ad788",
-          "deployed_at": 239
+          "on_ramp": "0xc351628EB244ec633d5f21fBD6621e1a683B1181",
+          "deployed_at": 258
         }
       },
       "dest_contracts": {
         "geth_2337": {
-          "off_ramp": "0x0b306bf915c4d645ff596e518faf3f9669b97016",
-          "commit_store": "0x0dcd1bf9a1b36ce34237eeafef220932846bcd82",
-          "receiver_dapp": ""
+          "off_ramp": "0x922D6956C99E12DFeB3224DEA977D0939758A1Fe",
+          "commit_store": "0xB0D4afd8879eD9F52b28595d31B441D079B2Ca07",
+          "receiver_dapp": "0xdbC43Ba45381e02825b14322cDdd15eC4B3164E6"
         }
       }
     },
     "geth_2337": {
       "is_mock_arm": true,
-      "fee_token": "0x8464135c8f25da09e49bc8782676a84730c318bc",
+      "fee_token": "0x20Fbd46DeEd5EEDEB6e5c87eeB31924e9CA312ad",
       "bridge_tokens": [
-        "0x8464135c8f25da09e49bc8782676a84730c318bc"
+        "0xAd5d57aD9bB17d34Debb88566ab2F5dB879Cc46F",
+        "0x7290f72B5C67052DDE8e6E179F7803c493e90d3f"
       ],
       "bridge_tokens_pools": [
-        "0x1275d096b9dbf2347bd2a131fb6bdab0b4882487"
+        "0xc63d2a04762529edB649d7a4cC3E57A0085e8544",
+        "0xD499f5F7d3C918D0e553BA03954c4E02af16B6e4"
       ],
-      "arm": "0xbcf26943c0197d2ee0e5d05c716be60cc2761508",
-      "router": "0xc6ba8c3233ecf65b761049ef63466945c362edd2",
-      "price_registry": "0x0b48af34f4c854f5ae1a3d587da471fea45bad52",
-      "wrapped_native": "0x712516e61c8b383df4a63cfe83d7701bce54b03e",
+      "arm": "0xcEC91d876E8f003110D43381359b1bAd124e7F2b",
+      "router": "0x8613A4029EaA95dA61AE65380aC2e7366451bF2b",
+      "price_registry": "0x49FcbCC4E425add3a45AFC82F4dD0E5c227A0Ff8",
+      "wrapped_native": "0x5370F78c6af2Da9cF6642382A3a75F9D5aEc9cc1",
       "multicall": "0x0000000000000000000000000000000000000000",
       "src_contracts": {
         "geth_1337": {
-          "on_ramp": "0x0f5d1ef48f12b6f691401bfe88c2037c690a6afe",
-          "deployed_at": 239
+          "on_ramp": "0xA82ED5224ba72f2f776e09B11DC99E30Ee65Da8d",
+          "deployed_at": 258
         }
       },
       "dest_contracts": {
         "geth_1337": {
-          "off_ramp": "0x381445710b5e73d34af196c53a3d5cda58edbf7a",
-          "commit_store": "0x2de080e97b0cae9825375d31f5d0ed5751fdf16d",
-          "receiver_dapp": ""
+          "off_ramp": "0x199c27B10a195ee79e02d50846e59A4aFB82CAD1",
+          "commit_store": "0xf69E1dFAc3D43F438Bae80090b8E186B0231CFeb",
+          "receiver_dapp": "0x7798A400cBe0Ca14a7D614ECa1CD15adE5055413"
         }
       }
     }
@@ -72,8 +76,8 @@ selected_networks = ['geth_1337', 'geth_2337']
 [CCIP.Env.Network.EVMNetworks.geth_1337]
 evm_name = 'geth_1337'
 evm_chain_id = 1337
-evm_urls = ['wss://crib-ani-geth-1337-ws.main.stage.cldev.sh']
-evm_http_urls = ['https://crib-ani-geth-1337-ws.main.stage.cldev.sh']
+evm_urls = ['wss://skudasov-crib-ccip-geth-1337-ws.main.stage.cldev.sh']
+evm_http_urls = ['https://skudasov-crib-ccip-geth-1337-ws.main.stage.cldev.sh']
 evm_keys = ['ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80']
 evm_simulated = true
 client_implementation = 'Ethereum'
@@ -83,12 +87,13 @@ evm_minimum_confirmations = 1
 evm_gas_estimation_buffer = 10000
 evm_supports_eip1559 = true
 evm_default_gas_limit = 6000000
+evm_finality_depth = 1
 
 [CCIP.Env.Network.EVMNetworks.geth_2337]
 evm_name = 'geth_2337'
 evm_chain_id = 2337
-evm_urls = ['wss://crib-ani-geth-2337-ws.main.stage.cldev.sh']
-evm_http_urls = ['https://crib-ani-geth-2337-ws.main.stage.cldev.sh']
+evm_urls = ['wss://skudasov-crib-ccip-geth-2337-ws.main.stage.cldev.sh']
+evm_http_urls = ['https://skudasov-crib-ccip-geth-2337-ws.main.stage.cldev.sh']
 evm_keys = ['59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d']
 evm_simulated = true
 client_implementation = 'Ethereum'
@@ -98,45 +103,45 @@ evm_minimum_confirmations = 1
 evm_gas_estimation_buffer = 10000
 evm_supports_eip1559 = true
 evm_default_gas_limit = 6000000
-
+evm_finality_depth = 1
 
 [CCIP.Env.ExistingCLCluster]
 Name = 'crib-ani'
 NoOfNodes = 6
 
 [[CCIP.Env.ExistingCLCluster.NodeConfigs]]
-URL = 'https://crib-ani-node1.main.stage.cldev.sh/'
+URL = 'https://skudasov-crib-ccip-node1.main.stage.cldev.sh/'
 Email = 'notreal@fakeemail.ch'
 Password = 'fj293fbBnlQ!f9vNs'
 InternalIP = 'app-node-1'
 
 
 [[CCIP.Env.ExistingCLCluster.NodeConfigs]]
-URL = 'https://crib-ani-node2.main.stage.cldev.sh/'
+URL = 'https://skudasov-crib-ccip-node2.main.stage.cldev.sh/'
 Email = 'notreal@fakeemail.ch'
 Password = 'fj293fbBnlQ!f9vNs'
 InternalIP = 'app-node-2'
 
 [[CCIP.Env.ExistingCLCluster.NodeConfigs]]
-URL = 'https://crib-ani-node3.main.stage.cldev.sh/'
+URL = 'https://skudasov-crib-ccip-node3.main.stage.cldev.sh/'
 Email = 'notreal@fakeemail.ch'
 Password = 'fj293fbBnlQ!f9vNs'
 InternalIP = 'app-node-3'
 
 [[CCIP.Env.ExistingCLCluster.NodeConfigs]]
-URL = 'https://crib-ani-node4.main.stage.cldev.sh/'
+URL = 'https://skudasov-crib-ccip-node4.main.stage.cldev.sh/'
 Email = 'notreal@fakeemail.ch'
 Password = 'fj293fbBnlQ!f9vNs'
 InternalIP = 'app-node-4'
 
 [[CCIP.Env.ExistingCLCluster.NodeConfigs]]
-URL = 'https://crib-ani-node5.main.stage.cldev.sh/'
+URL = 'https://skudasov-crib-ccip-node5.main.stage.cldev.sh/'
 Email = 'notreal@fakeemail.ch'
 Password = 'fj293fbBnlQ!f9vNs'
 InternalIP = 'app-node-5'
 
 [[CCIP.Env.ExistingCLCluster.NodeConfigs]]
-URL = 'https://crib-ani-node6.main.stage.cldev.sh/'
+URL = 'https://skudasov-crib-ccip-node6.main.stage.cldev.sh/'
 Email = 'notreal@fakeemail.ch'
 Password = 'fj293fbBnlQ!f9vNs'
 InternalIP = 'app-node-6'
@@ -144,14 +149,15 @@ InternalIP = 'app-node-6'
 [CCIP.Groups]
 [CCIP.Groups.smoke]
 LocalCluster = false
-TestRunName = 'crib-ani-smoke'
+TestRunName = 'skudasov-crib-ccip'
+NodeFunding = 1000.0
 ExistingDeployment = true
 
 [CCIP.Groups.load]
 LocalCluster = false
-TestRunName = 'crib-ani-load'
+TestRunName = 'skudasov-crib-ccip'
 TimeUnit = '1s'
 TestDuration = '15m'
 RequestPerUnitTime = [1]
-NodeFunding = 100.0
+NodeFunding = 1000.0
 ExistingDeployment = true

--- a/integration-tests/ccip-tests/testsetups/ccip.go
+++ b/integration-tests/ccip-tests/testsetups/ccip.go
@@ -804,8 +804,8 @@ func CCIPDefaultTestSetUp(
 	// deploy all lane specific contracts
 	lggr.Info().Msg("Deploying chain specific contracts")
 	laneAddGrp, _ := errgroup.WithContext(setUpArgs.SetUpContext)
-	// for memory management add only 5 lanes in parallel
-	laneAddGrp.SetLimit(5)
+	// for memory management add only 20 lanes in parallel
+	laneAddGrp.SetLimit(20)
 	for _, networkPair := range testConfig.NetworkPairs {
 		n := networkPair
 		var ok bool

--- a/integration-tests/ccip-tests/testsetups/ccip.go
+++ b/integration-tests/ccip-tests/testsetups/ccip.go
@@ -821,7 +821,7 @@ func CCIPDefaultTestSetUp(
 	lggr.Info().Msg("Deploying chain specific contracts")
 	laneAddGrp, _ := errgroup.WithContext(setUpArgs.SetUpContext)
 	// for memory management add only 20 lanes in parallel
-	laneAddGrp.SetLimit(20)
+	laneAddGrp.SetLimit(200)
 	for _, networkPair := range testConfig.NetworkPairs {
 		n := networkPair
 		var ok bool

--- a/integration-tests/ccip-tests/testsetups/ccip.go
+++ b/integration-tests/ccip-tests/testsetups/ccip.go
@@ -861,7 +861,7 @@ func CCIPDefaultTestSetUp(
 		setUpArgs.WaitForPriceUpdates()
 		// if dynamic price update is required
 		if setUpArgs.Cfg.TestGroupInput.DynamicPriceUpdateInterval != nil {
-			require.NoError(t, setUpArgs.SetupDynamicTokenPriceUpdates(), "setting up dynamic price update shoud not fail")
+			require.NoError(t, setUpArgs.SetupDynamicTokenPriceUpdates(), "setting up dynamic price update should not fail")
 		}
 	}
 

--- a/integration-tests/ccip-tests/testsetups/ccip.go
+++ b/integration-tests/ccip-tests/testsetups/ccip.go
@@ -820,7 +820,7 @@ func CCIPDefaultTestSetUp(
 	// deploy all lane specific contracts
 	lggr.Info().Msg("Deploying chain specific contracts")
 	laneAddGrp, _ := errgroup.WithContext(setUpArgs.SetUpContext)
-	// for memory management add only 20 lanes in parallel
+	// for memory management set a batch size for active lane deployment group
 	laneAddGrp.SetLimit(200)
 	for _, networkPair := range testConfig.NetworkPairs {
 		n := networkPair

--- a/integration-tests/ccip-tests/testsetups/ccip.go
+++ b/integration-tests/ccip-tests/testsetups/ccip.go
@@ -36,7 +36,7 @@ import (
 	"github.com/smartcontractkit/chainlink-testing-framework/k8s/environment"
 	"github.com/smartcontractkit/chainlink-testing-framework/networks"
 
-	"github.com/smartcontractkit/ccip/integration-tests/ccip-tests/contracts"
+	"github.com/smartcontractkit/chainlink/integration-tests/ccip-tests/contracts"
 
 	integrationactions "github.com/smartcontractkit/chainlink/integration-tests/actions"
 	"github.com/smartcontractkit/chainlink/integration-tests/ccip-tests/actions"

--- a/integration-tests/ccip-tests/testsetups/ccip.go
+++ b/integration-tests/ccip-tests/testsetups/ccip.go
@@ -804,6 +804,8 @@ func CCIPDefaultTestSetUp(
 	// deploy all lane specific contracts
 	lggr.Info().Msg("Deploying chain specific contracts")
 	laneAddGrp, _ := errgroup.WithContext(setUpArgs.SetUpContext)
+	// for memory management add only 5 lanes in parallel
+	laneAddGrp.SetLimit(5)
 	for _, networkPair := range testConfig.NetworkPairs {
 		n := networkPair
 		var ok bool

--- a/integration-tests/ccip-tests/testsetups/test_env.go
+++ b/integration-tests/ccip-tests/testsetups/test_env.go
@@ -103,7 +103,7 @@ func ChainlinkChart(
 		"additionalArgs":   formattedArgs,
 		"stateful":         pointer.GetBool(testInputs.EnvInput.NewCLCluster.IsStateful),
 		"capacity":         testInputs.EnvInput.NewCLCluster.DBCapacity,
-		"storageClassName": "gp3",
+		"storageClassName": pointer.GetString(testInputs.EnvInput.NewCLCluster.DBStorageClass),
 		"image": map[string]any{
 			"image":   testInputs.EnvInput.NewCLCluster.Common.DBImage,
 			"version": testInputs.EnvInput.NewCLCluster.Common.DBTag,

--- a/integration-tests/ccip-tests/testsetups/test_env.go
+++ b/integration-tests/ccip-tests/testsetups/test_env.go
@@ -99,11 +99,12 @@ func ChainlinkChart(
 		}
 	}
 	clProps["db"] = map[string]interface{}{
-		"resources":        SetResourceProfile(testInputs.EnvInput.NewCLCluster.DBCPU, testInputs.EnvInput.NewCLCluster.DBMemory),
-		"additionalArgs":   formattedArgs,
-		"stateful":         pointer.GetBool(testInputs.EnvInput.NewCLCluster.IsStateful),
-		"capacity":         testInputs.EnvInput.NewCLCluster.DBCapacity,
-		"storageClassName": pointer.GetString(testInputs.EnvInput.NewCLCluster.DBStorageClass),
+		"resources":                        SetResourceProfile(testInputs.EnvInput.NewCLCluster.DBCPU, testInputs.EnvInput.NewCLCluster.DBMemory),
+		"additionalArgs":                   formattedArgs,
+		"stateful":                         pointer.GetBool(testInputs.EnvInput.NewCLCluster.IsStateful),
+		"capacity":                         testInputs.EnvInput.NewCLCluster.DBCapacity,
+		"storageClassName":                 pointer.GetString(testInputs.EnvInput.NewCLCluster.DBStorageClass),
+		"enablePrometheusPostgresExporter": pointer.GetBool(testInputs.EnvInput.NewCLCluster.PromPgExporter),
 		"image": map[string]any{
 			"image":   testInputs.EnvInput.NewCLCluster.Common.DBImage,
 			"version": testInputs.EnvInput.NewCLCluster.Common.DBTag,

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.13
 	github.com/smartcontractkit/chainlink-automation v1.0.2-0.20240311111125-22812a072c35
 	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240326183122-8012c0f08116
-	github.com/smartcontractkit/chainlink-testing-framework v1.27.9
+	github.com/smartcontractkit/chainlink-testing-framework v1.28.0
 	github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868
 	github.com/smartcontractkit/chainlink/integration-tests v0.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.13
 	github.com/smartcontractkit/chainlink-automation v1.0.2-0.20240311111125-22812a072c35
 	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240326183122-8012c0f08116
-	github.com/smartcontractkit/chainlink-testing-framework v1.28.1-0.20240402015345-7e93d4806cad
+	github.com/smartcontractkit/chainlink-testing-framework v1.28.1-0.20240402041143-d05d8fef4769
 	github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868
 	github.com/smartcontractkit/chainlink/integration-tests v0.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240326183122-8012c0f08116
 	github.com/smartcontractkit/chainlink-testing-framework v1.27.10-0.20240402001619-19df4e8c3ad8
 	github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868
+	github.com/smartcontractkit/chainlink/integration-tests v0.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/libocr v0.0.0-20240229181116-bfb2432a7a66
 	github.com/smartcontractkit/seth v0.1.2

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.13
 	github.com/smartcontractkit/chainlink-automation v1.0.2-0.20240311111125-22812a072c35
 	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240326183122-8012c0f08116
-	github.com/smartcontractkit/chainlink-testing-framework v1.27.5
+	github.com/smartcontractkit/chainlink-testing-framework v1.27.9
 	github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868
 	github.com/smartcontractkit/chainlink/integration-tests v0.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -28,9 +28,8 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.13
 	github.com/smartcontractkit/chainlink-automation v1.0.2-0.20240311111125-22812a072c35
 	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240326183122-8012c0f08116
-	github.com/smartcontractkit/chainlink-testing-framework v1.28.0
+	github.com/smartcontractkit/chainlink-testing-framework v1.27.10-0.20240402001619-19df4e8c3ad8
 	github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868
-	github.com/smartcontractkit/chainlink/integration-tests v0.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/libocr v0.0.0-20240229181116-bfb2432a7a66
 	github.com/smartcontractkit/seth v0.1.2

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/smartcontractkit/chain-selectors v1.0.13
 	github.com/smartcontractkit/chainlink-automation v1.0.2-0.20240311111125-22812a072c35
 	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240326183122-8012c0f08116
-	github.com/smartcontractkit/chainlink-testing-framework v1.27.10-0.20240402001619-19df4e8c3ad8
+	github.com/smartcontractkit/chainlink-testing-framework v1.28.1-0.20240402015345-7e93d4806cad
 	github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868
 	github.com/smartcontractkit/chainlink/integration-tests v0.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1526,8 +1526,6 @@ github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.202402
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240213121419-1272736c2ac0/go.mod h1:SZ899lZYQ0maUulWbZg+SWqabHQ1wTbyk3jT8wJfyo8=
 github.com/smartcontractkit/chainlink-testing-framework v1.27.10-0.20240402001619-19df4e8c3ad8 h1:CPBESAJFgVtsTbc+17i7f/+FXzyo7kARTX8W39cpCvU=
 github.com/smartcontractkit/chainlink-testing-framework v1.27.10-0.20240402001619-19df4e8c3ad8/go.mod h1:jN+HgXbriq6fKRlIqLw9F3I81aYImV6kBJkIfz0mdIA=
-github.com/smartcontractkit/chainlink-testing-framework v1.28.0 h1:9klFNw4AVdbvbSAof347G0DIhu7sbxPv7WMJvsEDI5k=
-github.com/smartcontractkit/chainlink-testing-framework v1.28.0/go.mod h1:jN+HgXbriq6fKRlIqLw9F3I81aYImV6kBJkIfz0mdIA=
 github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868 h1:FFdvEzlYwcuVHkdZ8YnZR/XomeMGbz5E2F2HZI3I3w8=
 github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868/go.mod h1:Kn1Hape05UzFZ7bOUnm3GVsHzP0TNrVmpfXYNHdqGGs=
 github.com/smartcontractkit/go-plugin v0.0.0-20240208201424-b3b91517de16 h1:TFe+FvzxClblt6qRfqEhUfa4kFQx5UobuoFGO2W4mMo=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1524,6 +1524,8 @@ github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240216142700-c5869534c19
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240216142700-c5869534c19e/go.mod h1:JiykN+8W5TA4UD2ClrzQCVvcH3NcyLEVv7RwY0busrw=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240213121419-1272736c2ac0 h1:7m9PVtccb8/pvKTXMaGuyceFno1icRyC2SFH7KG7+70=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240213121419-1272736c2ac0/go.mod h1:SZ899lZYQ0maUulWbZg+SWqabHQ1wTbyk3jT8wJfyo8=
+github.com/smartcontractkit/chainlink-testing-framework v1.27.10-0.20240402001619-19df4e8c3ad8 h1:CPBESAJFgVtsTbc+17i7f/+FXzyo7kARTX8W39cpCvU=
+github.com/smartcontractkit/chainlink-testing-framework v1.27.10-0.20240402001619-19df4e8c3ad8/go.mod h1:jN+HgXbriq6fKRlIqLw9F3I81aYImV6kBJkIfz0mdIA=
 github.com/smartcontractkit/chainlink-testing-framework v1.28.0 h1:9klFNw4AVdbvbSAof347G0DIhu7sbxPv7WMJvsEDI5k=
 github.com/smartcontractkit/chainlink-testing-framework v1.28.0/go.mod h1:jN+HgXbriq6fKRlIqLw9F3I81aYImV6kBJkIfz0mdIA=
 github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868 h1:FFdvEzlYwcuVHkdZ8YnZR/XomeMGbz5E2F2HZI3I3w8=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1524,8 +1524,8 @@ github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240216142700-c5869534c19
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240216142700-c5869534c19e/go.mod h1:JiykN+8W5TA4UD2ClrzQCVvcH3NcyLEVv7RwY0busrw=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240213121419-1272736c2ac0 h1:7m9PVtccb8/pvKTXMaGuyceFno1icRyC2SFH7KG7+70=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240213121419-1272736c2ac0/go.mod h1:SZ899lZYQ0maUulWbZg+SWqabHQ1wTbyk3jT8wJfyo8=
-github.com/smartcontractkit/chainlink-testing-framework v1.27.10-0.20240402001619-19df4e8c3ad8 h1:CPBESAJFgVtsTbc+17i7f/+FXzyo7kARTX8W39cpCvU=
-github.com/smartcontractkit/chainlink-testing-framework v1.27.10-0.20240402001619-19df4e8c3ad8/go.mod h1:jN+HgXbriq6fKRlIqLw9F3I81aYImV6kBJkIfz0mdIA=
+github.com/smartcontractkit/chainlink-testing-framework v1.28.1-0.20240402015345-7e93d4806cad h1:u7dvfuMKJCTNmN+xBwcxCOYyckkobKsFtHBbpKI9R+A=
+github.com/smartcontractkit/chainlink-testing-framework v1.28.1-0.20240402015345-7e93d4806cad/go.mod h1:jN+HgXbriq6fKRlIqLw9F3I81aYImV6kBJkIfz0mdIA=
 github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868 h1:FFdvEzlYwcuVHkdZ8YnZR/XomeMGbz5E2F2HZI3I3w8=
 github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868/go.mod h1:Kn1Hape05UzFZ7bOUnm3GVsHzP0TNrVmpfXYNHdqGGs=
 github.com/smartcontractkit/go-plugin v0.0.0-20240208201424-b3b91517de16 h1:TFe+FvzxClblt6qRfqEhUfa4kFQx5UobuoFGO2W4mMo=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1524,8 +1524,8 @@ github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240216142700-c5869534c19
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240216142700-c5869534c19e/go.mod h1:JiykN+8W5TA4UD2ClrzQCVvcH3NcyLEVv7RwY0busrw=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240213121419-1272736c2ac0 h1:7m9PVtccb8/pvKTXMaGuyceFno1icRyC2SFH7KG7+70=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240213121419-1272736c2ac0/go.mod h1:SZ899lZYQ0maUulWbZg+SWqabHQ1wTbyk3jT8wJfyo8=
-github.com/smartcontractkit/chainlink-testing-framework v1.27.9 h1:oZcj9i1xo4X8OwRtIAT4kzvqlKJmWqKVJZ66eR7VVzk=
-github.com/smartcontractkit/chainlink-testing-framework v1.27.9/go.mod h1:jN+HgXbriq6fKRlIqLw9F3I81aYImV6kBJkIfz0mdIA=
+github.com/smartcontractkit/chainlink-testing-framework v1.28.0 h1:9klFNw4AVdbvbSAof347G0DIhu7sbxPv7WMJvsEDI5k=
+github.com/smartcontractkit/chainlink-testing-framework v1.28.0/go.mod h1:jN+HgXbriq6fKRlIqLw9F3I81aYImV6kBJkIfz0mdIA=
 github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868 h1:FFdvEzlYwcuVHkdZ8YnZR/XomeMGbz5E2F2HZI3I3w8=
 github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868/go.mod h1:Kn1Hape05UzFZ7bOUnm3GVsHzP0TNrVmpfXYNHdqGGs=
 github.com/smartcontractkit/go-plugin v0.0.0-20240208201424-b3b91517de16 h1:TFe+FvzxClblt6qRfqEhUfa4kFQx5UobuoFGO2W4mMo=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1524,8 +1524,8 @@ github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240216142700-c5869534c19
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240216142700-c5869534c19e/go.mod h1:JiykN+8W5TA4UD2ClrzQCVvcH3NcyLEVv7RwY0busrw=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240213121419-1272736c2ac0 h1:7m9PVtccb8/pvKTXMaGuyceFno1icRyC2SFH7KG7+70=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240213121419-1272736c2ac0/go.mod h1:SZ899lZYQ0maUulWbZg+SWqabHQ1wTbyk3jT8wJfyo8=
-github.com/smartcontractkit/chainlink-testing-framework v1.27.5 h1:wEPPalkJDb4hHmNayexBWxRc/StGV6ZgsXHe8LxdHKY=
-github.com/smartcontractkit/chainlink-testing-framework v1.27.5/go.mod h1:jN+HgXbriq6fKRlIqLw9F3I81aYImV6kBJkIfz0mdIA=
+github.com/smartcontractkit/chainlink-testing-framework v1.27.9 h1:oZcj9i1xo4X8OwRtIAT4kzvqlKJmWqKVJZ66eR7VVzk=
+github.com/smartcontractkit/chainlink-testing-framework v1.27.9/go.mod h1:jN+HgXbriq6fKRlIqLw9F3I81aYImV6kBJkIfz0mdIA=
 github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868 h1:FFdvEzlYwcuVHkdZ8YnZR/XomeMGbz5E2F2HZI3I3w8=
 github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868/go.mod h1:Kn1Hape05UzFZ7bOUnm3GVsHzP0TNrVmpfXYNHdqGGs=
 github.com/smartcontractkit/go-plugin v0.0.0-20240208201424-b3b91517de16 h1:TFe+FvzxClblt6qRfqEhUfa4kFQx5UobuoFGO2W4mMo=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1524,8 +1524,8 @@ github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240216142700-c5869534c19
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240216142700-c5869534c19e/go.mod h1:JiykN+8W5TA4UD2ClrzQCVvcH3NcyLEVv7RwY0busrw=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240213121419-1272736c2ac0 h1:7m9PVtccb8/pvKTXMaGuyceFno1icRyC2SFH7KG7+70=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240213121419-1272736c2ac0/go.mod h1:SZ899lZYQ0maUulWbZg+SWqabHQ1wTbyk3jT8wJfyo8=
-github.com/smartcontractkit/chainlink-testing-framework v1.28.1-0.20240402015345-7e93d4806cad h1:u7dvfuMKJCTNmN+xBwcxCOYyckkobKsFtHBbpKI9R+A=
-github.com/smartcontractkit/chainlink-testing-framework v1.28.1-0.20240402015345-7e93d4806cad/go.mod h1:jN+HgXbriq6fKRlIqLw9F3I81aYImV6kBJkIfz0mdIA=
+github.com/smartcontractkit/chainlink-testing-framework v1.28.1-0.20240402041143-d05d8fef4769 h1:EeKY/xZ2AbNGP46OI1lEldwE4Dqxnhjkk88icrj92vI=
+github.com/smartcontractkit/chainlink-testing-framework v1.28.1-0.20240402041143-d05d8fef4769/go.mod h1:jN+HgXbriq6fKRlIqLw9F3I81aYImV6kBJkIfz0mdIA=
 github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868 h1:FFdvEzlYwcuVHkdZ8YnZR/XomeMGbz5E2F2HZI3I3w8=
 github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868/go.mod h1:Kn1Hape05UzFZ7bOUnm3GVsHzP0TNrVmpfXYNHdqGGs=
 github.com/smartcontractkit/go-plugin v0.0.0-20240208201424-b3b91517de16 h1:TFe+FvzxClblt6qRfqEhUfa4kFQx5UobuoFGO2W4mMo=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/slack-go/slack v0.12.2
 	github.com/smartcontractkit/chainlink-automation v1.0.2-0.20240311111125-22812a072c35
 	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240326183122-8012c0f08116
-	github.com/smartcontractkit/chainlink-testing-framework v1.27.5
+	github.com/smartcontractkit/chainlink-testing-framework v1.27.9
 	github.com/smartcontractkit/chainlink/integration-tests v0.0.0-20240214231432-4ad5eb95178c
 	github.com/smartcontractkit/chainlink/v2 v2.9.0-beta0.0.20240216210048-da02459ddad8
 	github.com/smartcontractkit/libocr v0.0.0-20240229181116-bfb2432a7a66

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/slack-go/slack v0.12.2
 	github.com/smartcontractkit/chainlink-automation v1.0.2-0.20240311111125-22812a072c35
 	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240326183122-8012c0f08116
-	github.com/smartcontractkit/chainlink-testing-framework v1.28.1-0.20240402015345-7e93d4806cad
+	github.com/smartcontractkit/chainlink-testing-framework v1.28.1-0.20240402041143-d05d8fef4769
 	github.com/smartcontractkit/chainlink/integration-tests v0.0.0-20240214231432-4ad5eb95178c
 	github.com/smartcontractkit/chainlink/v2 v2.9.0-beta0.0.20240216210048-da02459ddad8
 	github.com/smartcontractkit/libocr v0.0.0-20240229181116-bfb2432a7a66

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/slack-go/slack v0.12.2
 	github.com/smartcontractkit/chainlink-automation v1.0.2-0.20240311111125-22812a072c35
 	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240326183122-8012c0f08116
-	github.com/smartcontractkit/chainlink-testing-framework v1.27.9
+	github.com/smartcontractkit/chainlink-testing-framework v1.28.0
 	github.com/smartcontractkit/chainlink/integration-tests v0.0.0-20240214231432-4ad5eb95178c
 	github.com/smartcontractkit/chainlink/v2 v2.9.0-beta0.0.20240216210048-da02459ddad8
 	github.com/smartcontractkit/libocr v0.0.0-20240229181116-bfb2432a7a66

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/slack-go/slack v0.12.2
 	github.com/smartcontractkit/chainlink-automation v1.0.2-0.20240311111125-22812a072c35
 	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240326183122-8012c0f08116
-	github.com/smartcontractkit/chainlink-testing-framework v1.28.0
+	github.com/smartcontractkit/chainlink-testing-framework v1.27.10-0.20240402001619-19df4e8c3ad8
 	github.com/smartcontractkit/chainlink/integration-tests v0.0.0-20240214231432-4ad5eb95178c
 	github.com/smartcontractkit/chainlink/v2 v2.9.0-beta0.0.20240216210048-da02459ddad8
 	github.com/smartcontractkit/libocr v0.0.0-20240229181116-bfb2432a7a66

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/slack-go/slack v0.12.2
 	github.com/smartcontractkit/chainlink-automation v1.0.2-0.20240311111125-22812a072c35
 	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240326183122-8012c0f08116
-	github.com/smartcontractkit/chainlink-testing-framework v1.27.10-0.20240402001619-19df4e8c3ad8
+	github.com/smartcontractkit/chainlink-testing-framework v1.28.1-0.20240402015345-7e93d4806cad
 	github.com/smartcontractkit/chainlink/integration-tests v0.0.0-20240214231432-4ad5eb95178c
 	github.com/smartcontractkit/chainlink/v2 v2.9.0-beta0.0.20240216210048-da02459ddad8
 	github.com/smartcontractkit/libocr v0.0.0-20240229181116-bfb2432a7a66

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1507,8 +1507,8 @@ github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240216142700-c5869534c19
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240216142700-c5869534c19e/go.mod h1:JiykN+8W5TA4UD2ClrzQCVvcH3NcyLEVv7RwY0busrw=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240213121419-1272736c2ac0 h1:7m9PVtccb8/pvKTXMaGuyceFno1icRyC2SFH7KG7+70=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240213121419-1272736c2ac0/go.mod h1:SZ899lZYQ0maUulWbZg+SWqabHQ1wTbyk3jT8wJfyo8=
-github.com/smartcontractkit/chainlink-testing-framework v1.28.0 h1:9klFNw4AVdbvbSAof347G0DIhu7sbxPv7WMJvsEDI5k=
-github.com/smartcontractkit/chainlink-testing-framework v1.28.0/go.mod h1:jN+HgXbriq6fKRlIqLw9F3I81aYImV6kBJkIfz0mdIA=
+github.com/smartcontractkit/chainlink-testing-framework v1.27.10-0.20240402001619-19df4e8c3ad8 h1:CPBESAJFgVtsTbc+17i7f/+FXzyo7kARTX8W39cpCvU=
+github.com/smartcontractkit/chainlink-testing-framework v1.27.10-0.20240402001619-19df4e8c3ad8/go.mod h1:jN+HgXbriq6fKRlIqLw9F3I81aYImV6kBJkIfz0mdIA=
 github.com/smartcontractkit/chainlink-testing-framework/grafana v0.0.0-20240227164431-18a7065e23ea h1:ZdLmNAfKRjH8AYUvjiiDGUgiWQfq/7iNpxyTkvjx/ko=
 github.com/smartcontractkit/chainlink-testing-framework/grafana v0.0.0-20240227164431-18a7065e23ea/go.mod h1:gCKC9w6XpNk6jm+XIk2psrkkfxhi421N9NSiFceXW88=
 github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868 h1:FFdvEzlYwcuVHkdZ8YnZR/XomeMGbz5E2F2HZI3I3w8=

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1507,8 +1507,8 @@ github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240216142700-c5869534c19
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240216142700-c5869534c19e/go.mod h1:JiykN+8W5TA4UD2ClrzQCVvcH3NcyLEVv7RwY0busrw=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240213121419-1272736c2ac0 h1:7m9PVtccb8/pvKTXMaGuyceFno1icRyC2SFH7KG7+70=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240213121419-1272736c2ac0/go.mod h1:SZ899lZYQ0maUulWbZg+SWqabHQ1wTbyk3jT8wJfyo8=
-github.com/smartcontractkit/chainlink-testing-framework v1.28.1-0.20240402015345-7e93d4806cad h1:u7dvfuMKJCTNmN+xBwcxCOYyckkobKsFtHBbpKI9R+A=
-github.com/smartcontractkit/chainlink-testing-framework v1.28.1-0.20240402015345-7e93d4806cad/go.mod h1:jN+HgXbriq6fKRlIqLw9F3I81aYImV6kBJkIfz0mdIA=
+github.com/smartcontractkit/chainlink-testing-framework v1.28.1-0.20240402041143-d05d8fef4769 h1:EeKY/xZ2AbNGP46OI1lEldwE4Dqxnhjkk88icrj92vI=
+github.com/smartcontractkit/chainlink-testing-framework v1.28.1-0.20240402041143-d05d8fef4769/go.mod h1:jN+HgXbriq6fKRlIqLw9F3I81aYImV6kBJkIfz0mdIA=
 github.com/smartcontractkit/chainlink-testing-framework/grafana v0.0.0-20240227164431-18a7065e23ea h1:ZdLmNAfKRjH8AYUvjiiDGUgiWQfq/7iNpxyTkvjx/ko=
 github.com/smartcontractkit/chainlink-testing-framework/grafana v0.0.0-20240227164431-18a7065e23ea/go.mod h1:gCKC9w6XpNk6jm+XIk2psrkkfxhi421N9NSiFceXW88=
 github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868 h1:FFdvEzlYwcuVHkdZ8YnZR/XomeMGbz5E2F2HZI3I3w8=

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1507,8 +1507,8 @@ github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240216142700-c5869534c19
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240216142700-c5869534c19e/go.mod h1:JiykN+8W5TA4UD2ClrzQCVvcH3NcyLEVv7RwY0busrw=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240213121419-1272736c2ac0 h1:7m9PVtccb8/pvKTXMaGuyceFno1icRyC2SFH7KG7+70=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240213121419-1272736c2ac0/go.mod h1:SZ899lZYQ0maUulWbZg+SWqabHQ1wTbyk3jT8wJfyo8=
-github.com/smartcontractkit/chainlink-testing-framework v1.27.9 h1:oZcj9i1xo4X8OwRtIAT4kzvqlKJmWqKVJZ66eR7VVzk=
-github.com/smartcontractkit/chainlink-testing-framework v1.27.9/go.mod h1:jN+HgXbriq6fKRlIqLw9F3I81aYImV6kBJkIfz0mdIA=
+github.com/smartcontractkit/chainlink-testing-framework v1.28.0 h1:9klFNw4AVdbvbSAof347G0DIhu7sbxPv7WMJvsEDI5k=
+github.com/smartcontractkit/chainlink-testing-framework v1.28.0/go.mod h1:jN+HgXbriq6fKRlIqLw9F3I81aYImV6kBJkIfz0mdIA=
 github.com/smartcontractkit/chainlink-testing-framework/grafana v0.0.0-20240227164431-18a7065e23ea h1:ZdLmNAfKRjH8AYUvjiiDGUgiWQfq/7iNpxyTkvjx/ko=
 github.com/smartcontractkit/chainlink-testing-framework/grafana v0.0.0-20240227164431-18a7065e23ea/go.mod h1:gCKC9w6XpNk6jm+XIk2psrkkfxhi421N9NSiFceXW88=
 github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868 h1:FFdvEzlYwcuVHkdZ8YnZR/XomeMGbz5E2F2HZI3I3w8=

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1507,8 +1507,8 @@ github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240216142700-c5869534c19
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240216142700-c5869534c19e/go.mod h1:JiykN+8W5TA4UD2ClrzQCVvcH3NcyLEVv7RwY0busrw=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240213121419-1272736c2ac0 h1:7m9PVtccb8/pvKTXMaGuyceFno1icRyC2SFH7KG7+70=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240213121419-1272736c2ac0/go.mod h1:SZ899lZYQ0maUulWbZg+SWqabHQ1wTbyk3jT8wJfyo8=
-github.com/smartcontractkit/chainlink-testing-framework v1.27.5 h1:wEPPalkJDb4hHmNayexBWxRc/StGV6ZgsXHe8LxdHKY=
-github.com/smartcontractkit/chainlink-testing-framework v1.27.5/go.mod h1:jN+HgXbriq6fKRlIqLw9F3I81aYImV6kBJkIfz0mdIA=
+github.com/smartcontractkit/chainlink-testing-framework v1.27.9 h1:oZcj9i1xo4X8OwRtIAT4kzvqlKJmWqKVJZ66eR7VVzk=
+github.com/smartcontractkit/chainlink-testing-framework v1.27.9/go.mod h1:jN+HgXbriq6fKRlIqLw9F3I81aYImV6kBJkIfz0mdIA=
 github.com/smartcontractkit/chainlink-testing-framework/grafana v0.0.0-20240227164431-18a7065e23ea h1:ZdLmNAfKRjH8AYUvjiiDGUgiWQfq/7iNpxyTkvjx/ko=
 github.com/smartcontractkit/chainlink-testing-framework/grafana v0.0.0-20240227164431-18a7065e23ea/go.mod h1:gCKC9w6XpNk6jm+XIk2psrkkfxhi421N9NSiFceXW88=
 github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868 h1:FFdvEzlYwcuVHkdZ8YnZR/XomeMGbz5E2F2HZI3I3w8=

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1507,8 +1507,8 @@ github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240216142700-c5869534c19
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20240216142700-c5869534c19e/go.mod h1:JiykN+8W5TA4UD2ClrzQCVvcH3NcyLEVv7RwY0busrw=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240213121419-1272736c2ac0 h1:7m9PVtccb8/pvKTXMaGuyceFno1icRyC2SFH7KG7+70=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20240213121419-1272736c2ac0/go.mod h1:SZ899lZYQ0maUulWbZg+SWqabHQ1wTbyk3jT8wJfyo8=
-github.com/smartcontractkit/chainlink-testing-framework v1.27.10-0.20240402001619-19df4e8c3ad8 h1:CPBESAJFgVtsTbc+17i7f/+FXzyo7kARTX8W39cpCvU=
-github.com/smartcontractkit/chainlink-testing-framework v1.27.10-0.20240402001619-19df4e8c3ad8/go.mod h1:jN+HgXbriq6fKRlIqLw9F3I81aYImV6kBJkIfz0mdIA=
+github.com/smartcontractkit/chainlink-testing-framework v1.28.1-0.20240402015345-7e93d4806cad h1:u7dvfuMKJCTNmN+xBwcxCOYyckkobKsFtHBbpKI9R+A=
+github.com/smartcontractkit/chainlink-testing-framework v1.28.1-0.20240402015345-7e93d4806cad/go.mod h1:jN+HgXbriq6fKRlIqLw9F3I81aYImV6kBJkIfz0mdIA=
 github.com/smartcontractkit/chainlink-testing-framework/grafana v0.0.0-20240227164431-18a7065e23ea h1:ZdLmNAfKRjH8AYUvjiiDGUgiWQfq/7iNpxyTkvjx/ko=
 github.com/smartcontractkit/chainlink-testing-framework/grafana v0.0.0-20240227164431-18a7065e23ea/go.mod h1:gCKC9w6XpNk6jm+XIk2psrkkfxhi421N9NSiFceXW88=
 github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868 h1:FFdvEzlYwcuVHkdZ8YnZR/XomeMGbz5E2F2HZI3I3w8=


### PR DESCRIPTION
## Motivation


## Solution
- Disabling Nethermind tests until we know the root cause of flakey tests
- Added a way to set network config in make commands. Now you can keep your network config separate from secrets.toml in BASE64_NETWORK_CONFIG 
- Included `DBStorageClass` and `PromPgExporter` as configurable in test.
- A little change in contract deployment to optimize space as soon as lane is deployed. Needed for scalability tests.
- Parallel lane deployment in batch of 200 lanes at a time instead of deploying all possible lanes in parallel, helps with memory management.