### PR TITLE
Log offramp in commit plugin init

### DIFF
--- a/.changeset/young-hounds-wave.md
+++ b/.changeset/young-hounds-wave.md
@@ -1,0 +1,5 @@
+---
+"ccip": patch
+---
+
+Add OffRamp address log during Commit plugin init

--- a/core/services/ocr2/plugins/ccip/ccipcommit/initializers.go
+++ b/core/services/ocr2/plugins/ccip/ccipcommit/initializers.go
@@ -124,6 +124,7 @@ func jobSpecToCommitPluginConfig(ctx context.Context, lggr logger.Logger, jb job
 
 	lggr.Infow("Initializing commit plugin",
 		"CommitStore", params.commitStoreAddress,
+		"OffRamp", params.pluginConfig.OffRamp,
 		"OnRamp", params.commitStoreStaticCfg.OnRamp,
 		"ArmProxy", params.commitStoreStaticCfg.ArmProxy,
 		"SourceChainSelector", params.commitStoreStaticCfg.SourceChainSelector,


### PR DESCRIPTION
## Motivation
Commit plugin init on Avax Fuji on beta env fails with invalid version 1.4, it doesn't make sense given the OffRamp in jobsepc is indeed v1.2. 

## Solution
Log the offramp address it is calling