### PR TITLE
Replace prettier with forge fmt

### DIFF
--- a/.github/workflows/solidity-foundry.yml
+++ b/.github/workflows/solidity-foundry.yml
@@ -3,6 +3,8 @@ on: [pull_request]
 
 env:
   FOUNDRY_PROFILE: ci
+  # Has to match the `make foundry` version in `contracts/GNUmakefile`
+  FOUNDRY_VERSION: nightly-2cb875799419c907cc3709e586ece2559e6b340e
 
 jobs:
   changes:
@@ -58,9 +60,10 @@ jobs:
         uses: ./.github/actions/setup-nodejs
 
       - name: Install Foundry
+        if: needs.changes.outputs.changes == 'true'
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: ${{ env.FOUNDRY_VERSION }}
 
       - name: Run Forge build
         if: ${{ needs.changes.outputs.changes == 'true' }}
@@ -121,8 +124,7 @@ jobs:
         if: needs.changes.outputs.changes == 'true'
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          # Has to match the `make foundry` version.
-          version: nightly-2cb875799419c907cc3709e586ece2559e6b340e
+          version: ${{ env.FOUNDRY_VERSION }}
 
       - name: Run Forge build
         if: needs.changes.outputs.changes == 'true'
@@ -148,6 +150,58 @@ jobs:
         run: |
           forge snapshot --nmt "testFuzz_\w{1,}?" --check gas-snapshots/${{ matrix.product }}.gas-snapshot
         id: snapshot
+        working-directory: contracts
+        env:
+          FOUNDRY_PROFILE: ${{ matrix.product }}
+
+      - name: Collect Metrics
+        if: needs.changes.outputs.changes == 'true'
+        id: collect-gha-metrics
+        uses: smartcontractkit/push-gha-metrics-action@0281b09807758be1dcc41651e44e62b353808c47 # v2.1.0
+        with:
+          org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
+          basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
+          hostname: ${{ secrets.GRAFANA_INTERNAL_HOST }}
+          this-job-name: Foundry Tests ${{ matrix.product }}
+        continue-on-error: true
+
+
+  fmt:
+    strategy:
+      fail-fast: false
+      matrix:
+        product: [ ccip ]
+    needs: [ changes ]
+    name: Forge fmt ${{ matrix.product }}
+    # See https://github.com/foundry-rs/foundry/issues/3827
+    runs-on: ubuntu-22.04
+
+    # The if statements for steps after checkout repo is workaround for
+    # passing required check for PRs that don't have filtered changes.
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          submodules: recursive
+
+      # Only needed because we use the NPM versions of packages
+      # and not native Foundry. This is to make sure the dependencies
+      # stay in sync.
+      - name: Setup NodeJS
+        if: needs.changes.outputs.changes == 'true'
+        uses: ./.github/actions/setup-nodejs
+
+      - name: Install Foundry
+        if: needs.changes.outputs.changes == 'true'
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: ${{ env.FOUNDRY_VERSION }}
+
+      - name: Run Forge fmt
+        if: needs.changes.outputs.changes == 'true'
+        run: |
+          forge fmt --check
+        id: fmt
         working-directory: contracts
         env:
           FOUNDRY_PROFILE: ${{ matrix.product }}

--- a/contracts/.prettierignore
+++ b/contracts/.prettierignore
@@ -26,6 +26,7 @@ src/v0.5
 src/v0.6
 src/v0.7
 **/vendor
+src/v0.8/ccip/**
 
 # Ignore TS definition and map files
 **/**.d.ts

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -19,7 +19,7 @@ block_number = 12345
 [fmt]
 tab_width = 2
 multiline_func_header = "params_first"
-sort_imports = false
+sort_imports = true
 single_line_statement_blocks = "preserve"
 
 [profile.ccip]

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -16,6 +16,12 @@ gas_price = 1
 block_timestamp = 1234567890
 block_number = 12345
 
+[fmt]
+tab_width = 2
+multiline_func_header = "params_first"
+sort_imports = false
+single_line_statement_blocks = "preserve"
+
 [profile.ccip]
 solc_version = '0.8.19'
 src = 'src/v0.8/ccip'

--- a/contracts/src/v0.8/ccip/ARMProxy.sol
+++ b/contracts/src/v0.8/ccip/ARMProxy.sol
@@ -52,9 +52,7 @@ contract ARMProxy is OwnerIsCreator, ITypeAndVersion {
     assembly {
       // Revert if no contract present at destination address, otherwise call
       // might succeed unintentionally.
-      if iszero(extcodesize(arm)) {
-        revert(0, 0)
-      }
+      if iszero(extcodesize(arm)) { revert(0, 0) }
       // We use memory starting at zero, overwriting anything that might already
       // be stored there. This messes with Solidity's expectations around memory
       // layout, but it's fine because we always exit execution of this contract
@@ -69,9 +67,7 @@ contract ARMProxy is OwnerIsCreator, ITypeAndVersion {
       // Copy the returned data.
       returndatacopy(0, 0, returndatasize())
       // Pass through successful return or revert and associated data.
-      if success {
-        return(0, returndatasize())
-      }
+      if success { return(0, returndatasize()) }
       revert(0, returndatasize())
     }
   }

--- a/contracts/src/v0.8/ccip/CommitStore.sol
+++ b/contracts/src/v0.8/ccip/CommitStore.sol
@@ -2,13 +2,13 @@
 pragma solidity 0.8.19;
 
 import {ITypeAndVersion} from "../shared/interfaces/ITypeAndVersion.sol";
-import {ICommitStore} from "./interfaces/ICommitStore.sol";
 import {IARM} from "./interfaces/IARM.sol";
+import {ICommitStore} from "./interfaces/ICommitStore.sol";
 import {IPriceRegistry} from "./interfaces/IPriceRegistry.sol";
 
-import {OCR2Base} from "./ocr/OCR2Base.sol";
 import {Internal} from "./libraries/Internal.sol";
 import {MerkleMultiProof} from "./libraries/MerkleMultiProof.sol";
+import {OCR2Base} from "./ocr/OCR2Base.sol";
 
 contract CommitStore is ICommitStore, ITypeAndVersion, OCR2Base {
   error StaleReport();

--- a/contracts/src/v0.8/ccip/CommitStore.sol
+++ b/contracts/src/v0.8/ccip/CommitStore.sol
@@ -88,10 +88,8 @@ contract CommitStore is ICommitStore, ITypeAndVersion, OCR2Base {
   /// will either be ignored (reverted as an invalid interval) or will be accepted as an additional valid price update.
   constructor(StaticConfig memory staticConfig) OCR2Base(false) {
     if (
-      staticConfig.onRamp == address(0) ||
-      staticConfig.chainSelector == 0 ||
-      staticConfig.sourceChainSelector == 0 ||
-      staticConfig.armProxy == address(0)
+      staticConfig.onRamp == address(0) || staticConfig.chainSelector == 0 || staticConfig.sourceChainSelector == 0
+        || staticConfig.armProxy == address(0)
     ) revert InvalidCommitStoreConfig();
 
     i_chainSelector = staticConfig.chainSelector;
@@ -207,8 +205,9 @@ contract CommitStore is ICommitStore, ITypeAndVersion, OCR2Base {
     }
 
     // If we reached this section, the report should contain a valid root
-    if (s_minSeqNr != report.interval.min || report.interval.min > report.interval.max)
+    if (s_minSeqNr != report.interval.min || report.interval.min > report.interval.max) {
       revert InvalidInterval(report.interval);
+    }
 
     if (report.merkleRoot == bytes32(0)) revert InvalidRoot();
     // Disallow duplicate roots as that would reset the timestamp and
@@ -228,13 +227,12 @@ contract CommitStore is ICommitStore, ITypeAndVersion, OCR2Base {
   /// @dev RMN depends on this function, if changing, please notify the RMN maintainers.
   /// @return the configuration.
   function getStaticConfig() external view returns (StaticConfig memory) {
-    return
-      StaticConfig({
-        chainSelector: i_chainSelector,
-        sourceChainSelector: i_sourceChainSelector,
-        onRamp: i_onRamp,
-        armProxy: i_armProxy
-      });
+    return StaticConfig({
+      chainSelector: i_chainSelector,
+      sourceChainSelector: i_sourceChainSelector,
+      onRamp: i_onRamp,
+      armProxy: i_armProxy
+    });
   }
 
   /// @notice Returns the dynamic commit store config.

--- a/contracts/src/v0.8/ccip/PriceRegistry.sol
+++ b/contracts/src/v0.8/ccip/PriceRegistry.sol
@@ -40,8 +40,8 @@ contract PriceRegistry is IPriceRegistry, OwnerIsCreator, ITypeAndVersion {
   ///     Very Expensive:   1 unit of gas costs 1 USD                  -> 1e18
   ///     Expensive:        1 unit of gas costs 0.1 USD                -> 1e17
   ///     Cheap:            1 unit of gas costs 0.000001 USD           -> 1e12
-  mapping(uint64 destChainSelector => Internal.TimestampedPackedUint224 price)
-    private s_usdPerUnitGasByDestChainSelector;
+  mapping(uint64 destChainSelector => Internal.TimestampedPackedUint224 price) private
+    s_usdPerUnitGasByDestChainSelector;
 
   /// @dev The price, in USD with 18 decimals, per 1e18 of the smallest token denomination.
   /// @dev Price of 1e18 represents 1 USD per 1e18 token amount.
@@ -79,9 +79,12 @@ contract PriceRegistry is IPriceRegistry, OwnerIsCreator, ITypeAndVersion {
   }
 
   // @inheritdoc IPriceRegistry
-  function getTokenPrices(
-    address[] calldata tokens
-  ) external view override returns (Internal.TimestampedPackedUint224[] memory) {
+  function getTokenPrices(address[] calldata tokens)
+    external
+    view
+    override
+    returns (Internal.TimestampedPackedUint224[] memory)
+  {
     uint256 length = tokens.length;
     Internal.TimestampedPackedUint224[] memory tokenPrices = new Internal.TimestampedPackedUint224[](length);
     for (uint256 i = 0; i < length; ++i) {
@@ -97,9 +100,12 @@ contract PriceRegistry is IPriceRegistry, OwnerIsCreator, ITypeAndVersion {
   }
 
   // @inheritdoc IPriceRegistry
-  function getDestinationChainGasPrice(
-    uint64 destChainSelector
-  ) external view override returns (Internal.TimestampedPackedUint224 memory) {
+  function getDestinationChainGasPrice(uint64 destChainSelector)
+    external
+    view
+    override
+    returns (Internal.TimestampedPackedUint224 memory)
+  {
     return s_usdPerUnitGasByDestChainSelector[destChainSelector];
   }
 
@@ -193,10 +199,8 @@ contract PriceRegistry is IPriceRegistry, OwnerIsCreator, ITypeAndVersion {
 
     for (uint256 i = 0; i < tokenUpdatesLength; ++i) {
       Internal.TokenPriceUpdate memory update = priceUpdates.tokenPriceUpdates[i];
-      s_usdPerToken[update.sourceToken] = Internal.TimestampedPackedUint224({
-        value: update.usdPerToken,
-        timestamp: uint32(block.timestamp)
-      });
+      s_usdPerToken[update.sourceToken] =
+        Internal.TimestampedPackedUint224({value: update.usdPerToken, timestamp: uint32(block.timestamp)});
       emit UsdPerTokenUpdated(update.sourceToken, update.usdPerToken, block.timestamp);
     }
 
@@ -204,10 +208,8 @@ contract PriceRegistry is IPriceRegistry, OwnerIsCreator, ITypeAndVersion {
 
     for (uint256 i = 0; i < gasUpdatesLength; ++i) {
       Internal.GasPriceUpdate memory update = priceUpdates.gasPriceUpdates[i];
-      s_usdPerUnitGasByDestChainSelector[update.destChainSelector] = Internal.TimestampedPackedUint224({
-        value: update.usdPerUnitGas,
-        timestamp: uint32(block.timestamp)
-      });
+      s_usdPerUnitGasByDestChainSelector[update.destChainSelector] =
+        Internal.TimestampedPackedUint224({value: update.usdPerUnitGas, timestamp: uint32(block.timestamp)});
       emit UsdPerUnitGasUpdated(update.destChainSelector, update.usdPerUnitGas, block.timestamp);
     }
   }

--- a/contracts/src/v0.8/ccip/Router.sol
+++ b/contracts/src/v0.8/ccip/Router.sol
@@ -164,11 +164,7 @@ contract Router is IRouter, IRouterClient, ITypeAndVersion, OwnerIsCreator {
     bytes memory data = abi.encodeWithSelector(IAny2EVMMessageReceiver.ccipReceive.selector, message);
 
     (success, retData, gasUsed) = CallWithExactGas._callWithExactGasSafeReturnData(
-      data,
-      receiver,
-      gasLimit,
-      gasForCallExactCheck,
-      Internal.MAX_RET_BYTES
+      data, receiver, gasLimit, gasForCallExactCheck, Internal.MAX_RET_BYTES
     );
 
     emit MessageExecuted(message.messageId, message.sourceChainSelector, msg.sender, keccak256(data));
@@ -216,10 +212,8 @@ contract Router is IRouter, IRouterClient, ITypeAndVersion, OwnerIsCreator {
     OffRamp[] memory offRamps = new OffRamp[](encodedOffRamps.length);
     for (uint256 i = 0; i < encodedOffRamps.length; ++i) {
       uint256 encodedOffRamp = encodedOffRamps[i];
-      offRamps[i] = OffRamp({
-        sourceChainSelector: uint64(encodedOffRamp >> 160),
-        offRamp: address(uint160(encodedOffRamp))
-      });
+      offRamps[i] =
+        OffRamp({sourceChainSelector: uint64(encodedOffRamp >> 160), offRamp: address(uint160(encodedOffRamp))});
     }
     return offRamps;
   }
@@ -251,8 +245,9 @@ contract Router is IRouter, IRouterClient, ITypeAndVersion, OwnerIsCreator {
       address offRampAddress = offRampRemoves[i].offRamp;
 
       // If the selector-offRamp pair does not exist, revert.
-      if (!s_chainSelectorAndOffRamps.remove(_mergeChainSelectorAndOffRamp(sourceChainSelector, offRampAddress)))
+      if (!s_chainSelectorAndOffRamps.remove(_mergeChainSelectorAndOffRamp(sourceChainSelector, offRampAddress))) {
         revert OffRampMismatch(sourceChainSelector, offRampAddress);
+      }
 
       emit OffRampRemoved(sourceChainSelector, offRampAddress);
     }
@@ -276,7 +271,7 @@ contract Router is IRouter, IRouterClient, ITypeAndVersion, OwnerIsCreator {
     if (to == address(0)) revert InvalidRecipientAddress(to);
 
     if (tokenAddress == address(0)) {
-      (bool success, ) = to.call{value: amount}("");
+      (bool success,) = to.call{value: amount}("");
       if (!success) revert FailedToSendValue();
       return;
     }

--- a/contracts/src/v0.8/ccip/Router.sol
+++ b/contracts/src/v0.8/ccip/Router.sol
@@ -2,21 +2,21 @@
 pragma solidity 0.8.19;
 
 import {ITypeAndVersion} from "../shared/interfaces/ITypeAndVersion.sol";
-import {IRouterClient} from "./interfaces/IRouterClient.sol";
-import {IRouter} from "./interfaces/IRouter.sol";
-import {IEVM2AnyOnRamp} from "./interfaces/IEVM2AnyOnRamp.sol";
 import {IARM} from "./interfaces/IARM.sol";
-import {IWrappedNative} from "./interfaces/IWrappedNative.sol";
 import {IAny2EVMMessageReceiver} from "./interfaces/IAny2EVMMessageReceiver.sol";
+import {IEVM2AnyOnRamp} from "./interfaces/IEVM2AnyOnRamp.sol";
+import {IRouter} from "./interfaces/IRouter.sol";
+import {IRouterClient} from "./interfaces/IRouterClient.sol";
+import {IWrappedNative} from "./interfaces/IWrappedNative.sol";
 
+import {OwnerIsCreator} from "../shared/access/OwnerIsCreator.sol";
+import {CallWithExactGas} from "../shared/call/CallWithExactGas.sol";
 import {Client} from "./libraries/Client.sol";
 import {Internal} from "./libraries/Internal.sol";
-import {CallWithExactGas} from "../shared/call/CallWithExactGas.sol";
-import {OwnerIsCreator} from "../shared/access/OwnerIsCreator.sol";
 
-import {EnumerableSet} from "../vendor/openzeppelin-solidity/v4.8.3/contracts/utils/structs/EnumerableSet.sol";
-import {SafeERC20} from "../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC20} from "../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/utils/SafeERC20.sol";
+import {EnumerableSet} from "../vendor/openzeppelin-solidity/v4.8.3/contracts/utils/structs/EnumerableSet.sol";
 
 /// @title Router
 /// @notice This is the entry point for the end user wishing to send data across chains.

--- a/contracts/src/v0.8/ccip/applications/CCIPClientExample.sol
+++ b/contracts/src/v0.8/ccip/applications/CCIPClientExample.sol
@@ -58,9 +58,13 @@ contract CCIPClientExample is CCIPReceiver, OwnerIsCreator {
     delete s_chains[chainSelector];
   }
 
-  function ccipReceive(
-    Client.Any2EVMMessage calldata message
-  ) external virtual override onlyRouter validChain(message.sourceChainSelector) {
+  function ccipReceive(Client.Any2EVMMessage calldata message)
+    external
+    virtual
+    override
+    onlyRouter
+    validChain(message.sourceChainSelector)
+  {
     // Extremely important to ensure only router calls this.
     // Tokens in message if any will be transferred to this contract
     // TODO: Validate sender/origin chain and process message and/or tokens.

--- a/contracts/src/v0.8/ccip/applications/CCIPClientExample.sol
+++ b/contracts/src/v0.8/ccip/applications/CCIPClientExample.sol
@@ -3,9 +3,9 @@ pragma solidity ^0.8.0;
 
 import {IRouterClient} from "../interfaces/IRouterClient.sol";
 
+import {OwnerIsCreator} from "../../shared/access/OwnerIsCreator.sol";
 import {Client} from "../libraries/Client.sol";
 import {CCIPReceiver} from "./CCIPReceiver.sol";
-import {OwnerIsCreator} from "../../shared/access/OwnerIsCreator.sol";
 
 import {IERC20} from "../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/src/v0.8/ccip/applications/DefensiveExample.sol
+++ b/contracts/src/v0.8/ccip/applications/DefensiveExample.sol
@@ -45,10 +45,14 @@ contract DefensiveExample is CCIPClientExample {
   /// never revert, all errors should be handled internally in this contract.
   /// @param message The message to process.
   /// @dev Extremely important to ensure only router calls this.
-  function ccipReceive(
-    Client.Any2EVMMessage calldata message
-  ) external override onlyRouter validChain(message.sourceChainSelector) {
-    try this.processMessage(message) {} catch (bytes memory err) {
+  function ccipReceive(Client.Any2EVMMessage calldata message)
+    external
+    override
+    onlyRouter
+    validChain(message.sourceChainSelector)
+  {
+    try this.processMessage(message) {}
+    catch (bytes memory err) {
       // Could set different error codes based on the caught error. Each could be
       // handled differently.
       s_failedMessages.set(message.messageId, uint256(ErrorCode.BASIC));
@@ -66,9 +70,11 @@ contract DefensiveExample is CCIPClientExample {
   /// @dev This example just sends the tokens to the owner of this contracts. More
   /// interesting functions could be implemented.
   /// @dev It has to be external because of the try/catch.
-  function processMessage(
-    Client.Any2EVMMessage calldata message
-  ) external onlySelf validChain(message.sourceChainSelector) {
+  function processMessage(Client.Any2EVMMessage calldata message)
+    external
+    onlySelf
+    validChain(message.sourceChainSelector)
+  {
     // Simulate a revert
     if (s_simRevert) revert ErrorCase();
 

--- a/contracts/src/v0.8/ccip/applications/PingPongDemo.sol
+++ b/contracts/src/v0.8/ccip/applications/PingPongDemo.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {IRouterClient} from "../interfaces/IRouterClient.sol";
 import {ITypeAndVersion} from "../../shared/interfaces/ITypeAndVersion.sol";
+import {IRouterClient} from "../interfaces/IRouterClient.sol";
 
 import {OwnerIsCreator} from "../../shared/access/OwnerIsCreator.sol";
 import {Client} from "../libraries/Client.sol";

--- a/contracts/src/v0.8/ccip/applications/SelfFundedPingPong.sol
+++ b/contracts/src/v0.8/ccip/applications/SelfFundedPingPong.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {PingPongDemo} from "./PingPongDemo.sol";
-import {Client} from "../libraries/Client.sol";
 import {Router} from "../Router.sol";
+import {Client} from "../libraries/Client.sol";
 import {EVM2EVMOnRamp} from "../onRamp/EVM2EVMOnRamp.sol";
+import {PingPongDemo} from "./PingPongDemo.sol";
 
 import {IERC20} from "../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/src/v0.8/ccip/applications/TokenProxy.sol
+++ b/contracts/src/v0.8/ccip/applications/TokenProxy.sol
@@ -3,11 +3,11 @@ pragma solidity 0.8.19;
 
 import {IRouterClient} from "../interfaces/IRouterClient.sol";
 
-import {Client} from "../libraries/Client.sol";
 import {OwnerIsCreator} from "../../shared/access/OwnerIsCreator.sol";
+import {Client} from "../libraries/Client.sol";
 
-import {SafeERC20} from "../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC20} from "../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/utils/SafeERC20.sol";
 
 contract TokenProxy is OwnerIsCreator {
   using SafeERC20 for IERC20;

--- a/contracts/src/v0.8/ccip/applications/TokenProxy.sol
+++ b/contracts/src/v0.8/ccip/applications/TokenProxy.sol
@@ -68,8 +68,9 @@ contract TokenProxy is OwnerIsCreator {
     if (message.tokenAmounts.length != 1 || message.tokenAmounts[0].token != i_token) revert InvalidToken();
     if (message.data.length > 0) revert NoDataAllowed();
 
-    if (message.extraArgs.length == 0 || bytes4(message.extraArgs) != Client.EVM_EXTRA_ARGS_V1_TAG)
+    if (message.extraArgs.length == 0 || bytes4(message.extraArgs) != Client.EVM_EXTRA_ARGS_V1_TAG) {
       revert GasShouldBeZero();
+    }
 
     if (abi.decode(message.extraArgs[4:], (Client.EVMExtraArgsV1)).gasLimit != 0) revert GasShouldBeZero();
   }

--- a/contracts/src/v0.8/ccip/interfaces/IPriceRegistry.sol
+++ b/contracts/src/v0.8/ccip/interfaces/IPriceRegistry.sol
@@ -31,9 +31,10 @@ interface IPriceRegistry {
   /// PriceRegistry does not contain chain-specific logic to parse destination chain price components.
   /// @param destChainSelector The destination chain to get the price for.
   /// @return gasPrice The encoded gasPrice for the given destination chain ID.
-  function getDestinationChainGasPrice(
-    uint64 destChainSelector
-  ) external view returns (Internal.TimestampedPackedUint224 memory);
+  function getDestinationChainGasPrice(uint64 destChainSelector)
+    external
+    view
+    returns (Internal.TimestampedPackedUint224 memory);
 
   /// @notice Gets the fee token price and the gas price, both denominated in dollars.
   /// @param token The source token to get the price for.

--- a/contracts/src/v0.8/ccip/libraries/Client.sol
+++ b/contracts/src/v0.8/ccip/libraries/Client.sol
@@ -28,6 +28,7 @@ library Client {
 
   // bytes4(keccak256("CCIP EVMExtraArgsV1"));
   bytes4 public constant EVM_EXTRA_ARGS_V1_TAG = 0x97a657c9;
+
   struct EVMExtraArgsV1 {
     uint256 gasLimit;
   }

--- a/contracts/src/v0.8/ccip/libraries/Internal.sol
+++ b/contracts/src/v0.8/ccip/libraries/Internal.sol
@@ -95,14 +95,13 @@ library Internal {
     EVM2EVMMessage memory original,
     Client.EVMTokenAmount[] memory destTokenAmounts
   ) internal pure returns (Client.Any2EVMMessage memory message) {
-    return
-      Client.Any2EVMMessage({
-        messageId: original.messageId,
-        sourceChainSelector: original.sourceChainSelector,
-        sender: abi.encode(original.sender),
-        data: original.data,
-        destTokenAmounts: destTokenAmounts
-      });
+    return Client.Any2EVMMessage({
+      messageId: original.messageId,
+      sourceChainSelector: original.sourceChainSelector,
+      sender: abi.encode(original.sender),
+      data: original.data,
+      destTokenAmounts: destTokenAmounts
+    });
   }
 
   bytes32 internal constant EVM_2_EVM_MESSAGE_HASH = keccak256("EVM2EVMMessageHashV2");
@@ -110,28 +109,27 @@ library Internal {
   function _hash(EVM2EVMMessage memory original, bytes32 metadataHash) internal pure returns (bytes32) {
     // Fixed-size message fields are included in nested hash to reduce stack pressure.
     // This hashing scheme is also used by RMN. If changing it, please notify the RMN maintainers.
-    return
-      keccak256(
-        abi.encode(
-          MerkleMultiProof.LEAF_DOMAIN_SEPARATOR,
-          metadataHash,
-          keccak256(
-            abi.encode(
-              original.sender,
-              original.receiver,
-              original.sequenceNumber,
-              original.gasLimit,
-              original.strict,
-              original.nonce,
-              original.feeToken,
-              original.feeTokenAmount
-            )
-          ),
-          keccak256(original.data),
-          keccak256(abi.encode(original.tokenAmounts)),
-          keccak256(abi.encode(original.sourceTokenData))
-        )
-      );
+    return keccak256(
+      abi.encode(
+        MerkleMultiProof.LEAF_DOMAIN_SEPARATOR,
+        metadataHash,
+        keccak256(
+          abi.encode(
+            original.sender,
+            original.receiver,
+            original.sequenceNumber,
+            original.gasLimit,
+            original.strict,
+            original.nonce,
+            original.feeToken,
+            original.feeTokenAmount
+          )
+        ),
+        keccak256(original.data),
+        keccak256(abi.encode(original.tokenAmounts)),
+        keccak256(abi.encode(original.sourceTokenData))
+      )
+    );
   }
 
   /// @notice Enum listing the possible message execution states within

--- a/contracts/src/v0.8/ccip/libraries/Internal.sol
+++ b/contracts/src/v0.8/ccip/libraries/Internal.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {Client} from "./Client.sol";
 import {MerkleMultiProof} from "../libraries/MerkleMultiProof.sol";
+import {Client} from "./Client.sol";
 
 // Library for CCIP internal definitions common to multiple contracts.
 library Internal {

--- a/contracts/src/v0.8/ccip/libraries/RateLimiter.sol
+++ b/contracts/src/v0.8/ccip/libraries/RateLimiter.sol
@@ -89,9 +89,8 @@ library RateLimiter {
     // We update the bucket to reflect the status at the exact time of the
     // call. This means we might need to refill a part of the bucket based
     // on the time that has passed since the last update.
-    bucket.tokens = uint128(
-      _calculateRefill(bucket.capacity, bucket.tokens, block.timestamp - bucket.lastUpdated, bucket.rate)
-    );
+    bucket.tokens =
+      uint128(_calculateRefill(bucket.capacity, bucket.tokens, block.timestamp - bucket.lastUpdated, bucket.rate));
     bucket.lastUpdated = uint32(block.timestamp);
     return bucket;
   }

--- a/contracts/src/v0.8/ccip/ocr/OCR2Base.sol
+++ b/contracts/src/v0.8/ccip/ocr/OCR2Base.sol
@@ -68,17 +68,15 @@ abstract contract OCR2Base is OwnerIsCreator, OCR2Abstract {
   // The constant-length components of the msg.data sent to transmit.
   // See the "If we wanted to call sam" example on for example reasoning
   // https://solidity.readthedocs.io/en/v0.7.2/abi-spec.html
-  uint16 private constant TRANSMIT_MSGDATA_CONSTANT_LENGTH_COMPONENT =
-    4 + // function selector
-      32 *
-      3 + // 3 words containing reportContext
-      32 + // word containing start location of abiencoded report value
-      32 + // word containing location start of abiencoded rs value
-      32 + // word containing start location of abiencoded ss value
-      32 + // rawVs value
-      32 + // word containing length of report
-      32 + // word containing length rs
-      32; // word containing length of ss
+  uint16 private constant TRANSMIT_MSGDATA_CONSTANT_LENGTH_COMPONENT = 4 // function selector
+    + 32 * 3 // 3 words containing reportContext
+    + 32 // word containing start location of abiencoded report value
+    + 32 // word containing location start of abiencoded rs value
+    + 32 // word containing start location of abiencoded ss value
+    + 32 // rawVs value
+    + 32 // word containing length of report
+    + 32 // word containing length rs
+    + 32; // word containing length of ss
 
   bool internal immutable i_uniqueReports;
   uint256 internal immutable i_chainID;
@@ -89,11 +87,7 @@ abstract contract OCR2Base is OwnerIsCreator, OCR2Abstract {
   }
 
   // Reverts transaction if config args are invalid
-  modifier checkConfigValid(
-    uint256 numSigners,
-    uint256 numTransmitters,
-    uint256 f
-  ) {
+  modifier checkConfigValid(uint256 numSigners, uint256 numTransmitters, uint256 f) {
     if (numSigners > MAX_NUM_ORACLES) revert InvalidConfig("too many signers");
     if (f == 0) revert InvalidConfig("f must be positive");
     if (numSigners != numTransmitters) revert InvalidConfig("oracle addresses out of registration");
@@ -207,8 +201,9 @@ abstract contract OCR2Base is OwnerIsCreator, OCR2Abstract {
     bytes32 configDigest = reportContext[0];
     ConfigInfo memory configInfo = s_configInfo;
 
-    if (configInfo.latestConfigDigest != configDigest)
+    if (configInfo.latestConfigDigest != configDigest) {
       revert ConfigDigestMismatch(configInfo.latestConfigDigest, configDigest);
+    }
     // If the cached chainID at time of deployment doesn't match the current chainID, we reject all signed reports.
     // This avoids a (rare) scenario where chain A forks into chain A and A', A' still has configDigest
     // calculated from chain A and so OCR reports will be valid on both forks.
@@ -229,17 +224,15 @@ abstract contract OCR2Base is OwnerIsCreator, OCR2Abstract {
     {
       Oracle memory transmitter = s_oracles[msg.sender];
       // Check that sender is authorized to report
-      if (!(transmitter.role == Role.Transmitter && msg.sender == s_transmitters[transmitter.index]))
+      if (!(transmitter.role == Role.Transmitter && msg.sender == s_transmitters[transmitter.index])) {
         revert UnauthorizedTransmitter();
+      }
     }
     // Scoping this reduces stack pressure and gas usage
     {
-      uint256 expectedDataLength = uint256(TRANSMIT_MSGDATA_CONSTANT_LENGTH_COMPONENT) +
-        report.length + // one byte pure entry in _report
-        rs.length *
-        32 + // 32 bytes per entry in _rs
-        ss.length *
-        32; // 32 bytes per entry in _ss)
+      uint256 expectedDataLength = uint256(TRANSMIT_MSGDATA_CONSTANT_LENGTH_COMPONENT) + report.length // one byte pure entry in _report
+        + rs.length * 32 // 32 bytes per entry in _rs
+        + ss.length * 32; // 32 bytes per entry in _ss)
       if (msg.data.length != expectedDataLength) revert WrongMessageLength(expectedDataLength, msg.data.length);
     }
 

--- a/contracts/src/v0.8/ccip/ocr/OCR2BaseNoChecks.sol
+++ b/contracts/src/v0.8/ccip/ocr/OCR2BaseNoChecks.sol
@@ -62,17 +62,15 @@ abstract contract OCR2BaseNoChecks is OwnerIsCreator, OCR2Abstract {
   // The constant-length components of the msg.data sent to transmit.
   // See the "If we wanted to call sam" example on for example reasoning
   // https://solidity.readthedocs.io/en/v0.7.2/abi-spec.html
-  uint16 private constant TRANSMIT_MSGDATA_CONSTANT_LENGTH_COMPONENT =
-    4 + // function selector
-      32 *
-      3 + // 3 words containing reportContext
-      32 + // word containing start location of abiencoded report value
-      32 + // word containing location start of abiencoded rs value
-      32 + // word containing start location of abiencoded ss value
-      32 + // rawVs value
-      32 + // word containing length of report
-      32 + // word containing length rs
-      32; // word containing length of ss
+  uint16 private constant TRANSMIT_MSGDATA_CONSTANT_LENGTH_COMPONENT = 4 // function selector
+    + 32 * 3 // 3 words containing reportContext
+    + 32 // word containing start location of abiencoded report value
+    + 32 // word containing location start of abiencoded rs value
+    + 32 // word containing start location of abiencoded ss value
+    + 32 // rawVs value
+    + 32 // word containing length of report
+    + 32 // word containing length rs
+    + 32; // word containing length of ss
 
   uint256 internal immutable i_chainID;
 
@@ -191,16 +189,14 @@ abstract contract OCR2BaseNoChecks is OwnerIsCreator, OCR2Abstract {
     {
       Oracle memory transmitter = s_oracles[msg.sender];
       // Check that sender is authorized to report
-      if (!(transmitter.role == Role.Transmitter && msg.sender == s_transmitters[transmitter.index]))
+      if (!(transmitter.role == Role.Transmitter && msg.sender == s_transmitters[transmitter.index])) {
         revert UnauthorizedTransmitter();
+      }
     }
 
-    uint256 expectedDataLength = uint256(TRANSMIT_MSGDATA_CONSTANT_LENGTH_COMPONENT) +
-      report.length + // one byte pure entry in _report
-      rs.length *
-      32 + // 32 bytes per entry in _rs
-      ss.length *
-      32; // 32 bytes per entry in _ss)
+    uint256 expectedDataLength = uint256(TRANSMIT_MSGDATA_CONSTANT_LENGTH_COMPONENT) + report.length // one byte pure entry in _report
+      + rs.length * 32 // 32 bytes per entry in _rs
+      + ss.length * 32; // 32 bytes per entry in _ss)
     if (msg.data.length != expectedDataLength) revert WrongMessageLength(expectedDataLength, msg.data.length);
   }
 

--- a/contracts/src/v0.8/ccip/offRamp/EVM2EVMOffRamp.sol
+++ b/contracts/src/v0.8/ccip/offRamp/EVM2EVMOffRamp.sol
@@ -2,21 +2,21 @@
 pragma solidity 0.8.19;
 
 import {ITypeAndVersion} from "../../shared/interfaces/ITypeAndVersion.sol";
-import {ICommitStore} from "../interfaces/ICommitStore.sol";
 import {IARM} from "../interfaces/IARM.sol";
-import {IPool} from "../interfaces/pools/IPool.sol";
-import {IRouter} from "../interfaces/IRouter.sol";
-import {IPriceRegistry} from "../interfaces/IPriceRegistry.sol";
 import {IAny2EVMMessageReceiver} from "../interfaces/IAny2EVMMessageReceiver.sol";
 import {IAny2EVMOffRamp} from "../interfaces/IAny2EVMOffRamp.sol";
+import {ICommitStore} from "../interfaces/ICommitStore.sol";
+import {IPriceRegistry} from "../interfaces/IPriceRegistry.sol";
+import {IRouter} from "../interfaces/IRouter.sol";
+import {IPool} from "../interfaces/pools/IPool.sol";
 
+import {CallWithExactGas} from "../../shared/call/CallWithExactGas.sol";
+import {EnumerableMapAddresses} from "../../shared/enumerable/EnumerableMapAddresses.sol";
+import {AggregateRateLimiter} from "../AggregateRateLimiter.sol";
 import {Client} from "../libraries/Client.sol";
 import {Internal} from "../libraries/Internal.sol";
 import {RateLimiter} from "../libraries/RateLimiter.sol";
-import {CallWithExactGas} from "../../shared/call/CallWithExactGas.sol";
 import {OCR2BaseNoChecks} from "../ocr/OCR2BaseNoChecks.sol";
-import {AggregateRateLimiter} from "../AggregateRateLimiter.sol";
-import {EnumerableMapAddresses} from "../../shared/enumerable/EnumerableMapAddresses.sol";
 
 import {IERC20} from "../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/IERC20.sol";
 import {ERC165Checker} from "../../vendor/openzeppelin-solidity/v4.8.3/contracts/utils/introspection/ERC165Checker.sol";

--- a/contracts/src/v0.8/ccip/offRamp/EVM2EVMOffRamp.sol
+++ b/contracts/src/v0.8/ccip/offRamp/EVM2EVMOffRamp.sol
@@ -67,10 +67,7 @@ contract EVM2EVMOffRamp is IAny2EVMOffRamp, AggregateRateLimiter, ITypeAndVersio
   event SkippedSenderWithPreviousRampMessageInflight(uint64 indexed nonce, address indexed sender);
   /// @dev RMN depends on this event, if changing, please notify the RMN maintainers.
   event ExecutionStateChanged(
-    uint64 indexed sequenceNumber,
-    bytes32 indexed messageId,
-    Internal.MessageExecutionState state,
-    bytes returnData
+    uint64 indexed sequenceNumber, bytes32 indexed messageId, Internal.MessageExecutionState state, bytes returnData
   );
 
   /// @notice Static offRamp config
@@ -177,11 +174,10 @@ contract EVM2EVMOffRamp is IAny2EVMOffRamp, AggregateRateLimiter, ITypeAndVersio
   /// @return The current execution state of the message.
   /// @dev we use the literal number 128 because using a constant increased gas usage.
   function getExecutionState(uint64 sequenceNumber) public view returns (Internal.MessageExecutionState) {
-    return
-      Internal.MessageExecutionState(
-        (s_executionStates[sequenceNumber / 128] >> ((sequenceNumber % 128) * MESSAGE_EXECUTION_STATE_BIT_WIDTH)) &
-          MESSAGE_EXECUTION_STATE_MASK
-      );
+    return Internal.MessageExecutionState(
+      (s_executionStates[sequenceNumber / 128] >> ((sequenceNumber % 128) * MESSAGE_EXECUTION_STATE_BIT_WIDTH))
+        & MESSAGE_EXECUTION_STATE_MASK
+    );
   }
 
   /// @notice Sets a new execution state for a given sequence number. It will overwrite any existing state.
@@ -273,17 +269,20 @@ contract EVM2EVMOffRamp is IAny2EVMOffRamp, AggregateRateLimiter, ITypeAndVersio
       // and failed. This check protects against reentry and re-execution because the other states are
       // IN_PROGRESS and SUCCESS, both should not be allowed to execute.
       if (
-        !(originalState == Internal.MessageExecutionState.UNTOUCHED ||
-          originalState == Internal.MessageExecutionState.FAILURE)
+        !(
+          originalState == Internal.MessageExecutionState.UNTOUCHED
+            || originalState == Internal.MessageExecutionState.FAILURE
+        )
       ) revert AlreadyExecuted(message.sequenceNumber);
 
       if (manualExecution) {
-        bool isOldCommitReport = (block.timestamp - timestampCommitted) >
-          s_dynamicConfig.permissionLessExecutionThresholdSeconds;
+        bool isOldCommitReport =
+          (block.timestamp - timestampCommitted) > s_dynamicConfig.permissionLessExecutionThresholdSeconds;
         // Manually execution is fine if we previously failed or if the commit report is just too old
         // Acceptable state transitions: FAILURE->SUCCESS, UNTOUCHED->SUCCESS, FAILURE->FAILURE
-        if (!(isOldCommitReport || originalState == Internal.MessageExecutionState.FAILURE))
+        if (!(isOldCommitReport || originalState == Internal.MessageExecutionState.FAILURE)) {
           revert ManualExecutionNotYetEnabled();
+        }
 
         // Manual execution gas limit can override gas limit specified in the message. Value of 0 indicates no override.
         if (manualExecGasLimits[i] != 0) {
@@ -350,8 +349,9 @@ contract EVM2EVMOffRamp is IAny2EVMOffRamp, AggregateRateLimiter, ITypeAndVersio
 
       // The only valid prior states are UNTOUCHED and FAILURE (checked above)
       // The only valid post states are FAILURE and SUCCESS (checked below)
-      if (newState != Internal.MessageExecutionState.FAILURE && newState != Internal.MessageExecutionState.SUCCESS)
+      if (newState != Internal.MessageExecutionState.FAILURE && newState != Internal.MessageExecutionState.SUCCESS) {
         revert InvalidNewState(message.sequenceNumber, newState);
+      }
 
       // Nonce changes per state transition
       // UNTOUCHED -> FAILURE  nonce bump
@@ -381,11 +381,13 @@ contract EVM2EVMOffRamp is IAny2EVMOffRamp, AggregateRateLimiter, ITypeAndVersio
     uint256 offchainTokenDataLength
   ) private view {
     if (sourceChainSelector != i_sourceChainSelector) revert InvalidSourceChain(sourceChainSelector);
-    if (numberOfTokens > uint256(s_dynamicConfig.maxNumberOfTokensPerMsg))
+    if (numberOfTokens > uint256(s_dynamicConfig.maxNumberOfTokensPerMsg)) {
       revert UnsupportedNumberOfTokens(sequenceNumber);
+    }
     if (numberOfTokens != offchainTokenDataLength) revert TokenDataMismatch(sequenceNumber);
-    if (dataLength > uint256(s_dynamicConfig.maxDataBytes))
+    if (dataLength > uint256(s_dynamicConfig.maxDataBytes)) {
       revert MessageTooLarge(uint256(s_dynamicConfig.maxDataBytes), dataLength);
+    }
   }
 
   /// @notice Try executing a message.
@@ -397,7 +399,8 @@ contract EVM2EVMOffRamp is IAny2EVMOffRamp, AggregateRateLimiter, ITypeAndVersio
     Internal.EVM2EVMMessage memory message,
     bytes[] memory offchainTokenData
   ) internal returns (Internal.MessageExecutionState, bytes memory) {
-    try this.executeSingleMessage(message, offchainTokenData) {} catch (bytes memory err) {
+    try this.executeSingleMessage(message, offchainTokenData) {}
+    catch (bytes memory err) {
       if (ReceiverError.selector == bytes4(err) || TokenHandlingError.selector == bytes4(err)) {
         // If CCIP receiver execution is not successful, bubble up receiver revert data,
         // prepended by the 4 bytes of ReceiverError.selector or TokenHandlingError.selector
@@ -424,19 +427,15 @@ contract EVM2EVMOffRamp is IAny2EVMOffRamp, AggregateRateLimiter, ITypeAndVersio
     Client.EVMTokenAmount[] memory destTokenAmounts = new Client.EVMTokenAmount[](0);
     if (message.tokenAmounts.length > 0) {
       destTokenAmounts = _releaseOrMintTokens(
-        message.tokenAmounts,
-        abi.encode(message.sender),
-        message.receiver,
-        message.sourceTokenData,
-        offchainTokenData
+        message.tokenAmounts, abi.encode(message.sender), message.receiver, message.sourceTokenData, offchainTokenData
       );
     }
     if (
-      message.receiver.code.length == 0 ||
-      !message.receiver.supportsInterface(type(IAny2EVMMessageReceiver).interfaceId)
+      message.receiver.code.length == 0
+        || !message.receiver.supportsInterface(type(IAny2EVMMessageReceiver).interfaceId)
     ) return;
 
-    (bool success, bytes memory returnData, ) = IRouter(s_dynamicConfig.router).routeMessage(
+    (bool success, bytes memory returnData,) = IRouter(s_dynamicConfig.router).routeMessage(
       Internal._toAny2EVMMessage(message, destTokenAmounts),
       Internal.GAS_FOR_CALL_EXACT_CHECK,
       message.gasLimit,
@@ -459,15 +458,14 @@ contract EVM2EVMOffRamp is IAny2EVMOffRamp, AggregateRateLimiter, ITypeAndVersio
   /// @dev This function will always return the same struct as the contents is static and can never change.
   /// RMN depends on this function, if changing, please notify the RMN maintainers.
   function getStaticConfig() external view returns (StaticConfig memory) {
-    return
-      StaticConfig({
-        commitStore: i_commitStore,
-        chainSelector: i_chainSelector,
-        sourceChainSelector: i_sourceChainSelector,
-        onRamp: i_onRamp,
-        prevOffRamp: i_prevOffRamp,
-        armProxy: i_armProxy
-      });
+    return StaticConfig({
+      commitStore: i_commitStore,
+      chainSelector: i_chainSelector,
+      sourceChainSelector: i_sourceChainSelector,
+      onRamp: i_onRamp,
+      prevOffRamp: i_prevOffRamp,
+      armProxy: i_armProxy
+    });
   }
 
   /// @notice Returns the current dynamic config.
@@ -506,7 +504,7 @@ contract EVM2EVMOffRamp is IAny2EVMOffRamp, AggregateRateLimiter, ITypeAndVersio
   function getSupportedTokens() external view returns (IERC20[] memory sourceTokens) {
     sourceTokens = new IERC20[](s_poolsBySourceToken.length());
     for (uint256 i = 0; i < sourceTokens.length; ++i) {
-      (address token, ) = s_poolsBySourceToken.at(i);
+      (address token,) = s_poolsBySourceToken.at(i);
       sourceTokens[i] = IERC20(token);
     }
     return sourceTokens;
@@ -542,7 +540,7 @@ contract EVM2EVMOffRamp is IAny2EVMOffRamp, AggregateRateLimiter, ITypeAndVersio
   function getDestinationTokens() external view returns (IERC20[] memory destTokens) {
     destTokens = new IERC20[](s_poolsByDestToken.length());
     for (uint256 i = 0; i < destTokens.length; ++i) {
-      (address token, ) = s_poolsByDestToken.at(i);
+      (address token,) = s_poolsByDestToken.at(i);
       destTokens[i] = IERC20(token);
     }
     return destTokens;
@@ -610,7 +608,7 @@ contract EVM2EVMOffRamp is IAny2EVMOffRamp, AggregateRateLimiter, ITypeAndVersio
       // Call the pool with exact gas to increase resistance against malicious tokens or token pools.
       // _callWithExactGas also protects against return data bombs by capping the return data size
       // at MAX_RET_BYTES.
-      (bool success, bytes memory returnData, ) = CallWithExactGas._callWithExactGasSafeReturnData(
+      (bool success, bytes memory returnData,) = CallWithExactGas._callWithExactGasSafeReturnData(
         abi.encodeWithSelector(
           pool.releaseOrMint.selector,
           originalSender,

--- a/contracts/src/v0.8/ccip/onRamp/EVM2EVMOnRamp.sol
+++ b/contracts/src/v0.8/ccip/onRamp/EVM2EVMOnRamp.sol
@@ -203,19 +203,13 @@ contract EVM2EVMOnRamp is IEVM2AnyOnRamp, ILinkAvailable, AggregateRateLimiter, 
     NopAndWeight[] memory nopsAndWeights
   ) AggregateRateLimiter(rateLimiterConfig) {
     if (
-      staticConfig.linkToken == address(0) ||
-      staticConfig.chainSelector == 0 ||
-      staticConfig.destChainSelector == 0 ||
-      staticConfig.defaultTxGasLimit == 0 ||
-      staticConfig.armProxy == address(0)
+      staticConfig.linkToken == address(0) || staticConfig.chainSelector == 0 || staticConfig.destChainSelector == 0
+        || staticConfig.defaultTxGasLimit == 0 || staticConfig.armProxy == address(0)
     ) revert InvalidConfig();
 
     i_metadataHash = keccak256(
       abi.encode(
-        Internal.EVM_2_EVM_MESSAGE_HASH,
-        staticConfig.chainSelector,
-        staticConfig.destChainSelector,
-        address(this)
+        Internal.EVM_2_EVM_MESSAGE_HASH, staticConfig.chainSelector, staticConfig.destChainSelector, address(this)
       )
     );
     i_linkToken = staticConfig.linkToken;
@@ -340,8 +334,9 @@ contract EVM2EVMOnRamp is IEVM2AnyOnRamp, ILinkAvailable, AggregateRateLimiter, 
       // This prevents gas bomb attacks on the NOPs. We use destBytesOverhead as a proxy to cap the number of bytes we accept.
       // As destBytesOverhead accounts for tokenData + offchainData, this caps the worst case abuse to the number of bytes reserved for offchainData.
       // It therefore fully mitigates gas bombs for most tokens, as most tokens don't use offchainData.
-      if (tokenData.length > s_tokenTransferFeeConfig[tokenAndAmount.token].destBytesOverhead)
+      if (tokenData.length > s_tokenTransferFeeConfig[tokenAndAmount.token].destBytesOverhead) {
         revert SourceTokenDataTooLarge(tokenAndAmount.token);
+      }
 
       newMessage.sourceTokenData[i] = tokenData;
     }
@@ -391,16 +386,15 @@ contract EVM2EVMOnRamp is IEVM2AnyOnRamp, ILinkAvailable, AggregateRateLimiter, 
   /// @dev RMN depends on this function, if changing, please notify the RMN maintainers.
   /// @return the configuration.
   function getStaticConfig() external view returns (StaticConfig memory) {
-    return
-      StaticConfig({
-        linkToken: i_linkToken,
-        chainSelector: i_chainSelector,
-        destChainSelector: i_destChainSelector,
-        defaultTxGasLimit: i_defaultTxGasLimit,
-        maxNopFeesJuels: i_maxNopFeesJuels,
-        prevOnRamp: i_prevOnRamp,
-        armProxy: i_armProxy
-      });
+    return StaticConfig({
+      linkToken: i_linkToken,
+      chainSelector: i_chainSelector,
+      destChainSelector: i_destChainSelector,
+      defaultTxGasLimit: i_defaultTxGasLimit,
+      maxNopFeesJuels: i_maxNopFeesJuels,
+      prevOnRamp: i_prevOnRamp,
+      armProxy: i_armProxy
+    });
   }
 
   /// @notice Returns the dynamic onRamp config.
@@ -441,26 +435,23 @@ contract EVM2EVMOnRamp is IEVM2AnyOnRamp, ILinkAvailable, AggregateRateLimiter, 
   // ================================================================
 
   /// @inheritdoc IEVM2AnyOnRampClient
-  function getSupportedTokens(uint64 /*destChainSelector*/) external view returns (address[] memory) {
+  function getSupportedTokens(uint64 /*destChainSelector*/ ) external view returns (address[] memory) {
     address[] memory sourceTokens = new address[](s_poolsBySourceToken.length());
     for (uint256 i = 0; i < sourceTokens.length; ++i) {
-      (sourceTokens[i], ) = s_poolsBySourceToken.at(i);
+      (sourceTokens[i],) = s_poolsBySourceToken.at(i);
     }
     return sourceTokens;
   }
 
   /// @inheritdoc IEVM2AnyOnRampClient
-  function getPoolBySourceToken(uint64 /*destChainSelector*/, IERC20 sourceToken) public view returns (IPool) {
+  function getPoolBySourceToken(uint64, /*destChainSelector*/ IERC20 sourceToken) public view returns (IPool) {
     if (!s_poolsBySourceToken.contains(address(sourceToken))) revert UnsupportedToken(sourceToken);
     return IPool(s_poolsBySourceToken.get(address(sourceToken)));
   }
 
   /// @inheritdoc IEVM2AnyOnRamp
   /// @dev This method can only be called by the owner of the contract.
-  function applyPoolUpdates(
-    Internal.PoolUpdate[] memory removes,
-    Internal.PoolUpdate[] memory adds
-  ) external onlyOwner {
+  function applyPoolUpdates(Internal.PoolUpdate[] memory removes, Internal.PoolUpdate[] memory adds) external onlyOwner {
     _applyPoolUpdates(removes, adds);
   }
 
@@ -514,8 +505,8 @@ contract EVM2EVMOnRamp is IEVM2AnyOnRamp, ILinkAvailable, AggregateRateLimiter, 
     FeeTokenConfig memory feeTokenConfig = s_feeTokenConfig[message.feeToken];
     if (!feeTokenConfig.enabled) revert NotAFeeToken(message.feeToken);
 
-    (uint224 feeTokenPrice, uint224 packedGasPrice) = IPriceRegistry(s_dynamicConfig.priceRegistry)
-      .getTokenAndGasPrices(message.feeToken, destChainSelector);
+    (uint224 feeTokenPrice, uint224 packedGasPrice) =
+      IPriceRegistry(s_dynamicConfig.priceRegistry).getTokenAndGasPrices(message.feeToken, destChainSelector);
     uint112 executionGasPrice = uint112(packedGasPrice);
 
     // Calculate premiumFee in USD with 18 decimals precision first.
@@ -526,11 +517,8 @@ contract EVM2EVMOnRamp is IEVM2AnyOnRamp, ILinkAvailable, AggregateRateLimiter, 
     uint32 tokenTransferGas = 0;
     uint32 tokenTransferBytesOverhead = 0;
     if (message.tokenAmounts.length > 0) {
-      (premiumFee, tokenTransferGas, tokenTransferBytesOverhead) = _getTokenTransferCost(
-        message.feeToken,
-        feeTokenPrice,
-        message.tokenAmounts
-      );
+      (premiumFee, tokenTransferGas, tokenTransferBytesOverhead) =
+        _getTokenTransferCost(message.feeToken, feeTokenPrice, message.tokenAmounts);
     } else {
       // Convert USD cents with 2 decimals to 18 decimals.
       premiumFee = uint256(feeTokenConfig.networkFeeUSDCents) * 1e16;
@@ -542,11 +530,13 @@ contract EVM2EVMOnRamp is IEVM2AnyOnRamp, ILinkAvailable, AggregateRateLimiter, 
     // Calculate execution gas fee on destination chain in USD with 36 decimals.
     // We add the message gas limit, the overhead gas, the gas of passing message data to receiver, and token transfer gas together.
     // We then multiply this gas total with the gas multiplier and gas price, converting it into USD with 36 decimals.
-    uint256 executionCost = executionGasPrice *
-      ((gasLimit +
-        s_dynamicConfig.destGasOverhead +
-        (message.data.length * s_dynamicConfig.destGasPerPayloadByte) +
-        tokenTransferGas) * feeTokenConfig.gasMultiplierWeiPerEth);
+    uint256 executionCost = executionGasPrice
+      * (
+        (
+          gasLimit + s_dynamicConfig.destGasOverhead + (message.data.length * s_dynamicConfig.destGasPerPayloadByte)
+            + tokenTransferGas
+        ) * feeTokenConfig.gasMultiplierWeiPerEth
+      );
 
     // Calculate data availability cost in USD with 36 decimals. Data availability cost exists on rollups that need to post
     // transaction calldata onto another storage layer, e.g. Eth mainnet, incurring additional storage gas costs.
@@ -558,10 +548,7 @@ contract EVM2EVMOnRamp is IEVM2AnyOnRamp, ILinkAvailable, AggregateRateLimiter, 
       uint112 dataAvailabilityGasPrice = uint112(packedGasPrice >> Internal.GAS_PRICE_BITS);
 
       dataAvailabilityCost = _getDataAvailabilityCost(
-        dataAvailabilityGasPrice,
-        message.data.length,
-        message.tokenAmounts.length,
-        tokenTransferBytesOverhead
+        dataAvailabilityGasPrice, message.data.length, message.tokenAmounts.length, tokenTransferBytesOverhead
       );
     }
 
@@ -586,20 +573,17 @@ contract EVM2EVMOnRamp is IEVM2AnyOnRamp, ILinkAvailable, AggregateRateLimiter, 
   ) internal view returns (uint256 dataAvailabilityCostUSD36Decimal) {
     // dataAvailabilityLengthBytes sums up byte lengths of fixed message fields and dynamic message fields.
     // Fixed message fields do account for the offset and length slot of the dynamic fields.
-    uint256 dataAvailabilityLengthBytes = Internal.MESSAGE_FIXED_BYTES +
-      messageDataLength +
-      (numberOfTokens * Internal.MESSAGE_FIXED_BYTES_PER_TOKEN) +
-      tokenTransferBytesOverhead;
+    uint256 dataAvailabilityLengthBytes = Internal.MESSAGE_FIXED_BYTES + messageDataLength
+      + (numberOfTokens * Internal.MESSAGE_FIXED_BYTES_PER_TOKEN) + tokenTransferBytesOverhead;
 
     // destDataAvailabilityOverheadGas is a separate config value for flexibility to be updated independently of message cost.
     // Its value is determined by CCIP lane implementation, e.g. the overhead data posted for OCR.
-    uint256 dataAvailabilityGas = (dataAvailabilityLengthBytes * s_dynamicConfig.destGasPerDataAvailabilityByte) +
-      s_dynamicConfig.destDataAvailabilityOverheadGas;
+    uint256 dataAvailabilityGas = (dataAvailabilityLengthBytes * s_dynamicConfig.destGasPerDataAvailabilityByte)
+      + s_dynamicConfig.destDataAvailabilityOverheadGas;
 
     // dataAvailabilityGasPrice is in 18 decimals, destDataAvailabilityMultiplierBps is in 4 decimals
     // We pad 14 decimals to bring the result to 36 decimals, in line with token bps and execution fee.
-    return
-      ((dataAvailabilityGas * dataAvailabilityGasPrice) * s_dynamicConfig.destDataAvailabilityMultiplierBps) * 1e14;
+    return ((dataAvailabilityGas * dataAvailabilityGasPrice) * s_dynamicConfig.destDataAvailabilityMultiplierBps) * 1e14;
   }
 
   /// @notice Returns the token transfer cost parameters.
@@ -698,17 +682,20 @@ contract EVM2EVMOnRamp is IEVM2AnyOnRamp, ILinkAvailable, AggregateRateLimiter, 
   }
 
   /// @notice Gets the transfer fee config for a given token.
-  function getTokenTransferFeeConfig(
-    address token
-  ) external view returns (TokenTransferFeeConfig memory tokenTransferFeeConfig) {
+  function getTokenTransferFeeConfig(address token)
+    external
+    view
+    returns (TokenTransferFeeConfig memory tokenTransferFeeConfig)
+  {
     return s_tokenTransferFeeConfig[token];
   }
 
   /// @notice Sets the transfer fee config.
   /// @dev only callable by the owner or admin.
-  function setTokenTransferFeeConfig(
-    TokenTransferFeeConfigArgs[] memory tokenTransferFeeConfigArgs
-  ) external onlyOwnerOrAdmin {
+  function setTokenTransferFeeConfig(TokenTransferFeeConfigArgs[] memory tokenTransferFeeConfigArgs)
+    external
+    onlyOwnerOrAdmin
+  {
     _setTokenTransferFeeConfig(tokenTransferFeeConfigArgs);
   }
 
@@ -775,7 +762,7 @@ contract EVM2EVMOnRamp is IEVM2AnyOnRamp, ILinkAvailable, AggregateRateLimiter, 
 
     // Remove all previous nops, move from end to start to avoid shifting
     for (uint256 i = s_nops.length(); i > 0; --i) {
-      (address nop, ) = s_nops.at(i - 1);
+      (address nop,) = s_nops.at(i - 1);
       s_nops.remove(nop);
     }
 
@@ -867,8 +854,9 @@ contract EVM2EVMOnRamp is IEVM2AnyOnRamp, ILinkAvailable, AggregateRateLimiter, 
 
   /// @dev Require that the sender is the owner or the fee admin or a nop
   modifier onlyOwnerOrAdminOrNop() {
-    if (msg.sender != owner() && msg.sender != s_admin && !s_nops.contains(msg.sender))
+    if (msg.sender != owner() && msg.sender != s_admin && !s_nops.contains(msg.sender)) {
       revert OnlyCallableByOwnerOrAdminOrNop();
+    }
     _;
   }
 

--- a/contracts/src/v0.8/ccip/onRamp/EVM2EVMOnRamp.sol
+++ b/contracts/src/v0.8/ccip/onRamp/EVM2EVMOnRamp.sol
@@ -2,22 +2,22 @@
 pragma solidity 0.8.19;
 
 import {ITypeAndVersion} from "../../shared/interfaces/ITypeAndVersion.sol";
-import {IPool} from "../interfaces/pools/IPool.sol";
 import {IARM} from "../interfaces/IARM.sol";
-import {IPriceRegistry} from "../interfaces/IPriceRegistry.sol";
 import {IEVM2AnyOnRamp} from "../interfaces/IEVM2AnyOnRamp.sol";
 import {IEVM2AnyOnRampClient} from "../interfaces/IEVM2AnyOnRampClient.sol";
+import {IPriceRegistry} from "../interfaces/IPriceRegistry.sol";
 import {ILinkAvailable} from "../interfaces/automation/ILinkAvailable.sol";
+import {IPool} from "../interfaces/pools/IPool.sol";
 
+import {EnumerableMapAddresses} from "../../shared/enumerable/EnumerableMapAddresses.sol";
 import {AggregateRateLimiter} from "../AggregateRateLimiter.sol";
 import {Client} from "../libraries/Client.sol";
 import {Internal} from "../libraries/Internal.sol";
 import {RateLimiter} from "../libraries/RateLimiter.sol";
 import {USDPriceWith18Decimals} from "../libraries/USDPriceWith18Decimals.sol";
-import {EnumerableMapAddresses} from "../../shared/enumerable/EnumerableMapAddresses.sol";
 
-import {SafeERC20} from "../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC20} from "../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/utils/SafeERC20.sol";
 import {EnumerableMap} from "../../vendor/openzeppelin-solidity/v4.8.3/contracts/utils/structs/EnumerableMap.sol";
 
 /// @notice The onRamp is a contract that handles lane-specific fee logic, NOP payments and

--- a/contracts/src/v0.8/ccip/pools/BurnFromMintTokenPool.sol
+++ b/contracts/src/v0.8/ccip/pools/BurnFromMintTokenPool.sol
@@ -4,8 +4,8 @@ pragma solidity 0.8.19;
 import {ITypeAndVersion} from "../../shared/interfaces/ITypeAndVersion.sol";
 import {IBurnMintERC20} from "../../shared/token/ERC20/IBurnMintERC20.sol";
 
-import {TokenPool} from "./TokenPool.sol";
 import {BurnMintTokenPoolAbstract} from "./BurnMintTokenPoolAbstract.sol";
+import {TokenPool} from "./TokenPool.sol";
 
 import {SafeERC20} from "../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/utils/SafeERC20.sol";
 

--- a/contracts/src/v0.8/ccip/pools/BurnMintTokenPool.sol
+++ b/contracts/src/v0.8/ccip/pools/BurnMintTokenPool.sol
@@ -4,8 +4,8 @@ pragma solidity 0.8.19;
 import {ITypeAndVersion} from "../../shared/interfaces/ITypeAndVersion.sol";
 import {IBurnMintERC20} from "../../shared/token/ERC20/IBurnMintERC20.sol";
 
-import {TokenPool} from "./TokenPool.sol";
 import {BurnMintTokenPoolAbstract} from "./BurnMintTokenPoolAbstract.sol";
+import {TokenPool} from "./TokenPool.sol";
 
 /// @notice This pool mints and burns a 3rd-party token.
 /// @dev Pool whitelisting mode is set in the constructor and cannot be modified later.

--- a/contracts/src/v0.8/ccip/pools/BurnWithFromMintTokenPool.sol
+++ b/contracts/src/v0.8/ccip/pools/BurnWithFromMintTokenPool.sol
@@ -4,8 +4,8 @@ pragma solidity 0.8.19;
 import {ITypeAndVersion} from "../../shared/interfaces/ITypeAndVersion.sol";
 import {IBurnMintERC20} from "../../shared/token/ERC20/IBurnMintERC20.sol";
 
-import {TokenPool} from "./TokenPool.sol";
 import {BurnMintTokenPoolAbstract} from "./BurnMintTokenPoolAbstract.sol";
+import {TokenPool} from "./TokenPool.sol";
 
 import {SafeERC20} from "../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/utils/SafeERC20.sol";
 

--- a/contracts/src/v0.8/ccip/pools/LockReleaseTokenPool.sol
+++ b/contracts/src/v0.8/ccip/pools/LockReleaseTokenPool.sol
@@ -95,10 +95,8 @@ contract LockReleaseTokenPool is TokenPool, ILiquidityContainer, ITypeAndVersion
 
   // @inheritdoc IERC165
   function supportsInterface(bytes4 interfaceId) public pure virtual override returns (bool) {
-    return
-      interfaceId == LOCK_RELEASE_INTERFACE_ID ||
-      interfaceId == type(ILiquidityContainer).interfaceId ||
-      super.supportsInterface(interfaceId);
+    return interfaceId == LOCK_RELEASE_INTERFACE_ID || interfaceId == type(ILiquidityContainer).interfaceId
+      || super.supportsInterface(interfaceId);
   }
 
   /// @notice Gets Rebalancer, can be address(0) if none is configured.

--- a/contracts/src/v0.8/ccip/pools/LockReleaseTokenPool.sol
+++ b/contracts/src/v0.8/ccip/pools/LockReleaseTokenPool.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.19;
 
-import {ITypeAndVersion} from "../../shared/interfaces/ITypeAndVersion.sol";
 import {ILiquidityContainer} from "../../rebalancer/interfaces/ILiquidityContainer.sol";
+import {ITypeAndVersion} from "../../shared/interfaces/ITypeAndVersion.sol";
 
-import {TokenPool} from "./TokenPool.sol";
 import {RateLimiter} from "../libraries/RateLimiter.sol";
+import {TokenPool} from "./TokenPool.sol";
 
 import {IERC20} from "../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/contracts/src/v0.8/ccip/pools/TokenPool.sol
+++ b/contracts/src/v0.8/ccip/pools/TokenPool.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.19;
 
-import {IPool} from "../interfaces/pools/IPool.sol";
 import {IARM} from "../interfaces/IARM.sol";
 import {IRouter} from "../interfaces/IRouter.sol";
+import {IPool} from "../interfaces/pools/IPool.sol";
 
 import {OwnerIsCreator} from "../../shared/access/OwnerIsCreator.sol";
 import {RateLimiter} from "../libraries/RateLimiter.sol";

--- a/contracts/src/v0.8/ccip/pools/TokenPool.sol
+++ b/contracts/src/v0.8/ccip/pools/TokenPool.sol
@@ -209,17 +209,21 @@ abstract contract TokenPool is IPool, OwnerIsCreator, IERC165 {
 
   /// @notice Gets the token bucket with its values for the block it was requested at.
   /// @return The token bucket.
-  function getCurrentOutboundRateLimiterState(
-    uint64 remoteChainSelector
-  ) external view returns (RateLimiter.TokenBucket memory) {
+  function getCurrentOutboundRateLimiterState(uint64 remoteChainSelector)
+    external
+    view
+    returns (RateLimiter.TokenBucket memory)
+  {
     return s_outboundRateLimits[remoteChainSelector]._currentTokenBucketState();
   }
 
   /// @notice Gets the token bucket with its values for the block it was requested at.
   /// @return The token bucket.
-  function getCurrentInboundRateLimiterState(
-    uint64 remoteChainSelector
-  ) external view returns (RateLimiter.TokenBucket memory) {
+  function getCurrentInboundRateLimiterState(uint64 remoteChainSelector)
+    external
+    view
+    returns (RateLimiter.TokenBucket memory)
+  {
     return s_inboundRateLimits[remoteChainSelector]._currentTokenBucketState();
   }
 

--- a/contracts/src/v0.8/ccip/pools/USDC/USDCTokenPool.sol
+++ b/contracts/src/v0.8/ccip/pools/USDC/USDCTokenPool.sol
@@ -126,11 +126,7 @@ contract USDCTokenPool is TokenPool, ITypeAndVersion {
     // is able to call replaceDepositForBurn. Since this contract does not implement
     // replaceDepositForBurn, the tokens cannot be maliciously re-routed to another address.
     uint64 nonce = i_tokenMessenger.depositForBurnWithCaller(
-      amount,
-      domain.domainIdentifier,
-      receiver,
-      address(i_token),
-      domain.allowedCaller
+      amount, domain.domainIdentifier, receiver, address(i_token), domain.allowedCaller
     );
     emit Burned(msg.sender, amount);
     return abi.encode(SourceTokenDataPayload({nonce: nonce, sourceDomain: i_localDomainIdentifier}));
@@ -164,8 +160,9 @@ contract USDCTokenPool is TokenPool, ITypeAndVersion {
 
     _validateMessage(msgAndAttestation.message, sourceTokenData);
 
-    if (!i_messageTransmitter.receiveMessage(msgAndAttestation.message, msgAndAttestation.attestation))
+    if (!i_messageTransmitter.receiveMessage(msgAndAttestation.message, msgAndAttestation.attestation)) {
       revert UnlockingUSDCFailed();
+    }
     emit Minted(msg.sender, receiver, amount);
   }
 
@@ -207,10 +204,12 @@ contract USDCTokenPool is TokenPool, ITypeAndVersion {
       nonce := mload(add(usdcMessage, 20)) // 12 + 8 = 20
     }
 
-    if (sourceDomain != sourceTokenData.sourceDomain)
+    if (sourceDomain != sourceTokenData.sourceDomain) {
       revert InvalidSourceDomain(sourceTokenData.sourceDomain, sourceDomain);
-    if (destinationDomain != i_localDomainIdentifier)
+    }
+    if (destinationDomain != i_localDomainIdentifier) {
       revert InvalidDestinationDomain(i_localDomainIdentifier, destinationDomain);
+    }
     if (nonce != sourceTokenData.nonce) revert InvalidNonce(sourceTokenData.nonce, nonce);
   }
 

--- a/contracts/src/v0.8/ccip/pools/USDC/USDCTokenPool.sol
+++ b/contracts/src/v0.8/ccip/pools/USDC/USDCTokenPool.sol
@@ -2,8 +2,8 @@
 pragma solidity 0.8.19;
 
 import {ITypeAndVersion} from "../../../shared/interfaces/ITypeAndVersion.sol";
-import {ITokenMessenger} from "./ITokenMessenger.sol";
 import {IMessageTransmitter} from "./IMessageTransmitter.sol";
+import {ITokenMessenger} from "./ITokenMessenger.sol";
 
 import {TokenPool} from "../TokenPool.sol";
 

--- a/contracts/src/v0.8/ccip/test/BaseTest.t.sol
+++ b/contracts/src/v0.8/ccip/test/BaseTest.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.19;
 
-import {Test, stdError} from "forge-std/Test.sol";
-import {MockARM} from "./mocks/MockARM.sol";
 import {StructFactory} from "./StructFactory.sol";
+import {MockARM} from "./mocks/MockARM.sol";
+import {Test, stdError} from "forge-std/Test.sol";
 
 contract BaseTest is Test, StructFactory {
   bool private s_baseTestInitialized;

--- a/contracts/src/v0.8/ccip/test/StructFactory.sol
+++ b/contracts/src/v0.8/ccip/test/StructFactory.sol
@@ -4,10 +4,10 @@ pragma solidity 0.8.19;
 import {IPool} from "../interfaces/pools/IPool.sol";
 
 import {ARM} from "../ARM.sol";
+import {Internal} from "../libraries/Internal.sol";
+import {RateLimiter} from "../libraries/RateLimiter.sol";
 import {EVM2EVMOffRamp} from "../offRamp/EVM2EVMOffRamp.sol";
 import {EVM2EVMOnRamp} from "../onRamp/EVM2EVMOnRamp.sol";
-import {RateLimiter} from "../libraries/RateLimiter.sol";
-import {Internal} from "../libraries/Internal.sol";
 
 contract StructFactory {
   // Addresses

--- a/contracts/src/v0.8/ccip/test/StructFactory.sol
+++ b/contracts/src/v0.8/ccip/test/StructFactory.sol
@@ -65,12 +65,11 @@ contract StructFactory {
       blessWeight: WEIGHT_40,
       curseWeight: WEIGHT_40
     });
-    return
-      ARM.Config({
-        voters: voters,
-        blessWeightThreshold: WEIGHT_10 + WEIGHT_20 + WEIGHT_40,
-        curseWeightThreshold: WEIGHT_1 + WEIGHT_10 + WEIGHT_20 + WEIGHT_40
-      });
+    return ARM.Config({
+      voters: voters,
+      blessWeightThreshold: WEIGHT_10 + WEIGHT_20 + WEIGHT_40,
+      curseWeightThreshold: WEIGHT_1 + WEIGHT_10 + WEIGHT_20 + WEIGHT_40
+    });
   }
 
   uint8 internal constant ZERO = 0;
@@ -101,12 +100,9 @@ contract StructFactory {
 
   // Total L1 data availability overhead estimate is 33_596 gas.
   // This value includes complete CommitStore and OffRamp call data.
-  uint32 internal constant DEST_DATA_AVAILABILITY_OVERHEAD_GAS =
-    188 + // Fixed data availability overhead in OP stack.
-      (32 * 31 + 4) *
-      DEST_GAS_PER_DATA_AVAILABILITY_BYTE + // CommitStore single-root transmission takes up about 31 slots, plus selector.
-      (32 * 34 + 4) *
-      DEST_GAS_PER_DATA_AVAILABILITY_BYTE; // OffRamp transmission excluding EVM2EVMMessage takes up about 34 slots, plus selector.
+  uint32 internal constant DEST_DATA_AVAILABILITY_OVERHEAD_GAS = 188 // Fixed data availability overhead in OP stack.
+    + (32 * 31 + 4) * DEST_GAS_PER_DATA_AVAILABILITY_BYTE // CommitStore single-root transmission takes up about 31 slots, plus selector.
+    + (32 * 34 + 4) * DEST_GAS_PER_DATA_AVAILABILITY_BYTE; // OffRamp transmission excluding EVM2EVMMessage takes up about 34 slots, plus selector.
 
   // Multiples of bps, or 0.0001, use 6840 to be same as OP mainnet compression factor of 0.684.
   uint16 internal constant DEST_GAS_DATA_AVAILABILITY_MULTIPLIER_BPS = 6840;
@@ -129,34 +125,32 @@ contract StructFactory {
     address router,
     address priceRegistry
   ) internal pure returns (EVM2EVMOffRamp.DynamicConfig memory) {
-    return
-      EVM2EVMOffRamp.DynamicConfig({
-        permissionLessExecutionThresholdSeconds: PERMISSION_LESS_EXECUTION_THRESHOLD_SECONDS,
-        router: router,
-        priceRegistry: priceRegistry,
-        maxNumberOfTokensPerMsg: MAX_TOKENS_LENGTH,
-        maxDataBytes: MAX_DATA_SIZE,
-        maxPoolReleaseOrMintGas: MAX_TOKEN_POOL_RELEASE_OR_MINT_GAS
-      });
+    return EVM2EVMOffRamp.DynamicConfig({
+      permissionLessExecutionThresholdSeconds: PERMISSION_LESS_EXECUTION_THRESHOLD_SECONDS,
+      router: router,
+      priceRegistry: priceRegistry,
+      maxNumberOfTokensPerMsg: MAX_TOKENS_LENGTH,
+      maxDataBytes: MAX_DATA_SIZE,
+      maxPoolReleaseOrMintGas: MAX_TOKEN_POOL_RELEASE_OR_MINT_GAS
+    });
   }
 
   function generateDynamicOnRampConfig(
     address router,
     address priceRegistry
   ) internal pure returns (EVM2EVMOnRamp.DynamicConfig memory) {
-    return
-      EVM2EVMOnRamp.DynamicConfig({
-        router: router,
-        maxNumberOfTokensPerMsg: MAX_TOKENS_LENGTH,
-        destGasOverhead: DEST_GAS_OVERHEAD,
-        destGasPerPayloadByte: DEST_GAS_PER_PAYLOAD_BYTE,
-        destDataAvailabilityOverheadGas: DEST_DATA_AVAILABILITY_OVERHEAD_GAS,
-        destGasPerDataAvailabilityByte: DEST_GAS_PER_DATA_AVAILABILITY_BYTE,
-        destDataAvailabilityMultiplierBps: DEST_GAS_DATA_AVAILABILITY_MULTIPLIER_BPS,
-        priceRegistry: priceRegistry,
-        maxDataBytes: MAX_DATA_SIZE,
-        maxPerMsgGasLimit: MAX_GAS_LIMIT
-      });
+    return EVM2EVMOnRamp.DynamicConfig({
+      router: router,
+      maxNumberOfTokensPerMsg: MAX_TOKENS_LENGTH,
+      destGasOverhead: DEST_GAS_OVERHEAD,
+      destGasPerPayloadByte: DEST_GAS_PER_PAYLOAD_BYTE,
+      destDataAvailabilityOverheadGas: DEST_DATA_AVAILABILITY_OVERHEAD_GAS,
+      destGasPerDataAvailabilityByte: DEST_GAS_PER_DATA_AVAILABILITY_BYTE,
+      destDataAvailabilityMultiplierBps: DEST_GAS_DATA_AVAILABILITY_MULTIPLIER_BPS,
+      priceRegistry: priceRegistry,
+      maxDataBytes: MAX_DATA_SIZE,
+      maxPerMsgGasLimit: MAX_GAS_LIMIT
+    });
   }
 
   function getTokensAndPools(
@@ -196,10 +190,8 @@ contract StructFactory {
     Internal.TokenPriceUpdate[] memory tokenPriceUpdates = new Internal.TokenPriceUpdate[](1);
     tokenPriceUpdates[0] = Internal.TokenPriceUpdate({sourceToken: token, usdPerToken: price});
 
-    Internal.PriceUpdates memory priceUpdates = Internal.PriceUpdates({
-      tokenPriceUpdates: tokenPriceUpdates,
-      gasPriceUpdates: new Internal.GasPriceUpdate[](0)
-    });
+    Internal.PriceUpdates memory priceUpdates =
+      Internal.PriceUpdates({tokenPriceUpdates: tokenPriceUpdates, gasPriceUpdates: new Internal.GasPriceUpdate[](0)});
 
     return priceUpdates;
   }
@@ -211,10 +203,8 @@ contract StructFactory {
     Internal.GasPriceUpdate[] memory gasPriceUpdates = new Internal.GasPriceUpdate[](1);
     gasPriceUpdates[0] = Internal.GasPriceUpdate({destChainSelector: chainSelector, usdPerUnitGas: usdPerUnitGas});
 
-    Internal.PriceUpdates memory priceUpdates = Internal.PriceUpdates({
-      tokenPriceUpdates: new Internal.TokenPriceUpdate[](0),
-      gasPriceUpdates: gasPriceUpdates
-    });
+    Internal.PriceUpdates memory priceUpdates =
+      Internal.PriceUpdates({tokenPriceUpdates: new Internal.TokenPriceUpdate[](0), gasPriceUpdates: gasPriceUpdates});
 
     return priceUpdates;
   }
@@ -240,20 +230,17 @@ contract StructFactory {
     for (uint256 i = 0; i < length; ++i) {
       tokenPriceUpdates[i] = Internal.TokenPriceUpdate({sourceToken: tokens[i], usdPerToken: prices[i]});
     }
-    Internal.PriceUpdates memory priceUpdates = Internal.PriceUpdates({
-      tokenPriceUpdates: tokenPriceUpdates,
-      gasPriceUpdates: new Internal.GasPriceUpdate[](0)
-    });
+    Internal.PriceUpdates memory priceUpdates =
+      Internal.PriceUpdates({tokenPriceUpdates: tokenPriceUpdates, gasPriceUpdates: new Internal.GasPriceUpdate[](0)});
 
     return priceUpdates;
   }
 
   // OffRamp
   function getEmptyPriceUpdates() internal pure returns (Internal.PriceUpdates memory priceUpdates) {
-    return
-      Internal.PriceUpdates({
-        tokenPriceUpdates: new Internal.TokenPriceUpdate[](0),
-        gasPriceUpdates: new Internal.GasPriceUpdate[](0)
-      });
+    return Internal.PriceUpdates({
+      tokenPriceUpdates: new Internal.TokenPriceUpdate[](0),
+      gasPriceUpdates: new Internal.GasPriceUpdate[](0)
+    });
   }
 }

--- a/contracts/src/v0.8/ccip/test/TokenSetup.t.sol
+++ b/contracts/src/v0.8/ccip/test/TokenSetup.t.sol
@@ -3,12 +3,12 @@ pragma solidity 0.8.19;
 
 import {IPool} from "../interfaces/pools/IPool.sol";
 
-import {BurnMintTokenPool} from "../pools/BurnMintTokenPool.sol";
-import {TokenPool} from "../pools/TokenPool.sol";
-import {LockReleaseTokenPool} from "../pools/LockReleaseTokenPool.sol";
-import {RateLimiter} from "../libraries/RateLimiter.sol";
-import {Client} from "../libraries/Client.sol";
 import {BurnMintERC677} from "../../shared/token/ERC677/BurnMintERC677.sol";
+import {Client} from "../libraries/Client.sol";
+import {RateLimiter} from "../libraries/RateLimiter.sol";
+import {BurnMintTokenPool} from "../pools/BurnMintTokenPool.sol";
+import {LockReleaseTokenPool} from "../pools/LockReleaseTokenPool.sol";
+import {TokenPool} from "../pools/TokenPool.sol";
 import {MaybeRevertingBurnMintTokenPool} from "./helpers/MaybeRevertingBurnMintTokenPool.sol";
 import {RouterSetup} from "./router/RouterSetup.t.sol";
 

--- a/contracts/src/v0.8/ccip/test/applications/DefensiveExample.t.sol
+++ b/contracts/src/v0.8/ccip/test/applications/DefensiveExample.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {EVM2EVMOnRampSetup} from "../onRamp/EVM2EVMOnRampSetup.t.sol";
 import {DefensiveExample} from "../../applications/DefensiveExample.sol";
 import {Client} from "../../libraries/Client.sol";
+import {EVM2EVMOnRampSetup} from "../onRamp/EVM2EVMOnRampSetup.t.sol";
 
 import {IERC20} from "../../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/src/v0.8/ccip/test/applications/ImmutableExample.t.sol
+++ b/contracts/src/v0.8/ccip/test/applications/ImmutableExample.t.sol
@@ -2,13 +2,13 @@ pragma solidity ^0.8.0;
 
 import {IAny2EVMMessageReceiver} from "../../interfaces/IAny2EVMMessageReceiver.sol";
 
-import {EVM2EVMOnRampSetup} from "../onRamp/EVM2EVMOnRampSetup.t.sol";
 import {CCIPClientExample} from "../../applications/CCIPClientExample.sol";
 import {Client} from "../../libraries/Client.sol";
+import {EVM2EVMOnRampSetup} from "../onRamp/EVM2EVMOnRampSetup.t.sol";
 
+import {IERC20} from "../../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/IERC20.sol";
 import {ERC165Checker} from
   "../../../vendor/openzeppelin-solidity/v4.8.3/contracts/utils/introspection/ERC165Checker.sol";
-import {IERC20} from "../../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/IERC20.sol";
 
 contract CCIPClientExample_sanity is EVM2EVMOnRampSetup {
   function testExamples() public {

--- a/contracts/src/v0.8/ccip/test/applications/ImmutableExample.t.sol
+++ b/contracts/src/v0.8/ccip/test/applications/ImmutableExample.t.sol
@@ -6,7 +6,8 @@ import {EVM2EVMOnRampSetup} from "../onRamp/EVM2EVMOnRampSetup.t.sol";
 import {CCIPClientExample} from "../../applications/CCIPClientExample.sol";
 import {Client} from "../../libraries/Client.sol";
 
-import {ERC165Checker} from "../../../vendor/openzeppelin-solidity/v4.8.3/contracts/utils/introspection/ERC165Checker.sol";
+import {ERC165Checker} from
+  "../../../vendor/openzeppelin-solidity/v4.8.3/contracts/utils/introspection/ERC165Checker.sol";
 import {IERC20} from "../../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/IERC20.sol";
 
 contract CCIPClientExample_sanity is EVM2EVMOnRampSetup {
@@ -34,8 +35,7 @@ contract CCIPClientExample_sanity is EVM2EVMOnRampSetup {
 
     // Can send data tokens
     assertEq(
-      address(s_onRamp.getPoolBySourceToken(DEST_CHAIN_SELECTOR, IERC20(s_sourceTokens[1]))),
-      address(s_sourcePools[1])
+      address(s_onRamp.getPoolBySourceToken(DEST_CHAIN_SELECTOR, IERC20(s_sourceTokens[1]))), address(s_sourcePools[1])
     );
     deal(s_sourceTokens[1], OWNER, 100 ether);
     IERC20(s_sourceTokens[1]).approve(address(exampleContract), 1 ether);

--- a/contracts/src/v0.8/ccip/test/applications/PingPongDemo.t.sol
+++ b/contracts/src/v0.8/ccip/test/applications/PingPongDemo.t.sol
@@ -2,8 +2,8 @@
 pragma solidity 0.8.19;
 
 import "../../applications/PingPongDemo.sol";
-import "../onRamp/EVM2EVMOnRampSetup.t.sol";
 import "../../libraries/Client.sol";
+import "../onRamp/EVM2EVMOnRampSetup.t.sol";
 
 // setup
 contract PingPongDappSetup is EVM2EVMOnRampSetup {

--- a/contracts/src/v0.8/ccip/test/applications/SelfFundedPingPong.t.sol
+++ b/contracts/src/v0.8/ccip/test/applications/SelfFundedPingPong.t.sol
@@ -2,9 +2,9 @@
 pragma solidity 0.8.19;
 
 import {SelfFundedPingPong} from "../../applications/SelfFundedPingPong.sol";
-import {EVM2EVMOnRampSetup} from "../onRamp/EVM2EVMOnRampSetup.t.sol";
-import {EVM2EVMOnRamp} from "../../onRamp/EVM2EVMOnRamp.sol";
 import {Client} from "../../libraries/Client.sol";
+import {EVM2EVMOnRamp} from "../../onRamp/EVM2EVMOnRamp.sol";
+import {EVM2EVMOnRampSetup} from "../onRamp/EVM2EVMOnRampSetup.t.sol";
 
 import {IERC20} from "../../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/src/v0.8/ccip/test/applications/TokenProxy.t.sol
+++ b/contracts/src/v0.8/ccip/test/applications/TokenProxy.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
 
-import {EVM2EVMOnRampSetup} from "../onRamp/EVM2EVMOnRampSetup.t.sol";
 import {TokenProxy} from "../../applications/TokenProxy.sol";
 import {Client} from "../../libraries/Client.sol";
 import {Internal} from "../../libraries/Internal.sol";
+import {EVM2EVMOnRampSetup} from "../onRamp/EVM2EVMOnRampSetup.t.sol";
 
 import {IERC20} from "../../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/src/v0.8/ccip/test/arm/ARM.t.sol
+++ b/contracts/src/v0.8/ccip/test/arm/ARM.t.sol
@@ -26,7 +26,7 @@ contract ConfigCompare is Test {
 contract ARM_constructor is ConfigCompare, ARMSetup {
   function testConstructorSuccess() public {
     ARM.Config memory expectedConfig = armConstructorArgs();
-    (uint32 actualVersion, , ARM.Config memory actualConfig) = s_arm.getConfigDetails();
+    (uint32 actualVersion,, ARM.Config memory actualConfig) = s_arm.getConfigDetails();
     assertEq(actualVersion, 1);
     assertConfigEq(actualConfig, expectedConfig);
   }
@@ -120,7 +120,7 @@ contract ARM_voteToBlessRoots is ARMSetup {
   }
 
   function testSenderAlreadyVotedIgnoredSuccess() public {
-    (address voter, ) = _getFirstBlessVoterAndWeight();
+    (address voter,) = _getFirstBlessVoterAndWeight();
 
     vm.startPrank(voter);
     s_arm.voteToBless(makeTaggedRootSingleton(1));
@@ -182,13 +182,8 @@ contract ARM_unvoteToCurse is ARMSetup {
     s_arm.voteToCurse(makeCurseId(1));
     bytes32 expectedCursesHash = keccak256(abi.encode(bytes32(0), makeCurseId(1)));
     assertFalse(s_arm.isCursed());
-    (
-      address[] memory cursers,
-      uint32[] memory voteCounts,
-      bytes32[] memory cursesHashes,
-      uint16 weight,
-      bool cursed
-    ) = s_arm.getCurseProgress();
+    (address[] memory cursers, uint32[] memory voteCounts, bytes32[] memory cursesHashes, uint16 weight, bool cursed) =
+      s_arm.getCurseProgress();
     assertEq(1, cursers.length);
     assertEq(1, voteCounts.length);
     assertEq(cfg.voters[s_curser].curseVoteAddr, cursers[0]);
@@ -219,8 +214,7 @@ contract ARM_unvoteToCurse is ARMSetup {
       // should fail when using garbage curses hash
       vm.expectRevert(expectedRevert);
       s_arm.unvoteToCurse(
-        cfg.voters[s_curser].curseVoteAddr,
-        0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+        cfg.voters[s_curser].curseVoteAddr, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
       );
     }
   }
@@ -230,14 +224,11 @@ contract ARM_unvoteToCurse is ARMSetup {
     vm.startPrank(cfg.voters[s_curser].curseUnvoteAddr);
     vm.expectRevert(
       abi.encodeWithSelector(
-        ARM.InvalidCursesHash.selector,
-        s_cursesHash,
-        0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+        ARM.InvalidCursesHash.selector, s_cursesHash, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
       )
     );
     s_arm.unvoteToCurse(
-      cfg.voters[s_curser].curseVoteAddr,
-      0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+      cfg.voters[s_curser].curseVoteAddr, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
     );
   }
 
@@ -316,20 +307,14 @@ contract ARM_voteToCurse is ARMSetup {
     vm.startPrank(voter);
     vm.expectEmit();
     emit VotedToCurse(
-      1,
-      voter,
-      weight,
-      1,
-      makeCurseId(123),
-      keccak256(abi.encode(bytes32(0), makeCurseId(123))),
-      weight
+      1, voter, weight, 1, makeCurseId(123), keccak256(abi.encode(bytes32(0), makeCurseId(123))), weight
     );
 
     vm.resumeGasMetering();
     s_arm.voteToCurse(makeCurseId(123));
     vm.pauseGasMetering();
 
-    (address[] memory voters, , , uint16 votes, bool cursed) = s_arm.getCurseProgress();
+    (address[] memory voters,,, uint16 votes, bool cursed) = s_arm.getCurseProgress();
     assertEq(1, voters.length);
     assertEq(voter, voters[0]);
     assertEq(weight, votes);
@@ -375,8 +360,7 @@ contract ARM_voteToCurse is ARMSetup {
       makeCurseId(cfg.voters.length + 1), // this curse id
       keccak256(
         abi.encode(
-          keccak256(abi.encode(bytes32(0), makeCurseId(cfg.voters.length - 1))),
-          makeCurseId(cfg.voters.length + 1)
+          keccak256(abi.encode(bytes32(0), makeCurseId(cfg.voters.length - 1))), makeCurseId(cfg.voters.length + 1)
         )
       ), // cursesHash
       weightSum // accumulatedWeight
@@ -395,7 +379,7 @@ contract ARM_voteToCurse is ARMSetup {
     s_arm.ownerCurse();
 
     {
-      (address[] memory voters, , , uint24 accWeight, bool cursed) = s_arm.getCurseProgress();
+      (address[] memory voters,,, uint24 accWeight, bool cursed) = s_arm.getCurseProgress();
       assertEq(voters.length, 0);
       assertEq(accWeight, 0);
       assertTrue(cursed);
@@ -407,7 +391,7 @@ contract ARM_voteToCurse is ARMSetup {
     s_arm.ownerCurse();
 
     {
-      (address[] memory voters, , , uint24 accWeight, bool cursed) = s_arm.getCurseProgress();
+      (address[] memory voters,,, uint24 accWeight, bool cursed) = s_arm.getCurseProgress();
       assertEq(voters.length, 0);
       assertEq(accWeight, 0);
       assertTrue(cursed);
@@ -418,7 +402,7 @@ contract ARM_voteToCurse is ARMSetup {
     emit RecoveredFromCurse();
     s_arm.ownerUnvoteToCurse(unvoteRecords);
     {
-      (address[] memory voters, , , uint24 accWeight, bool cursed) = s_arm.getCurseProgress();
+      (address[] memory voters,,, uint24 accWeight, bool cursed) = s_arm.getCurseProgress();
       assertEq(voters.length, 0);
       assertEq(accWeight, 0);
       assertFalse(cursed);
@@ -435,7 +419,7 @@ contract ARM_voteToCurse is ARMSetup {
   }
 
   function testAlreadyVotedReverts() public {
-    (address voter, ) = _getFirstCurseVoterAndWeight();
+    (address voter,) = _getFirstCurseVoterAndWeight();
     vm.startPrank(voter);
     s_arm.voteToCurse(makeCurseId(1));
 
@@ -479,14 +463,11 @@ contract ARM_ownerUnvoteToCurse is ARMSetup {
   }
 
   function makeUnvoteToCurseRecords() internal pure returns (ARM.UnvoteToCurseRecord[] memory) {
-    (address[] memory cursers, ) = getCursersAndCurseCounts();
+    (address[] memory cursers,) = getCursersAndCurseCounts();
     ARM.UnvoteToCurseRecord[] memory records = new ARM.UnvoteToCurseRecord[](cursers.length);
     for (uint256 i = 0; i < cursers.length; ++i) {
-      records[i] = ARM.UnvoteToCurseRecord({
-        curseVoteAddr: cursers[i],
-        cursesHash: bytes32(uint256(0)),
-        forceUnvote: true
-      });
+      records[i] =
+        ARM.UnvoteToCurseRecord({curseVoteAddr: cursers[i], cursesHash: bytes32(uint256(0)), forceUnvote: true});
     }
     return records;
   }
@@ -505,7 +486,7 @@ contract ARM_ownerUnvoteToCurse is ARMSetup {
     vm.pauseGasMetering();
 
     assertFalse(s_arm.isCursed());
-    (address[] memory voters, , bytes32[] memory cursesHashes, uint256 weight, bool cursed) = s_arm.getCurseProgress();
+    (address[] memory voters,, bytes32[] memory cursesHashes, uint256 weight, bool cursed) = s_arm.getCurseProgress();
     assertEq(voters.length, 0);
     assertEq(cursesHashes.length, 0);
     assertEq(weight, 0);
@@ -519,13 +500,8 @@ contract ARM_ownerUnvoteToCurse is ARMSetup {
     ownerUnvoteToCurse();
 
     assertFalse(s_arm.isCursed());
-    (
-      address[] memory voters,
-      uint32[] memory voteCounts,
-      bytes32[] memory cursesHashes,
-      uint256 weight,
-      bool cursed
-    ) = s_arm.getCurseProgress();
+    (address[] memory voters, uint32[] memory voteCounts, bytes32[] memory cursesHashes, uint256 weight, bool cursed) =
+      s_arm.getCurseProgress();
     assertEq(voters.length, 0);
     assertEq(cursesHashes.length, 0);
     assertEq(voteCounts.length, 0);
@@ -581,12 +557,11 @@ contract ARM_setConfig is ConfigCompare, ARMSetup {
       blessWeight: WEIGHT_10,
       curseWeight: WEIGHT_10
     });
-    return
-      ARM.Config({
-        voters: voters,
-        blessWeightThreshold: WEIGHT_1 + WEIGHT_10,
-        curseWeightThreshold: WEIGHT_1 + WEIGHT_10
-      });
+    return ARM.Config({
+      voters: voters,
+      blessWeightThreshold: WEIGHT_1 + WEIGHT_10,
+      curseWeightThreshold: WEIGHT_1 + WEIGHT_10
+    });
   }
 
   function setUp() public virtual override {
@@ -626,19 +601,19 @@ contract ARM_setConfig is ConfigCompare, ARMSetup {
     vm.expectEmit();
     emit ConfigSet(2, cfg);
 
-    (uint32 configVersionBefore, , ) = s_arm.getConfigDetails();
+    (uint32 configVersionBefore,,) = s_arm.getConfigDetails();
     vm.resumeGasMetering();
     s_arm.setConfig(cfg);
     vm.pauseGasMetering();
     // Assert VersionedConfig has changed correctly
-    (uint32 configVersionAfter, , ARM.Config memory configAfter) = s_arm.getConfigDetails();
+    (uint32 configVersionAfter,, ARM.Config memory configAfter) = s_arm.getConfigDetails();
     assertEq(configVersionBefore + 1, configVersionAfter);
     assertConfigEq(configAfter, cfg);
 
     // Assert that curse votes have been cleared, except for CURSE_VOTER_2 who
     // has already voted and is also part of the new config
-    (address[] memory curseVoters, , bytes32[] memory cursesHashes, uint256 curseWeight, bool cursed) = s_arm
-      .getCurseProgress();
+    (address[] memory curseVoters,, bytes32[] memory cursesHashes, uint256 curseWeight, bool cursed) =
+      s_arm.getCurseProgress();
     assertEq(1, curseVoters.length);
     assertEq(WEIGHT_10, curseWeight);
     assertEq(1, cursesHashes.length);

--- a/contracts/src/v0.8/ccip/test/arm/ARM.t.sol
+++ b/contracts/src/v0.8/ccip/test/arm/ARM.t.sol
@@ -3,9 +3,9 @@ pragma solidity 0.8.19;
 
 import {IARM} from "../../interfaces/IARM.sol";
 
-import {Test} from "forge-std/Test.sol";
-import {ARMSetup} from "./ARMSetup.t.sol";
 import {ARM} from "../../ARM.sol";
+import {ARMSetup} from "./ARMSetup.t.sol";
+import {Test} from "forge-std/Test.sol";
 
 contract ConfigCompare is Test {
   function assertConfigEq(ARM.Config memory actualConfig, ARM.Config memory expectedConfig) public {

--- a/contracts/src/v0.8/ccip/test/arm/ARMProxy.t.sol
+++ b/contracts/src/v0.8/ccip/test/arm/ARMProxy.t.sol
@@ -3,10 +3,10 @@ pragma solidity 0.8.19;
 
 import {IARM} from "../../interfaces/IARM.sol";
 
-import {ARMSetup} from "./ARMSetup.t.sol";
-import {MockARM} from "../mocks/MockARM.sol";
-import {ARMProxy} from "../../ARMProxy.sol";
 import {ARM} from "../../ARM.sol";
+import {ARMProxy} from "../../ARMProxy.sol";
+import {MockARM} from "../mocks/MockARM.sol";
+import {ARMSetup} from "./ARMSetup.t.sol";
 
 contract ARMProxyTest is ARMSetup {
   event ARMSet(address arm);

--- a/contracts/src/v0.8/ccip/test/arm/ARMProxy_standalone.t.sol
+++ b/contracts/src/v0.8/ccip/test/arm/ARMProxy_standalone.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.19;
 
-import {Test} from "forge-std/Test.sol";
 import {ARMProxy} from "../../ARMProxy.sol";
+import {Test} from "forge-std/Test.sol";
 
 contract ARMProxyStandaloneTest is Test {
   event ARMSet(address arm);

--- a/contracts/src/v0.8/ccip/test/arm/ARMProxy_standalone.t.sol
+++ b/contracts/src/v0.8/ccip/test/arm/ARMProxy_standalone.t.sol
@@ -74,7 +74,7 @@ contract ARMProxyStandaloneTest is Test {
     s_armProxy.setARM(EMPTY_ADDRESS); // No code at address 1, should revert.
     vm.expectRevert();
     bytes memory b = new bytes(0);
-    (bool success, ) = address(s_armProxy).call(b);
+    (bool success,) = address(s_armProxy).call(b);
     success;
   }
 }

--- a/contracts/src/v0.8/ccip/test/arm/ARMSetup.t.sol
+++ b/contracts/src/v0.8/ccip/test/arm/ARMSetup.t.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.19;
 
 import {IARM} from "../../interfaces/IARM.sol";
 
-import {BaseTest} from "../BaseTest.t.sol";
 import {ARM} from "../../ARM.sol";
+import {BaseTest} from "../BaseTest.t.sol";
 
 contract ARMSetup is BaseTest {
   function makeTaggedRootsInclusive(uint256 from, uint256 to) internal pure returns (IARM.TaggedRoot[] memory) {

--- a/contracts/src/v0.8/ccip/test/arm/ARMSetup.t.sol
+++ b/contracts/src/v0.8/ccip/test/arm/ARMSetup.t.sol
@@ -41,7 +41,7 @@ contract ARMSetup is BaseTest {
   }
 
   function hasVotedToBlessRoot(address voter, IARM.TaggedRoot memory taggedRoot_) internal view returns (bool) {
-    (address[] memory voters, , ) = s_arm.getBlessProgress(taggedRoot_);
+    (address[] memory voters,,) = s_arm.getBlessProgress(taggedRoot_);
     for (uint256 i = 0; i < voters.length; ++i) {
       if (voters[i] == voter) {
         return true;
@@ -51,7 +51,7 @@ contract ARMSetup is BaseTest {
   }
 
   function getWeightOfVotesToBlessRoot(IARM.TaggedRoot memory taggedRoot_) internal view returns (uint16) {
-    (, uint16 weight, ) = s_arm.getBlessProgress(taggedRoot_);
+    (, uint16 weight,) = s_arm.getBlessProgress(taggedRoot_);
     return weight;
   }
 }

--- a/contracts/src/v0.8/ccip/test/attacks/onRamp/FacadeClient.sol
+++ b/contracts/src/v0.8/ccip/test/attacks/onRamp/FacadeClient.sol
@@ -4,8 +4,8 @@ pragma solidity 0.8.19;
 import {IRouterClient} from "../../../interfaces/IRouterClient.sol";
 
 import {OwnerIsCreator} from "../../../../shared/access/OwnerIsCreator.sol";
-import {Client} from "../../../libraries/Client.sol";
 import {CCIPReceiver} from "../../../applications/CCIPReceiver.sol";
+import {Client} from "../../../libraries/Client.sol";
 
 import {IERC20} from "../../../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/src/v0.8/ccip/test/attacks/onRamp/OnRampTokenPoolReentrancy.t.sol
+++ b/contracts/src/v0.8/ccip/test/attacks/onRamp/OnRampTokenPoolReentrancy.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.19;
 
-import {Internal} from "../../../libraries/Internal.sol";
 import {Client} from "../../../libraries/Client.sol";
+import {Internal} from "../../../libraries/Internal.sol";
+import {EVM2EVMOnRampSetup} from "../../onRamp/EVM2EVMOnRampSetup.t.sol";
 import {FacadeClient} from "./FacadeClient.sol";
 import {ReentrantMaliciousTokenPool} from "./ReentrantMaliciousTokenPool.sol";
-import {EVM2EVMOnRampSetup} from "../../onRamp/EVM2EVMOnRampSetup.t.sol";
 
 import {IERC20} from "../../../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/src/v0.8/ccip/test/attacks/onRamp/OnRampTokenPoolReentrancy.t.sol
+++ b/contracts/src/v0.8/ccip/test/attacks/onRamp/OnRampTokenPoolReentrancy.t.sol
@@ -26,10 +26,7 @@ contract OnRampTokenPoolReentrancy is EVM2EVMOnRampSetup {
     s_facadeClient = new FacadeClient(address(s_sourceRouter), DEST_CHAIN_SELECTOR, s_sourceToken, s_feeToken);
 
     s_maliciousTokenPool = new ReentrantMaliciousTokenPool(
-      address(s_facadeClient),
-      s_sourceToken,
-      address(s_mockARM),
-      address(s_sourceRouter)
+      address(s_facadeClient), s_sourceToken, address(s_mockARM), address(s_sourceRouter)
     );
 
     Internal.PoolUpdate[] memory removes = new Internal.PoolUpdate[](1);

--- a/contracts/src/v0.8/ccip/test/attacks/onRamp/ReentrantMaliciousTokenPool.sol
+++ b/contracts/src/v0.8/ccip/test/attacks/onRamp/ReentrantMaliciousTokenPool.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.19;
 
-import {FacadeClient} from "./FacadeClient.sol";
 import {RateLimiter} from "../../../libraries/RateLimiter.sol";
 import {TokenPool} from "../../../pools/TokenPool.sol";
+import {FacadeClient} from "./FacadeClient.sol";
 
 import {IERC20} from "../../../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/src/v0.8/ccip/test/commitStore/CommitStore.t.sol
+++ b/contracts/src/v0.8/ccip/test/commitStore/CommitStore.t.sol
@@ -4,14 +4,13 @@ pragma solidity 0.8.19;
 import {IARM} from "../../interfaces/IARM.sol";
 import {IPriceRegistry} from "../../interfaces/IPriceRegistry.sol";
 
+import {ARM} from "../../ARM.sol";
 import {CommitStore} from "../../CommitStore.sol";
 import {PriceRegistry} from "../../PriceRegistry.sol";
-import {ARM} from "../../ARM.sol";
 import {MerkleMultiProof} from "../../libraries/MerkleMultiProof.sol";
-
 import {CommitStoreHelper} from "../helpers/CommitStoreHelper.sol";
-import {PriceRegistrySetup} from "../priceRegistry/PriceRegistry.t.sol";
 import {OCR2BaseSetup} from "../ocr/OCR2Base.t.sol";
+import {PriceRegistrySetup} from "../priceRegistry/PriceRegistry.t.sol";
 
 contract CommitStoreSetup is PriceRegistrySetup, OCR2BaseSetup {
   event ConfigSet(CommitStore.StaticConfig, CommitStore.DynamicConfig);

--- a/contracts/src/v0.8/ccip/test/commitStore/CommitStore.t.sol
+++ b/contracts/src/v0.8/ccip/test/commitStore/CommitStore.t.sol
@@ -30,16 +30,10 @@ contract CommitStoreSetup is PriceRegistrySetup, OCR2BaseSetup {
         armProxy: address(s_mockARM)
       })
     );
-    CommitStore.DynamicConfig memory dynamicConfig = CommitStore.DynamicConfig({
-      priceRegistry: address(s_priceRegistry)
-    });
+    CommitStore.DynamicConfig memory dynamicConfig =
+      CommitStore.DynamicConfig({priceRegistry: address(s_priceRegistry)});
     s_commitStore.setOCR2Config(
-      s_valid_signers,
-      s_valid_transmitters,
-      s_f,
-      abi.encode(dynamicConfig),
-      s_offchainConfigVersion,
-      abi.encode("")
+      s_valid_signers, s_valid_transmitters, s_f, abi.encode(dynamicConfig), s_offchainConfigVersion, abi.encode("")
     );
 
     address[] memory priceUpdaters = new address[](1);
@@ -77,16 +71,10 @@ contract CommitStoreRealARMSetup is PriceRegistrySetup, OCR2BaseSetup {
         armProxy: address(s_arm)
       })
     );
-    CommitStore.DynamicConfig memory dynamicConfig = CommitStore.DynamicConfig({
-      priceRegistry: address(s_priceRegistry)
-    });
+    CommitStore.DynamicConfig memory dynamicConfig =
+      CommitStore.DynamicConfig({priceRegistry: address(s_priceRegistry)});
     s_commitStore.setOCR2Config(
-      s_valid_signers,
-      s_valid_transmitters,
-      s_f,
-      abi.encode(dynamicConfig),
-      s_offchainConfigVersion,
-      abi.encode("")
+      s_valid_signers, s_valid_transmitters, s_f, abi.encode(dynamicConfig), s_offchainConfigVersion, abi.encode("")
     );
   }
 }
@@ -107,21 +95,15 @@ contract CommitStore_constructor is PriceRegistrySetup, OCR2BaseSetup {
       onRamp: 0x2C44CDDdB6a900Fa2B585dd299E03D12Fa4293Bc,
       armProxy: address(s_mockARM)
     });
-    CommitStore.DynamicConfig memory dynamicConfig = CommitStore.DynamicConfig({
-      priceRegistry: address(s_priceRegistry)
-    });
+    CommitStore.DynamicConfig memory dynamicConfig =
+      CommitStore.DynamicConfig({priceRegistry: address(s_priceRegistry)});
 
     vm.expectEmit();
     emit ConfigSet(staticConfig, dynamicConfig);
 
     CommitStore commitStore = new CommitStore(staticConfig);
     commitStore.setOCR2Config(
-      s_valid_signers,
-      s_valid_transmitters,
-      s_f,
-      abi.encode(dynamicConfig),
-      s_offchainConfigVersion,
-      abi.encode("")
+      s_valid_signers, s_valid_transmitters, s_f, abi.encode(dynamicConfig), s_offchainConfigVersion, abi.encode("")
     );
 
     CommitStore.StaticConfig memory gotStaticConfig = commitStore.getStaticConfig();
@@ -187,12 +169,7 @@ contract CommitStore_setDynamicConfig is CommitStoreSetup {
     );
 
     s_commitStore.setOCR2Config(
-      s_valid_signers,
-      s_valid_transmitters,
-      s_f,
-      onchainConfig,
-      s_offchainConfigVersion,
-      abi.encode("")
+      s_valid_signers, s_valid_transmitters, s_f, onchainConfig, s_offchainConfigVersion, abi.encode("")
     );
 
     CommitStore.DynamicConfig memory gotDynamicConfig = s_commitStore.getDynamicConfig();
@@ -208,12 +185,7 @@ contract CommitStore_setDynamicConfig is CommitStoreSetup {
     CommitStore.DynamicConfig memory dynamicConfig = CommitStore.DynamicConfig({priceRegistry: address(1)});
     // New config should clear it.
     s_commitStore.setOCR2Config(
-      s_valid_signers,
-      s_valid_transmitters,
-      s_f,
-      abi.encode(dynamicConfig),
-      s_offchainConfigVersion,
-      abi.encode("")
+      s_valid_signers, s_valid_transmitters, s_f, abi.encode(dynamicConfig), s_offchainConfigVersion, abi.encode("")
     );
     // Assert cleared.
     assertEq(0, s_commitStore.getLatestPriceEpochAndRound());
@@ -226,12 +198,7 @@ contract CommitStore_setDynamicConfig is CommitStoreSetup {
     vm.stopPrank();
     vm.expectRevert("Only callable by owner");
     s_commitStore.setOCR2Config(
-      s_valid_signers,
-      s_valid_transmitters,
-      s_f,
-      abi.encode(dynamicConfig),
-      s_offchainConfigVersion,
-      abi.encode("")
+      s_valid_signers, s_valid_transmitters, s_f, abi.encode(dynamicConfig), s_offchainConfigVersion, abi.encode("")
     );
   }
 
@@ -240,12 +207,7 @@ contract CommitStore_setDynamicConfig is CommitStoreSetup {
 
     vm.expectRevert(CommitStore.InvalidCommitStoreConfig.selector);
     s_commitStore.setOCR2Config(
-      s_valid_signers,
-      s_valid_transmitters,
-      s_f,
-      abi.encode(dynamicConfig),
-      s_offchainConfigVersion,
-      abi.encode("")
+      s_valid_signers, s_valid_transmitters, s_f, abi.encode(dynamicConfig), s_offchainConfigVersion, abi.encode("")
     );
   }
 }
@@ -363,9 +325,8 @@ contract CommitStore_report is CommitStoreSetup {
 
   function testStaleReportWithRootSuccess() public {
     uint64 maxSeq = 12;
-    uint224 tokenStartPrice = IPriceRegistry(s_commitStore.getDynamicConfig().priceRegistry)
-      .getTokenPrice(s_sourceFeeToken)
-      .value;
+    uint224 tokenStartPrice =
+      IPriceRegistry(s_commitStore.getDynamicConfig().priceRegistry).getTokenPrice(s_sourceFeeToken).value;
 
     CommitStore.CommitReport memory report = CommitStore.CommitReport({
       priceUpdates: getSingleTokenPriceUpdateStruct(s_sourceFeeToken, 4e18),
@@ -456,8 +417,7 @@ contract CommitStore_report is CommitStoreSetup {
 
     assertEq(maxSeq + 1, s_commitStore.getExpectedNextSequenceNumber());
     assertEq(
-      tokenPrice1,
-      IPriceRegistry(s_commitStore.getDynamicConfig().priceRegistry).getTokenPrice(s_sourceFeeToken).value
+      tokenPrice1, IPriceRegistry(s_commitStore.getDynamicConfig().priceRegistry).getTokenPrice(s_sourceFeeToken).value
     );
     assertEq(s_latestEpochAndRound, s_commitStore.getLatestPriceEpochAndRound());
   }
@@ -491,11 +451,8 @@ contract CommitStore_report is CommitStoreSetup {
 
   function testInvalidIntervalReverts() public {
     CommitStore.Interval memory interval = CommitStore.Interval(2, 2);
-    CommitStore.CommitReport memory report = CommitStore.CommitReport({
-      priceUpdates: getEmptyPriceUpdates(),
-      interval: interval,
-      merkleRoot: bytes32(0)
-    });
+    CommitStore.CommitReport memory report =
+      CommitStore.CommitReport({priceUpdates: getEmptyPriceUpdates(), interval: interval, merkleRoot: bytes32(0)});
 
     vm.expectRevert(abi.encodeWithSelector(CommitStore.InvalidInterval.selector, interval));
 
@@ -504,11 +461,8 @@ contract CommitStore_report is CommitStoreSetup {
 
   function testInvalidIntervalMinLargerThanMaxReverts() public {
     CommitStore.Interval memory interval = CommitStore.Interval(1, 0);
-    CommitStore.CommitReport memory report = CommitStore.CommitReport({
-      priceUpdates: getEmptyPriceUpdates(),
-      interval: interval,
-      merkleRoot: bytes32(0)
-    });
+    CommitStore.CommitReport memory report =
+      CommitStore.CommitReport({priceUpdates: getEmptyPriceUpdates(), interval: interval, merkleRoot: bytes32(0)});
 
     vm.expectRevert(abi.encodeWithSelector(CommitStore.InvalidInterval.selector, interval));
 

--- a/contracts/src/v0.8/ccip/test/e2e/End2End.t.sol
+++ b/contracts/src/v0.8/ccip/test/e2e/End2End.t.sol
@@ -73,26 +73,17 @@ contract E2E is EVM2EVMOnRampSetup, CommitStoreSetup, EVM2EVMOffRampSetup {
 
     vm.expectEmit();
     emit ExecutionStateChanged(
-      messages[0].sequenceNumber,
-      messages[0].messageId,
-      Internal.MessageExecutionState.SUCCESS,
-      ""
+      messages[0].sequenceNumber, messages[0].messageId, Internal.MessageExecutionState.SUCCESS, ""
     );
 
     vm.expectEmit();
     emit ExecutionStateChanged(
-      messages[1].sequenceNumber,
-      messages[1].messageId,
-      Internal.MessageExecutionState.SUCCESS,
-      ""
+      messages[1].sequenceNumber, messages[1].messageId, Internal.MessageExecutionState.SUCCESS, ""
     );
 
     vm.expectEmit();
     emit ExecutionStateChanged(
-      messages[2].sequenceNumber,
-      messages[2].messageId,
-      Internal.MessageExecutionState.SUCCESS,
-      ""
+      messages[2].sequenceNumber, messages[2].messageId, Internal.MessageExecutionState.SUCCESS, ""
     );
 
     Internal.ExecutionReport memory execReport = _generateReportFromMessages(messages);
@@ -108,13 +99,8 @@ contract E2E is EVM2EVMOnRampSetup, CommitStoreSetup, EVM2EVMOffRampSetup {
     IERC20(s_sourceTokens[1]).approve(address(s_sourceRouter), i_tokenAmount1);
 
     message.receiver = abi.encode(address(s_receiver));
-    Internal.EVM2EVMMessage memory geEvent = _messageToEvent(
-      message,
-      expectedSeqNum,
-      expectedSeqNum,
-      expectedFee,
-      OWNER
-    );
+    Internal.EVM2EVMMessage memory geEvent =
+      _messageToEvent(message, expectedSeqNum, expectedSeqNum, expectedFee, OWNER);
 
     vm.expectEmit();
     emit CCIPSendRequested(geEvent);

--- a/contracts/src/v0.8/ccip/test/e2e/End2End.t.sol
+++ b/contracts/src/v0.8/ccip/test/e2e/End2End.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.19;
 
-import "../helpers/MerkleHelper.sol";
 import "../commitStore/CommitStore.t.sol";
-import "../onRamp/EVM2EVMOnRampSetup.t.sol";
+import "../helpers/MerkleHelper.sol";
 import "../offRamp/EVM2EVMOffRampSetup.t.sol";
+import "../onRamp/EVM2EVMOnRampSetup.t.sol";
 
 contract E2E is EVM2EVMOnRampSetup, CommitStoreSetup, EVM2EVMOffRampSetup {
   using Internal for Internal.EVM2EVMMessage;

--- a/contracts/src/v0.8/ccip/test/helpers/CustomTokenPool.sol
+++ b/contracts/src/v0.8/ccip/test/helpers/CustomTokenPool.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.19;
 
-import {TokenPool} from "../../pools/TokenPool.sol";
 import {RateLimiter} from "../../libraries/RateLimiter.sol";
+import {TokenPool} from "../../pools/TokenPool.sol";
 
 import {IERC20} from "../../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/src/v0.8/ccip/test/helpers/MaybeRevertingBurnMintTokenPool.sol
+++ b/contracts/src/v0.8/ccip/test/helpers/MaybeRevertingBurnMintTokenPool.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {BurnMintTokenPool} from "../../pools/BurnMintTokenPool.sol";
 import {IBurnMintERC20} from "../../../shared/token/ERC20/IBurnMintERC20.sol";
+import {BurnMintTokenPool} from "../../pools/BurnMintTokenPool.sol";
 
 contract MaybeRevertingBurnMintTokenPool is BurnMintTokenPool {
   bytes public s_revertReason = "";

--- a/contracts/src/v0.8/ccip/test/helpers/OCR2Helper.sol
+++ b/contracts/src/v0.8/ccip/test/helpers/OCR2Helper.sol
@@ -15,18 +15,17 @@ contract OCR2Helper is OCR2Base(false) {
     uint64 offchainConfigVersion,
     bytes memory offchainConfig
   ) public pure returns (bytes32) {
-    return
-      _configDigestFromConfigData(
-        chainSelector,
-        contractAddress,
-        configCount,
-        signers,
-        transmitters,
-        f,
-        onchainConfig,
-        offchainConfigVersion,
-        offchainConfig
-      );
+    return _configDigestFromConfigData(
+      chainSelector,
+      contractAddress,
+      configCount,
+      signers,
+      transmitters,
+      f,
+      onchainConfig,
+      offchainConfigVersion,
+      offchainConfig
+    );
   }
 
   function _report(bytes calldata report, uint40 epochAndRound) internal override {}

--- a/contracts/src/v0.8/ccip/test/helpers/OCR2NoChecksHelper.sol
+++ b/contracts/src/v0.8/ccip/test/helpers/OCR2NoChecksHelper.sol
@@ -15,18 +15,17 @@ contract OCR2NoChecksHelper is OCR2BaseNoChecks {
     uint64 offchainConfigVersion,
     bytes memory offchainConfig
   ) public pure returns (bytes32) {
-    return
-      _configDigestFromConfigData(
-        chainSelector,
-        contractAddress,
-        configCount,
-        signers,
-        transmitters,
-        f,
-        onchainConfig,
-        offchainConfigVersion,
-        offchainConfig
-      );
+    return _configDigestFromConfigData(
+      chainSelector,
+      contractAddress,
+      configCount,
+      signers,
+      transmitters,
+      f,
+      onchainConfig,
+      offchainConfigVersion,
+      offchainConfig
+    );
   }
 
   function _report(bytes calldata report) internal override {}

--- a/contracts/src/v0.8/ccip/test/helpers/USDCTokenPoolHelper.sol
+++ b/contracts/src/v0.8/ccip/test/helpers/USDCTokenPoolHelper.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.19;
 
 import {IBurnMintERC20} from "../../../shared/token/ERC20/IBurnMintERC20.sol";
 
-import {USDCTokenPool} from "../../pools/USDC/USDCTokenPool.sol";
 import {ITokenMessenger} from "../../pools/USDC/ITokenMessenger.sol";
+import {USDCTokenPool} from "../../pools/USDC/USDCTokenPool.sol";
 
 contract USDCTokenPoolHelper is USDCTokenPool {
   constructor(

--- a/contracts/src/v0.8/ccip/test/helpers/receivers/MaybeRevertMessageReceiverNo165.sol
+++ b/contracts/src/v0.8/ccip/test/helpers/receivers/MaybeRevertMessageReceiverNo165.sol
@@ -6,6 +6,7 @@ import "../../../interfaces/IAny2EVMMessageReceiver.sol";
 contract MaybeRevertMessageReceiverNo165 is IAny2EVMMessageReceiver {
   address private s_manager;
   bool public s_toRevert;
+
   event MessageReceived();
 
   constructor(bool toRevert) {

--- a/contracts/src/v0.8/ccip/test/helpers/receivers/ReentrancyAbuser.sol
+++ b/contracts/src/v0.8/ccip/test/helpers/receivers/ReentrancyAbuser.sol
@@ -2,9 +2,9 @@
 pragma solidity 0.8.19;
 
 import {CCIPReceiver} from "../../../applications/CCIPReceiver.sol";
-import {EVM2EVMOffRamp} from "../../../offRamp/EVM2EVMOffRamp.sol";
 import {Client} from "../../../libraries/Client.sol";
 import {Internal} from "../../../libraries/Internal.sol";
+import {EVM2EVMOffRamp} from "../../../offRamp/EVM2EVMOffRamp.sol";
 
 contract ReentrancyAbuser is CCIPReceiver {
   event ReentrancySucceeded();

--- a/contracts/src/v0.8/ccip/test/libraries/MerkleMultiProof.t.sol
+++ b/contracts/src/v0.8/ccip/test/libraries/MerkleMultiProof.t.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.19;
 
 import "../BaseTest.t.sol";
 
-import {MerkleHelper} from "../helpers/MerkleHelper.sol";
 import {MerkleMultiProof} from "../../libraries/MerkleMultiProof.sol";
+import {MerkleHelper} from "../helpers/MerkleHelper.sol";
 
 contract MerkleMultiProofTest is BaseTest {
   // This must match the spec

--- a/contracts/src/v0.8/ccip/test/libraries/RateLimiter.t.sol
+++ b/contracts/src/v0.8/ccip/test/libraries/RateLimiter.t.sol
@@ -37,11 +37,8 @@ contract RateLimiter_setTokenBucketConfig is RateLimiterSetup {
     assertEq(s_config.rate, rateLimiter.rate);
     assertEq(s_config.capacity, rateLimiter.capacity);
 
-    s_config = RateLimiter.Config({
-      isEnabled: true,
-      rate: uint128(rateLimiter.rate * 2),
-      capacity: rateLimiter.capacity * 8
-    });
+    s_config =
+      RateLimiter.Config({isEnabled: true, rate: uint128(rateLimiter.rate * 2), capacity: rateLimiter.capacity * 8});
 
     vm.expectEmit();
     emit ConfigChanged(s_config);
@@ -219,9 +216,7 @@ contract RateLimiter_consume is RateLimiterSetup {
 
     vm.expectRevert(
       abi.encodeWithSelector(
-        RateLimiter.AggregateValueMaxCapacityExceeded.selector,
-        rateLimiter.capacity,
-        rateLimiter.capacity + 1
+        RateLimiter.AggregateValueMaxCapacityExceeded.selector, rateLimiter.capacity, rateLimiter.capacity + 1
       )
     );
     s_helper.consume(rateLimiter.capacity + 1, address(0));
@@ -232,10 +227,7 @@ contract RateLimiter_consume is RateLimiterSetup {
 
     vm.expectRevert(
       abi.encodeWithSelector(
-        RateLimiter.TokenMaxCapacityExceeded.selector,
-        rateLimiter.capacity,
-        rateLimiter.capacity + 1,
-        s_token
+        RateLimiter.TokenMaxCapacityExceeded.selector, rateLimiter.capacity, rateLimiter.capacity + 1, s_token
       )
     );
     s_helper.consume(rateLimiter.capacity + 1, s_token);
@@ -265,9 +257,7 @@ contract RateLimiter_consume is RateLimiterSetup {
 
     vm.expectRevert(
       abi.encodeWithSelector(
-        RateLimiter.AggregateValueRateLimitReached.selector,
-        waitInSeconds,
-        rateLimiter.capacity - requestTokens1
+        RateLimiter.AggregateValueRateLimitReached.selector, waitInSeconds, rateLimiter.capacity - requestTokens1
       )
     );
     s_helper.consume(requestTokens2, address(0));
@@ -286,10 +276,7 @@ contract RateLimiter_consume is RateLimiterSetup {
 
     vm.expectRevert(
       abi.encodeWithSelector(
-        RateLimiter.TokenRateLimitReached.selector,
-        waitInSeconds,
-        rateLimiter.capacity - requestTokens1,
-        s_token
+        RateLimiter.TokenRateLimitReached.selector, waitInSeconds, rateLimiter.capacity - requestTokens1, s_token
       )
     );
     s_helper.consume(requestTokens2, s_token);

--- a/contracts/src/v0.8/ccip/test/libraries/RateLimiter.t.sol
+++ b/contracts/src/v0.8/ccip/test/libraries/RateLimiter.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.19;
 
+import {RateLimiter} from "../../libraries/RateLimiter.sol";
 import {BaseTest} from "../BaseTest.t.sol";
 import {RateLimiterHelper} from "../helpers/RateLimiterHelper.sol";
-import {RateLimiter} from "../../libraries/RateLimiter.sol";
 
 contract RateLimiterSetup is BaseTest {
   RateLimiterHelper internal s_helper;

--- a/contracts/src/v0.8/ccip/test/mocks/MockARM.sol
+++ b/contracts/src/v0.8/ccip/test/mocks/MockARM.sol
@@ -7,6 +7,7 @@ import {OwnerIsCreator} from "./../../../shared/access/OwnerIsCreator.sol";
 
 contract MockARM is IARM, OwnerIsCreator {
   error CustomError(bytes err);
+
   bool private s_curse;
   bytes private s_err;
   ARM.VersionedConfig private s_versionedConfig;

--- a/contracts/src/v0.8/ccip/test/mocks/MockARM.sol
+++ b/contracts/src/v0.8/ccip/test/mocks/MockARM.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.19;
 
-import {IARM} from "../../interfaces/IARM.sol";
 import {ARM} from "../../ARM.sol";
+import {IARM} from "../../interfaces/IARM.sol";
 import {OwnerIsCreator} from "./../../../shared/access/OwnerIsCreator.sol";
 
 contract MockARM is IARM, OwnerIsCreator {

--- a/contracts/src/v0.8/ccip/test/mocks/MockE2EUSDCTokenMessenger.sol
+++ b/contracts/src/v0.8/ccip/test/mocks/MockE2EUSDCTokenMessenger.sol
@@ -48,19 +48,10 @@ contract MockE2EUSDCTokenMessenger is ITokenMessenger {
     IBurnMintERC20(burnToken).transferFrom(msg.sender, address(this), amount);
     IBurnMintERC20(burnToken).burn(amount);
     // Format message body
-    bytes memory _burnMessage = abi.encodePacked(
-      i_messageBodyVersion,
-      burnToken,
-      mintRecipient,
-      amount,
-      bytes32(uint256(uint160((msg.sender))))
-    );
-    s_nonce = _sendDepositForBurnMessage(
-      destinationDomain,
-      i_destinationTokenMessenger,
-      destinationCaller,
-      _burnMessage
-    );
+    bytes memory _burnMessage =
+      abi.encodePacked(i_messageBodyVersion, burnToken, mintRecipient, amount, bytes32(uint256(uint160((msg.sender)))));
+    s_nonce =
+      _sendDepositForBurnMessage(destinationDomain, i_destinationTokenMessenger, destinationCaller, _burnMessage);
     emit DepositForBurn(
       s_nonce,
       burnToken,
@@ -102,13 +93,9 @@ contract MockE2EUSDCTokenMessenger is ITokenMessenger {
     if (_destinationCaller == bytes32(0)) {
       return localMessageTransmitterWithRelay.sendMessage(_destinationDomain, _destinationTokenMessenger, _burnMessage);
     } else {
-      return
-        localMessageTransmitterWithRelay.sendMessageWithCaller(
-          _destinationDomain,
-          _destinationTokenMessenger,
-          _destinationCaller,
-          _burnMessage
-        );
+      return localMessageTransmitterWithRelay.sendMessageWithCaller(
+        _destinationDomain, _destinationTokenMessenger, _destinationCaller, _burnMessage
+      );
     }
   }
 }

--- a/contracts/src/v0.8/ccip/test/mocks/MockE2EUSDCTokenMessenger.sol
+++ b/contracts/src/v0.8/ccip/test/mocks/MockE2EUSDCTokenMessenger.sol
@@ -15,9 +15,9 @@
  */
 pragma solidity 0.8.19;
 
+import {IBurnMintERC20} from "../../../shared/token/ERC20/IBurnMintERC20.sol";
 import {ITokenMessenger} from "../../pools/USDC/ITokenMessenger.sol";
 import {IMessageTransmitterWithRelay} from "./interfaces/IMessageTransmitterWithRelay.sol";
-import {IBurnMintERC20} from "../../../shared/token/ERC20/IBurnMintERC20.sol";
 
 // This contract mocks both the ITokenMessenger and IMessageTransmitter
 // contracts involved with the Cross Chain Token Protocol.

--- a/contracts/src/v0.8/ccip/test/mocks/MockE2EUSDCTransmitter.sol
+++ b/contracts/src/v0.8/ccip/test/mocks/MockE2EUSDCTransmitter.sol
@@ -137,14 +137,7 @@ contract MockE2EUSDCTransmitter is IMessageTransmitterWithRelay {
     require(_recipient != bytes32(0), "Recipient must be nonzero");
     // serialize message
     bytes memory _message = abi.encodePacked(
-      i_version,
-      i_localDomain,
-      _destinationDomain,
-      _nonce,
-      _sender,
-      _recipient,
-      _destinationCaller,
-      _messageBody
+      i_version, i_localDomain, _destinationDomain, _nonce, _sender, _recipient, _destinationCaller, _messageBody
     );
 
     // Emit MessageSent event

--- a/contracts/src/v0.8/ccip/test/mocks/MockRouter.sol
+++ b/contracts/src/v0.8/ccip/test/mocks/MockRouter.sol
@@ -11,7 +11,8 @@ import {Internal} from "../../libraries/Internal.sol";
 
 import {SafeERC20} from "../../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC20} from "../../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/IERC20.sol";
-import {ERC165Checker} from "../../../vendor/openzeppelin-solidity/v4.8.3/contracts/utils/introspection/ERC165Checker.sol";
+import {ERC165Checker} from
+  "../../../vendor/openzeppelin-solidity/v4.8.3/contracts/utils/introspection/ERC165Checker.sol";
 
 contract MockCCIPRouter is IRouter, IRouterClient {
   using SafeERC20 for IERC20;
@@ -43,17 +44,14 @@ contract MockCCIPRouter is IRouter, IRouterClient {
     address receiver
   ) internal returns (bool success, bytes memory retData, uint256 gasUsed) {
     // Only send through the router if the receiver is a contract and implements the IAny2EVMMessageReceiver interface.
-    if (receiver.code.length == 0 || !receiver.supportsInterface(type(IAny2EVMMessageReceiver).interfaceId))
+    if (receiver.code.length == 0 || !receiver.supportsInterface(type(IAny2EVMMessageReceiver).interfaceId)) {
       return (true, "", 0);
+    }
 
     bytes memory data = abi.encodeWithSelector(IAny2EVMMessageReceiver.ccipReceive.selector, message);
 
     (success, retData, gasUsed) = CallWithExactGas._callWithExactGasSafeReturnData(
-      data,
-      receiver,
-      gasLimit,
-      gasForCallExactCheck,
-      Internal.MAX_RET_BYTES
+      data, receiver, gasLimit, gasForCallExactCheck, Internal.MAX_RET_BYTES
     );
 
     // Event to assist testing, does not exist on real deployments
@@ -93,7 +91,7 @@ contract MockCCIPRouter is IRouter, IRouterClient {
       IERC20(message.tokenAmounts[i].token).safeTransferFrom(msg.sender, receiver, message.tokenAmounts[i].amount);
     }
 
-    (bool success, bytes memory retData, ) = _routeMessage(executableMsg, GAS_FOR_CALL_EXACT_CHECK, gasLimit, receiver);
+    (bool success, bytes memory retData,) = _routeMessage(executableMsg, GAS_FOR_CALL_EXACT_CHECK, gasLimit, receiver);
 
     if (!success) revert ReceiverError(retData);
 
@@ -124,12 +122,12 @@ contract MockCCIPRouter is IRouter, IRouterClient {
   }
 
   /// @notice Always returns address(1234567890)
-  function getOnRamp(uint64 /* destChainSelector */) external pure returns (address onRampAddress) {
+  function getOnRamp(uint64 /* destChainSelector */ ) external pure returns (address onRampAddress) {
     return address(1234567890);
   }
 
   /// @notice Always returns true
-  function isOffRamp(uint64 /* sourceChainSelector */, address /* offRamp */) external pure returns (bool) {
+  function isOffRamp(uint64, /* sourceChainSelector */ address /* offRamp */ ) external pure returns (bool) {
     return true;
   }
 }

--- a/contracts/src/v0.8/ccip/test/mocks/MockRouter.sol
+++ b/contracts/src/v0.8/ccip/test/mocks/MockRouter.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import {IAny2EVMMessageReceiver} from "../../interfaces/IAny2EVMMessageReceiver.sol";
 import {IRouter} from "../../interfaces/IRouter.sol";
 import {IRouterClient} from "../../interfaces/IRouterClient.sol";
-import {IAny2EVMMessageReceiver} from "../../interfaces/IAny2EVMMessageReceiver.sol";
 
-import {Client} from "../../libraries/Client.sol";
 import {CallWithExactGas} from "../../../shared/call/CallWithExactGas.sol";
+import {Client} from "../../libraries/Client.sol";
 import {Internal} from "../../libraries/Internal.sol";
 
-import {SafeERC20} from "../../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC20} from "../../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "../../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/utils/SafeERC20.sol";
 import {ERC165Checker} from
   "../../../vendor/openzeppelin-solidity/v4.8.3/contracts/utils/introspection/ERC165Checker.sol";
 

--- a/contracts/src/v0.8/ccip/test/mocks/MockUSDCTokenMessenger.sol
+++ b/contracts/src/v0.8/ccip/test/mocks/MockUSDCTokenMessenger.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.19;
 
-import {ITokenMessenger} from "../../pools/USDC/ITokenMessenger.sol";
 import {IBurnMintERC20} from "../../../shared/token/ERC20/IBurnMintERC20.sol";
+import {ITokenMessenger} from "../../pools/USDC/ITokenMessenger.sol";
 
 // This contract mocks both the ITokenMessenger and IMessageTransmitter
 // contracts involved with the Cross Chain Token Protocol.

--- a/contracts/src/v0.8/ccip/test/ocr/OCR2Base.t.sol
+++ b/contracts/src/v0.8/ccip/test/ocr/OCR2Base.t.sol
@@ -47,18 +47,17 @@ contract OCR2BaseSetup is OCR2Setup {
 
   function getBasicConfigDigest(uint8 f, uint64 currentConfigCount) internal view returns (bytes32) {
     bytes memory configBytes = abi.encode("");
-    return
-      s_OCR2Base.configDigestFromConfigData(
-        block.chainid,
-        address(s_OCR2Base),
-        currentConfigCount + 1,
-        s_valid_signers,
-        s_valid_transmitters,
-        f,
-        configBytes,
-        s_offchainConfigVersion,
-        configBytes
-      );
+    return s_OCR2Base.configDigestFromConfigData(
+      block.chainid,
+      address(s_OCR2Base),
+      currentConfigCount + 1,
+      s_valid_signers,
+      s_valid_transmitters,
+      f,
+      configBytes,
+      s_offchainConfigVersion,
+      configBytes
+    );
   }
 
   function getTestReportDigest() internal view returns (bytes32) {
@@ -73,18 +72,17 @@ contract OCR2BaseSetup is OCR2Setup {
     uint64 currentConfigCount,
     bytes memory onchainConfig
   ) internal view returns (bytes32) {
-    return
-      s_OCR2Base.configDigestFromConfigData(
-        block.chainid,
-        contractAddress,
-        currentConfigCount + 1,
-        s_valid_signers,
-        s_valid_transmitters,
-        f,
-        onchainConfig,
-        s_offchainConfigVersion,
-        abi.encode("")
-      );
+    return s_OCR2Base.configDigestFromConfigData(
+      block.chainid,
+      contractAddress,
+      currentConfigCount + 1,
+      s_valid_signers,
+      s_valid_transmitters,
+      f,
+      onchainConfig,
+      s_offchainConfigVersion,
+      abi.encode("")
+    );
   }
 }
 
@@ -97,12 +95,7 @@ contract OCR2Base_transmit is OCR2BaseSetup {
 
     s_configDigest = getBasicConfigDigest(s_f, 0);
     s_OCR2Base.setOCR2Config(
-      s_valid_signers,
-      s_valid_transmitters,
-      s_f,
-      configBytes,
-      s_offchainConfigVersion,
-      configBytes
+      s_valid_signers, s_valid_transmitters, s_f, configBytes, s_offchainConfigVersion, configBytes
     );
   }
 
@@ -214,12 +207,7 @@ contract OCR2Base_setOCR2Config is OCR2BaseSetup {
     );
 
     s_OCR2Base.setOCR2Config(
-      s_valid_signers,
-      s_valid_transmitters,
-      s_f,
-      configBytes,
-      s_offchainConfigVersion,
-      configBytes
+      s_valid_signers, s_valid_transmitters, s_f, configBytes, s_offchainConfigVersion, configBytes
     );
 
     transmitters = s_OCR2Base.getTransmitters();
@@ -241,12 +229,7 @@ contract OCR2Base_setOCR2Config is OCR2BaseSetup {
     );
     vm.resumeGasMetering();
     s_OCR2Base.setOCR2Config(
-      s_valid_signers,
-      s_valid_transmitters,
-      s_f,
-      configBytes,
-      s_offchainConfigVersion,
-      configBytes
+      s_valid_signers, s_valid_transmitters, s_f, configBytes, s_offchainConfigVersion, configBytes
     );
   }
 

--- a/contracts/src/v0.8/ccip/test/ocr/OCR2Base.t.sol
+++ b/contracts/src/v0.8/ccip/test/ocr/OCR2Base.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.19;
 
-import {OCR2Setup} from "./OCR2Setup.t.sol";
 import {OCR2Base} from "../../ocr/OCR2Base.sol";
 import {OCR2Helper} from "../helpers/OCR2Helper.sol";
+import {OCR2Setup} from "./OCR2Setup.t.sol";
 
 contract OCR2BaseSetup is OCR2Setup {
   event ConfigSet(

--- a/contracts/src/v0.8/ccip/test/ocr/OCR2BaseNoChecks.t.sol
+++ b/contracts/src/v0.8/ccip/test/ocr/OCR2BaseNoChecks.t.sol
@@ -19,18 +19,17 @@ contract OCR2BaseNoChecksSetup is OCR2Setup {
 
   function getBasicConfigDigest(uint8 f, uint64 currentConfigCount) internal view returns (bytes32) {
     bytes memory configBytes = abi.encode("");
-    return
-      s_OCR2Base.configDigestFromConfigData(
-        block.chainid,
-        address(s_OCR2Base),
-        currentConfigCount + 1,
-        s_valid_signers,
-        s_valid_transmitters,
-        f,
-        configBytes,
-        s_offchainConfigVersion,
-        configBytes
-      );
+    return s_OCR2Base.configDigestFromConfigData(
+      block.chainid,
+      address(s_OCR2Base),
+      currentConfigCount + 1,
+      s_valid_signers,
+      s_valid_transmitters,
+      f,
+      configBytes,
+      s_offchainConfigVersion,
+      configBytes
+    );
   }
 }
 
@@ -43,12 +42,7 @@ contract OCR2BaseNoChecks_transmit is OCR2BaseNoChecksSetup {
 
     s_configDigest = getBasicConfigDigest(s_f, 0);
     s_OCR2Base.setOCR2Config(
-      s_valid_signers,
-      s_valid_transmitters,
-      s_f,
-      configBytes,
-      s_offchainConfigVersion,
-      configBytes
+      s_valid_signers, s_valid_transmitters, s_f, configBytes, s_offchainConfigVersion, configBytes
     );
   }
 
@@ -132,12 +126,7 @@ contract OCR2BaseNoChecks_setOCR2Config is OCR2BaseNoChecksSetup {
     );
 
     s_OCR2Base.setOCR2Config(
-      s_valid_signers,
-      s_valid_transmitters,
-      s_f,
-      configBytes,
-      s_offchainConfigVersion,
-      configBytes
+      s_valid_signers, s_valid_transmitters, s_f, configBytes, s_offchainConfigVersion, configBytes
     );
 
     transmitters = s_OCR2Base.getTransmitters();
@@ -159,12 +148,7 @@ contract OCR2BaseNoChecks_setOCR2Config is OCR2BaseNoChecksSetup {
     );
     vm.resumeGasMetering();
     s_OCR2Base.setOCR2Config(
-      s_valid_signers,
-      s_valid_transmitters,
-      s_f,
-      configBytes,
-      s_offchainConfigVersion,
-      configBytes
+      s_valid_signers, s_valid_transmitters, s_f, configBytes, s_offchainConfigVersion, configBytes
     );
   }
 

--- a/contracts/src/v0.8/ccip/test/ocr/OCR2BaseNoChecks.t.sol
+++ b/contracts/src/v0.8/ccip/test/ocr/OCR2BaseNoChecks.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.19;
 
-import {OCR2Setup} from "./OCR2Setup.t.sol";
 import {OCR2BaseNoChecks} from "../../ocr/OCR2BaseNoChecks.sol";
 import {OCR2NoChecksHelper} from "../helpers/OCR2NoChecksHelper.sol";
+import {OCR2Setup} from "./OCR2Setup.t.sol";
 
 contract OCR2BaseNoChecksSetup is OCR2Setup {
   OCR2NoChecksHelper internal s_OCR2Base;

--- a/contracts/src/v0.8/ccip/test/offRamp/EVM2EVMOffRamp.t.sol
+++ b/contracts/src/v0.8/ccip/test/offRamp/EVM2EVMOffRamp.t.sol
@@ -39,10 +39,8 @@ contract EVM2EVMOffRamp_constructor is EVM2EVMOffRampSetup {
       prevOffRamp: address(0),
       armProxy: address(s_mockARM)
     });
-    EVM2EVMOffRamp.DynamicConfig memory dynamicConfig = generateDynamicOffRampConfig(
-      address(s_destRouter),
-      address(s_priceRegistry)
-    );
+    EVM2EVMOffRamp.DynamicConfig memory dynamicConfig =
+      generateDynamicOffRampConfig(address(s_destRouter), address(s_priceRegistry));
     IERC20[] memory sourceTokens = getCastedSourceTokens();
     IPool[] memory castedPools = getCastedDestinationPools();
 
@@ -54,12 +52,7 @@ contract EVM2EVMOffRamp_constructor is EVM2EVMOffRampSetup {
     s_offRamp = new EVM2EVMOffRampHelper(staticConfig, sourceTokens, castedPools, getInboundRateLimiterConfig());
 
     s_offRamp.setOCR2Config(
-      s_valid_signers,
-      s_valid_transmitters,
-      s_f,
-      abi.encode(dynamicConfig),
-      s_offchainConfigVersion,
-      abi.encode("")
+      s_valid_signers, s_valid_transmitters, s_f, abi.encode(dynamicConfig), s_offchainConfigVersion, abi.encode("")
     );
 
     // Static config
@@ -81,7 +74,7 @@ contract EVM2EVMOffRamp_constructor is EVM2EVMOffRampSetup {
     assertTrue(address(pools[1]) == address(s_sourceTokens[1]));
     assertEq(address(s_offRamp.getPoolByDestToken(IERC20(s_destTokens[0]))), address(s_destPools[0]));
 
-    (uint32 configCount, uint32 blockNumber, ) = s_offRamp.latestConfigDetails();
+    (uint32 configCount, uint32 blockNumber,) = s_offRamp.latestConfigDetails();
     assertEq(1, configCount);
     assertEq(block.number, blockNumber);
 
@@ -116,11 +109,7 @@ contract EVM2EVMOffRamp_constructor is EVM2EVMOffRampSetup {
     IPool[] memory pools = new IPool[](2);
     pools[0] = IPool(s_sourcePools[0]);
     pools[1] = new LockReleaseTokenPool(
-      IERC20(s_sourceTokens[1]),
-      new address[](0),
-      address(s_mockARM),
-      true,
-      address(s_destRouter)
+      IERC20(s_sourceTokens[1]), new address[](0), address(s_mockARM), true, address(s_destRouter)
     );
 
     vm.expectRevert(EVM2EVMOffRamp.ZeroAddressNotAllowed.selector);
@@ -190,12 +179,7 @@ contract EVM2EVMOffRamp_setDynamicConfig is EVM2EVMOffRampSetup {
     );
 
     s_offRamp.setOCR2Config(
-      s_valid_signers,
-      s_valid_transmitters,
-      s_f,
-      onchainConfig,
-      s_offchainConfigVersion,
-      abi.encode("")
+      s_valid_signers, s_valid_transmitters, s_f, onchainConfig, s_offchainConfigVersion, abi.encode("")
     );
 
     EVM2EVMOffRamp.DynamicConfig memory newConfig = s_offRamp.getDynamicConfig();
@@ -209,12 +193,7 @@ contract EVM2EVMOffRamp_setDynamicConfig is EVM2EVMOffRampSetup {
     vm.expectRevert("Only callable by owner");
 
     s_offRamp.setOCR2Config(
-      s_valid_signers,
-      s_valid_transmitters,
-      s_f,
-      abi.encode(dynamicConfig),
-      s_offchainConfigVersion,
-      abi.encode("")
+      s_valid_signers, s_valid_transmitters, s_f, abi.encode(dynamicConfig), s_offchainConfigVersion, abi.encode("")
     );
   }
 
@@ -224,12 +203,7 @@ contract EVM2EVMOffRamp_setDynamicConfig is EVM2EVMOffRampSetup {
     vm.expectRevert(EVM2EVMOffRamp.ZeroAddressNotAllowed.selector);
 
     s_offRamp.setOCR2Config(
-      s_valid_signers,
-      s_valid_transmitters,
-      s_f,
-      abi.encode(dynamicConfig),
-      s_offchainConfigVersion,
-      abi.encode("")
+      s_valid_signers, s_valid_transmitters, s_f, abi.encode(dynamicConfig), s_offchainConfigVersion, abi.encode("")
     );
   }
 }
@@ -263,10 +237,7 @@ contract EVM2EVMOffRamp_execute is EVM2EVMOffRampSetup {
     Internal.EVM2EVMMessage[] memory messages = _generateBasicMessages();
     vm.expectEmit();
     emit ExecutionStateChanged(
-      messages[0].sequenceNumber,
-      messages[0].messageId,
-      Internal.MessageExecutionState.SUCCESS,
-      ""
+      messages[0].sequenceNumber, messages[0].messageId, Internal.MessageExecutionState.SUCCESS, ""
     );
 
     s_offRamp.execute(_generateReportFromMessages(messages), new uint256[](0));
@@ -277,10 +248,7 @@ contract EVM2EVMOffRamp_execute is EVM2EVMOffRampSetup {
 
     vm.expectEmit();
     emit ExecutionStateChanged(
-      messages[0].sequenceNumber,
-      messages[0].messageId,
-      Internal.MessageExecutionState.SUCCESS,
-      ""
+      messages[0].sequenceNumber, messages[0].messageId, Internal.MessageExecutionState.SUCCESS, ""
     );
 
     uint64 nonceBefore = s_offRamp.getSenderNonce(messages[0].sender);
@@ -324,10 +292,7 @@ contract EVM2EVMOffRamp_execute is EVM2EVMOffRampSetup {
 
     vm.expectEmit();
     emit ExecutionStateChanged(
-      messages[0].sequenceNumber,
-      messages[0].messageId,
-      Internal.MessageExecutionState.SUCCESS,
-      ""
+      messages[0].sequenceNumber, messages[0].messageId, Internal.MessageExecutionState.SUCCESS, ""
     );
     // Nonce should increment on a strict untouched -> success.
     assertEq(uint64(0), s_offRamp.getSenderNonce(address(OWNER)));
@@ -355,10 +320,7 @@ contract EVM2EVMOffRamp_execute is EVM2EVMOffRampSetup {
 
     vm.expectEmit();
     emit ExecutionStateChanged(
-      messages[0].sequenceNumber,
-      messages[0].messageId,
-      Internal.MessageExecutionState.SUCCESS,
-      ""
+      messages[0].sequenceNumber, messages[0].messageId, Internal.MessageExecutionState.SUCCESS, ""
     );
 
     vm.expectEmit();
@@ -377,10 +339,7 @@ contract EVM2EVMOffRamp_execute is EVM2EVMOffRampSetup {
 
     vm.expectEmit();
     emit ExecutionStateChanged(
-      messages[0].sequenceNumber,
-      messages[0].messageId,
-      Internal.MessageExecutionState.SUCCESS,
-      ""
+      messages[0].sequenceNumber, messages[0].messageId, Internal.MessageExecutionState.SUCCESS, ""
     );
 
     s_offRamp.execute(_generateReportFromMessages(messages), new uint256[](0));
@@ -392,10 +351,7 @@ contract EVM2EVMOffRamp_execute is EVM2EVMOffRampSetup {
 
     vm.expectEmit();
     emit ExecutionStateChanged(
-      messages[0].sequenceNumber,
-      messages[0].messageId,
-      Internal.MessageExecutionState.SUCCESS,
-      ""
+      messages[0].sequenceNumber, messages[0].messageId, Internal.MessageExecutionState.SUCCESS, ""
     );
 
     Internal.ExecutionReport memory report = _generateReportFromMessages(messages);
@@ -413,18 +369,12 @@ contract EVM2EVMOffRamp_execute is EVM2EVMOffRampSetup {
 
     vm.expectEmit();
     emit ExecutionStateChanged(
-      messages[0].sequenceNumber,
-      messages[0].messageId,
-      Internal.MessageExecutionState.SUCCESS,
-      ""
+      messages[0].sequenceNumber, messages[0].messageId, Internal.MessageExecutionState.SUCCESS, ""
     );
 
     vm.expectEmit();
     emit ExecutionStateChanged(
-      messages[1].sequenceNumber,
-      messages[1].messageId,
-      Internal.MessageExecutionState.SUCCESS,
-      ""
+      messages[1].sequenceNumber, messages[1].messageId, Internal.MessageExecutionState.SUCCESS, ""
     );
 
     Internal.ExecutionReport memory report = _generateReportFromMessages(messages);
@@ -441,18 +391,12 @@ contract EVM2EVMOffRamp_execute is EVM2EVMOffRampSetup {
 
     vm.expectEmit();
     emit ExecutionStateChanged(
-      messages[0].sequenceNumber,
-      messages[0].messageId,
-      Internal.MessageExecutionState.SUCCESS,
-      ""
+      messages[0].sequenceNumber, messages[0].messageId, Internal.MessageExecutionState.SUCCESS, ""
     );
 
     vm.expectEmit();
     emit ExecutionStateChanged(
-      messages[1].sequenceNumber,
-      messages[1].messageId,
-      Internal.MessageExecutionState.SUCCESS,
-      ""
+      messages[1].sequenceNumber, messages[1].messageId, Internal.MessageExecutionState.SUCCESS, ""
     );
 
     assertEq(uint64(0), s_offRamp.getSenderNonce(OWNER));
@@ -521,9 +465,7 @@ contract EVM2EVMOffRamp_execute is EVM2EVMOffRampSetup {
 
   function testManualExecutionNotYetEnabledReverts() public {
     vm.mockCall(
-      address(s_mockCommitStore),
-      abi.encodeWithSelector(ICommitStore.verify.selector),
-      abi.encode(BLOCK_TIME)
+      address(s_mockCommitStore), abi.encodeWithSelector(ICommitStore.verify.selector), abi.encode(BLOCK_TIME)
     );
     vm.expectRevert(EVM2EVMOffRamp.ManualExecutionNotYetEnabled.selector);
 
@@ -611,8 +553,7 @@ contract EVM2EVMOffRamp_execute is EVM2EVMOffRampSetup {
 
     vm.expectRevert(
       abi.encodeWithSelector(
-        EVM2EVMOffRamp.ExecutionError.selector,
-        abi.encodeWithSelector(CallWithExactGas.NotEnoughGasForCall.selector)
+        EVM2EVMOffRamp.ExecutionError.selector, abi.encodeWithSelector(CallWithExactGas.NotEnoughGasForCall.selector)
       )
     );
     s_offRamp.execute(executionReport, new uint256[](0));
@@ -636,10 +577,7 @@ contract EVM2EVMOffRamp_execute_upgrade is EVM2EVMOffRampSetup {
     Internal.EVM2EVMMessage[] memory messages = _generateBasicMessages();
     vm.expectEmit();
     emit ExecutionStateChanged(
-      messages[0].sequenceNumber,
-      messages[0].messageId,
-      Internal.MessageExecutionState.SUCCESS,
-      ""
+      messages[0].sequenceNumber, messages[0].messageId, Internal.MessageExecutionState.SUCCESS, ""
     );
 
     s_offRamp.execute(_generateReportFromMessages(messages), new uint256[](0));
@@ -664,10 +602,7 @@ contract EVM2EVMOffRamp_execute_upgrade is EVM2EVMOffRampSetup {
     Internal.EVM2EVMMessage[] memory messages = _generateBasicMessages();
     vm.expectEmit();
     emit ExecutionStateChanged(
-      messages[0].sequenceNumber,
-      messages[0].messageId,
-      Internal.MessageExecutionState.SUCCESS,
-      ""
+      messages[0].sequenceNumber, messages[0].messageId, Internal.MessageExecutionState.SUCCESS, ""
     );
 
     uint64 startNonce = s_offRamp.getSenderNonce(messages[0].sender);
@@ -681,10 +616,7 @@ contract EVM2EVMOffRamp_execute_upgrade is EVM2EVMOffRampSetup {
 
     vm.expectEmit();
     emit ExecutionStateChanged(
-      messages[0].sequenceNumber,
-      messages[0].messageId,
-      Internal.MessageExecutionState.SUCCESS,
-      ""
+      messages[0].sequenceNumber, messages[0].messageId, Internal.MessageExecutionState.SUCCESS, ""
     );
 
     s_offRamp.execute(_generateReportFromMessages(messages), new uint256[](0));
@@ -696,10 +628,7 @@ contract EVM2EVMOffRamp_execute_upgrade is EVM2EVMOffRampSetup {
 
     vm.expectEmit();
     emit ExecutionStateChanged(
-      messages[0].sequenceNumber,
-      messages[0].messageId,
-      Internal.MessageExecutionState.SUCCESS,
-      ""
+      messages[0].sequenceNumber, messages[0].messageId, Internal.MessageExecutionState.SUCCESS, ""
     );
 
     s_offRamp.execute(_generateReportFromMessages(messages), new uint256[](0));
@@ -710,10 +639,7 @@ contract EVM2EVMOffRamp_execute_upgrade is EVM2EVMOffRampSetup {
     Internal.EVM2EVMMessage[] memory messages = _generateBasicMessages();
     vm.expectEmit();
     emit ExecutionStateChanged(
-      messages[0].sequenceNumber,
-      messages[0].messageId,
-      Internal.MessageExecutionState.SUCCESS,
-      ""
+      messages[0].sequenceNumber, messages[0].messageId, Internal.MessageExecutionState.SUCCESS, ""
     );
 
     s_prevOffRamp.execute(_generateReportFromMessages(messages), new uint256[](0));
@@ -724,10 +650,7 @@ contract EVM2EVMOffRamp_execute_upgrade is EVM2EVMOffRampSetup {
 
     vm.expectEmit();
     emit ExecutionStateChanged(
-      messages[0].sequenceNumber,
-      messages[0].messageId,
-      Internal.MessageExecutionState.SUCCESS,
-      ""
+      messages[0].sequenceNumber, messages[0].messageId, Internal.MessageExecutionState.SUCCESS, ""
     );
 
     // new sender nonce in new offramp should go from 0 -> 1
@@ -759,10 +682,7 @@ contract EVM2EVMOffRamp_execute_upgrade is EVM2EVMOffRampSetup {
     // previous offramp executes msg and increases nonce
     vm.expectEmit();
     emit ExecutionStateChanged(
-      messages[0].sequenceNumber,
-      messages[0].messageId,
-      Internal.MessageExecutionState.SUCCESS,
-      ""
+      messages[0].sequenceNumber, messages[0].messageId, Internal.MessageExecutionState.SUCCESS, ""
     );
     s_prevOffRamp.execute(_generateReportFromMessages(messages), new uint256[](0));
     assertEq(startNonce + 1, s_offRamp.getSenderNonce(messages[0].sender));
@@ -773,10 +693,7 @@ contract EVM2EVMOffRamp_execute_upgrade is EVM2EVMOffRampSetup {
     // new offramp is able to execute
     vm.expectEmit();
     emit ExecutionStateChanged(
-      messages[0].sequenceNumber,
-      messages[0].messageId,
-      Internal.MessageExecutionState.SUCCESS,
-      ""
+      messages[0].sequenceNumber, messages[0].messageId, Internal.MessageExecutionState.SUCCESS, ""
     );
 
     s_offRamp.execute(_generateReportFromMessages(messages), new uint256[](0));
@@ -878,10 +795,7 @@ contract EVM2EVMOffRamp__report is EVM2EVMOffRampSetup {
 
     vm.expectEmit();
     emit ExecutionStateChanged(
-      messages[0].sequenceNumber,
-      messages[0].messageId,
-      Internal.MessageExecutionState.SUCCESS,
-      ""
+      messages[0].sequenceNumber, messages[0].messageId, Internal.MessageExecutionState.SUCCESS, ""
     );
     s_offRamp.report(abi.encode(report));
   }
@@ -900,10 +814,7 @@ contract EVM2EVMOffRamp_manuallyExecute is EVM2EVMOffRampSetup {
 
     vm.expectEmit();
     emit ExecutionStateChanged(
-      messages[0].sequenceNumber,
-      messages[0].messageId,
-      Internal.MessageExecutionState.SUCCESS,
-      ""
+      messages[0].sequenceNumber, messages[0].messageId, Internal.MessageExecutionState.SUCCESS, ""
     );
     s_offRamp.manuallyExecute(_generateReportFromMessages(messages), new uint256[](messages.length));
   }
@@ -918,10 +829,7 @@ contract EVM2EVMOffRamp_manuallyExecute is EVM2EVMOffRampSetup {
 
     vm.expectEmit();
     emit ExecutionStateChanged(
-      messages[0].sequenceNumber,
-      messages[0].messageId,
-      Internal.MessageExecutionState.SUCCESS,
-      ""
+      messages[0].sequenceNumber, messages[0].messageId, Internal.MessageExecutionState.SUCCESS, ""
     );
 
     uint256[] memory gasLimitOverrides = _getGasLimitsFromMessages(messages);
@@ -955,10 +863,7 @@ contract EVM2EVMOffRamp_manuallyExecute is EVM2EVMOffRampSetup {
 
     vm.expectEmit();
     emit ExecutionStateChanged(
-      messages[0].sequenceNumber,
-      messages[0].messageId,
-      Internal.MessageExecutionState.SUCCESS,
-      ""
+      messages[0].sequenceNumber, messages[0].messageId, Internal.MessageExecutionState.SUCCESS, ""
     );
     s_offRamp.manuallyExecute(_generateReportFromMessages(messages), gasLimitOverrides);
   }
@@ -1137,10 +1042,7 @@ contract EVM2EVMOffRamp_getExecutionState is EVM2EVMOffRampSetup {
 
     for (uint64 i = 0; i < 3; ++i) {
       // 0x555... == 0b101010101010.....
-      assertEq(
-        0x5555555555555555555555555555555555555555555555555555555555555555,
-        s_offRamp.getExecutionStateBitMap(i)
-      );
+      assertEq(0x5555555555555555555555555555555555555555555555555555555555555555, s_offRamp.getExecutionStateBitMap(i));
     }
   }
 }
@@ -1155,10 +1057,8 @@ contract EVM2EVMOffRamp__trialExecute is EVM2EVMOffRampSetup {
     IERC20 dstToken0 = IERC20(s_destTokens[0]);
     uint256 startingBalance = dstToken0.balanceOf(message.receiver);
 
-    (Internal.MessageExecutionState newState, bytes memory err) = s_offRamp.trialExecute(
-      message,
-      new bytes[](message.tokenAmounts.length)
-    );
+    (Internal.MessageExecutionState newState, bytes memory err) =
+      s_offRamp.trialExecute(message, new bytes[](message.tokenAmounts.length));
     assertEq(uint256(Internal.MessageExecutionState.SUCCESS), uint256(newState));
     assertEq("", err);
 
@@ -1179,10 +1079,8 @@ contract EVM2EVMOffRamp__trialExecute is EVM2EVMOffRampSetup {
     Internal.EVM2EVMMessage memory message = _generateAny2EVMMessageWithTokens(1, amounts);
     MaybeRevertingBurnMintTokenPool(s_destPools[1]).setShouldRevert(errorMessage);
 
-    (Internal.MessageExecutionState newState, bytes memory err) = s_offRamp.trialExecute(
-      message,
-      new bytes[](message.tokenAmounts.length)
-    );
+    (Internal.MessageExecutionState newState, bytes memory err) =
+      s_offRamp.trialExecute(message, new bytes[](message.tokenAmounts.length));
     assertEq(uint256(Internal.MessageExecutionState.FAILURE), uint256(newState));
     assertEq(abi.encodeWithSelector(EVM2EVMOffRamp.TokenHandlingError.selector, errorMessage), err);
 
@@ -1200,10 +1098,8 @@ contract EVM2EVMOffRamp__trialExecute is EVM2EVMOffRampSetup {
     Internal.EVM2EVMMessage memory message = _generateAny2EVMMessageWithTokens(1, amounts);
     MaybeRevertingBurnMintTokenPool(s_destPools[1]).setShouldRevert(errorMessage);
 
-    (Internal.MessageExecutionState newState, bytes memory err) = s_offRamp.trialExecute(
-      message,
-      new bytes[](message.tokenAmounts.length)
-    );
+    (Internal.MessageExecutionState newState, bytes memory err) =
+      s_offRamp.trialExecute(message, new bytes[](message.tokenAmounts.length));
     assertEq(uint256(Internal.MessageExecutionState.FAILURE), uint256(newState));
     assertEq(abi.encodeWithSelector(EVM2EVMOffRamp.TokenHandlingError.selector, errorMessage), err);
   }
@@ -1266,29 +1162,15 @@ contract EVM2EVMOffRamp__releaseOrMintTokens is EVM2EVMOffRampSetup {
 
     bytes[] memory rateLimitErrors = new bytes[](5);
     rateLimitErrors[0] = abi.encodeWithSelector(RateLimiter.BucketOverfilled.selector);
-    rateLimitErrors[1] = abi.encodeWithSelector(
-      RateLimiter.AggregateValueMaxCapacityExceeded.selector,
-      uint256(100),
-      uint256(1000)
-    );
-    rateLimitErrors[2] = abi.encodeWithSelector(
-      RateLimiter.AggregateValueRateLimitReached.selector,
-      uint256(42),
-      1,
-      s_sourceTokens[0]
-    );
+    rateLimitErrors[1] =
+      abi.encodeWithSelector(RateLimiter.AggregateValueMaxCapacityExceeded.selector, uint256(100), uint256(1000));
+    rateLimitErrors[2] =
+      abi.encodeWithSelector(RateLimiter.AggregateValueRateLimitReached.selector, uint256(42), 1, s_sourceTokens[0]);
     rateLimitErrors[3] = abi.encodeWithSelector(
-      RateLimiter.TokenMaxCapacityExceeded.selector,
-      uint256(100),
-      uint256(1000),
-      s_sourceTokens[0]
+      RateLimiter.TokenMaxCapacityExceeded.selector, uint256(100), uint256(1000), s_sourceTokens[0]
     );
-    rateLimitErrors[4] = abi.encodeWithSelector(
-      RateLimiter.TokenRateLimitReached.selector,
-      uint256(42),
-      1,
-      s_sourceTokens[0]
-    );
+    rateLimitErrors[4] =
+      abi.encodeWithSelector(RateLimiter.TokenRateLimitReached.selector, uint256(42), 1, s_sourceTokens[0]);
 
     for (uint256 i = 0; i < rateLimitErrors.length; ++i) {
       MaybeRevertingBurnMintTokenPool(s_destPools[1]).setShouldRevert(rateLimitErrors[i]);
@@ -1323,7 +1205,7 @@ contract EVM2EVMOffRamp_applyPoolUpdates is EVM2EVMOffRampSetup {
       token: address(1),
       pool: address(
         new LockReleaseTokenPool(IERC20(address(1)), new address[](0), address(s_mockARM), true, address(s_destRouter))
-      )
+        )
     });
 
     vm.expectEmit();
@@ -1357,13 +1239,13 @@ contract EVM2EVMOffRamp_applyPoolUpdates is EVM2EVMOffRampSetup {
       token: address(1),
       pool: address(
         new LockReleaseTokenPool(IERC20(address(1)), new address[](0), address(s_mockARM), true, address(s_destRouter))
-      )
+        )
     });
     adds[1] = Internal.PoolUpdate({
       token: address(1),
       pool: address(
         new LockReleaseTokenPool(IERC20(address(1)), new address[](0), address(s_mockARM), true, address(s_destRouter))
-      )
+        )
     });
 
     vm.expectRevert(EVM2EVMOffRamp.PoolAlreadyAdded.selector);
@@ -1392,7 +1274,7 @@ contract EVM2EVMOffRamp_applyPoolUpdates is EVM2EVMOffRampSetup {
       token: address(1),
       pool: address(
         new LockReleaseTokenPool(IERC20(address(1)), new address[](0), address(s_mockARM), true, address(s_destRouter))
-      )
+        )
     });
 
     vm.expectRevert(EVM2EVMOffRamp.PoolDoesNotExist.selector);
@@ -1406,7 +1288,7 @@ contract EVM2EVMOffRamp_applyPoolUpdates is EVM2EVMOffRampSetup {
       token: address(1),
       pool: address(
         new LockReleaseTokenPool(IERC20(address(1)), new address[](0), address(s_mockARM), true, address(s_destRouter))
-      )
+        )
     });
     s_offRamp.applyPoolUpdates(new Internal.PoolUpdate[](0), adds);
 
@@ -1414,14 +1296,8 @@ contract EVM2EVMOffRamp_applyPoolUpdates is EVM2EVMOffRampSetup {
     removes[0] = Internal.PoolUpdate({
       token: address(1),
       pool: address(
-        new LockReleaseTokenPool(
-          IERC20(address(1000)),
-          new address[](0),
-          address(s_mockARM),
-          true,
-          address(s_destRouter)
+        new LockReleaseTokenPool(IERC20(address(1000)), new address[](0), address(s_mockARM), true, address(s_destRouter))
         )
-      )
     });
 
     vm.expectRevert(EVM2EVMOffRamp.TokenPoolMismatch.selector);

--- a/contracts/src/v0.8/ccip/test/offRamp/EVM2EVMOffRamp.t.sol
+++ b/contracts/src/v0.8/ccip/test/offRamp/EVM2EVMOffRamp.t.sol
@@ -1,28 +1,27 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.19;
 
-import {IPool} from "../../interfaces/pools/IPool.sol";
 import {ICommitStore} from "../../interfaces/ICommitStore.sol";
+import {IPool} from "../../interfaces/pools/IPool.sol";
 
-import {EVM2EVMOffRampSetup} from "./EVM2EVMOffRampSetup.t.sol";
-import {OCR2Base} from "../ocr/OCR2Base.t.sol";
-import {OCR2BaseNoChecks} from "../ocr/OCR2BaseNoChecks.t.sol";
-import {Router} from "../../Router.sol";
+import {CallWithExactGas} from "../../../shared/call/CallWithExactGas.sol";
 import {ARM} from "../../ARM.sol";
-import {RateLimiter} from "../../libraries/RateLimiter.sol";
-import {Internal} from "../../libraries/Internal.sol";
+import {Router} from "../../Router.sol";
 import {Client} from "../../libraries/Client.sol";
+import {Internal} from "../../libraries/Internal.sol";
+import {RateLimiter} from "../../libraries/RateLimiter.sol";
 import {EVM2EVMOffRamp} from "../../offRamp/EVM2EVMOffRamp.sol";
 import {LockReleaseTokenPool} from "../../pools/LockReleaseTokenPool.sol";
-
-import {MockCommitStore} from "../mocks/MockCommitStore.sol";
-import {CallWithExactGas} from "../../../shared/call/CallWithExactGas.sol";
-import {ConformingReceiver} from "../helpers/receivers/ConformingReceiver.sol";
-import {MaybeRevertMessageReceiverNo165} from "../helpers/receivers/MaybeRevertMessageReceiverNo165.sol";
-import {MaybeRevertMessageReceiver} from "../helpers/receivers/MaybeRevertMessageReceiver.sol";
-import {ReentrancyAbuser} from "../helpers/receivers/ReentrancyAbuser.sol";
-import {MaybeRevertingBurnMintTokenPool} from "../helpers/MaybeRevertingBurnMintTokenPool.sol";
 import {EVM2EVMOffRampHelper} from "../helpers/EVM2EVMOffRampHelper.sol";
+import {MaybeRevertingBurnMintTokenPool} from "../helpers/MaybeRevertingBurnMintTokenPool.sol";
+import {ConformingReceiver} from "../helpers/receivers/ConformingReceiver.sol";
+import {MaybeRevertMessageReceiver} from "../helpers/receivers/MaybeRevertMessageReceiver.sol";
+import {MaybeRevertMessageReceiverNo165} from "../helpers/receivers/MaybeRevertMessageReceiverNo165.sol";
+import {ReentrancyAbuser} from "../helpers/receivers/ReentrancyAbuser.sol";
+import {MockCommitStore} from "../mocks/MockCommitStore.sol";
+import {OCR2Base} from "../ocr/OCR2Base.t.sol";
+import {OCR2BaseNoChecks} from "../ocr/OCR2BaseNoChecks.t.sol";
+import {EVM2EVMOffRampSetup} from "./EVM2EVMOffRampSetup.t.sol";
 
 import {IERC20} from "../../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/src/v0.8/ccip/test/offRamp/EVM2EVMOffRampSetup.t.sol
+++ b/contracts/src/v0.8/ccip/test/offRamp/EVM2EVMOffRampSetup.t.sol
@@ -29,10 +29,7 @@ contract EVM2EVMOffRampSetup is TokenSetup, PriceRegistrySetup, OCR2BaseSetup {
   EVM2EVMOffRampHelper internal s_offRamp;
 
   event ExecutionStateChanged(
-    uint64 indexed sequenceNumber,
-    bytes32 indexed messageId,
-    Internal.MessageExecutionState state,
-    bytes returnData
+    uint64 indexed sequenceNumber, bytes32 indexed messageId, Internal.MessageExecutionState state, bytes returnData
   );
   event SkippedIncorrectNonce(uint64 indexed nonce, address indexed sender);
 
@@ -90,9 +87,11 @@ contract EVM2EVMOffRampSetup is TokenSetup, PriceRegistrySetup, OCR2BaseSetup {
     s_destRouter.applyRampUpdates(onRampUpdates, new Router.OffRamp[](0), offRampUpdates);
   }
 
-  function _convertToGeneralMessage(
-    Internal.EVM2EVMMessage memory original
-  ) internal view returns (Client.Any2EVMMessage memory message) {
+  function _convertToGeneralMessage(Internal.EVM2EVMMessage memory original)
+    internal
+    view
+    returns (Client.Any2EVMMessage memory message)
+  {
     uint256 numberOfTokens = original.tokenAmounts.length;
     Client.EVMTokenAmount[] memory destTokenAmounts = new Client.EVMTokenAmount[](numberOfTokens);
 
@@ -102,19 +101,20 @@ contract EVM2EVMOffRampSetup is TokenSetup, PriceRegistrySetup, OCR2BaseSetup {
       destTokenAmounts[i].amount = original.tokenAmounts[i].amount;
     }
 
-    return
-      Client.Any2EVMMessage({
-        messageId: original.messageId,
-        sourceChainSelector: original.sourceChainSelector,
-        sender: abi.encode(original.sender),
-        data: original.data,
-        destTokenAmounts: destTokenAmounts
-      });
+    return Client.Any2EVMMessage({
+      messageId: original.messageId,
+      sourceChainSelector: original.sourceChainSelector,
+      sender: abi.encode(original.sender),
+      data: original.data,
+      destTokenAmounts: destTokenAmounts
+    });
   }
 
-  function _generateAny2EVMMessageNoTokens(
-    uint64 sequenceNumber
-  ) internal view returns (Internal.EVM2EVMMessage memory) {
+  function _generateAny2EVMMessageNoTokens(uint64 sequenceNumber)
+    internal
+    view
+    returns (Internal.EVM2EVMMessage memory)
+  {
     return _generateAny2EVMMessage(sequenceNumber, new Client.EVMTokenAmount[](0));
   }
 
@@ -175,27 +175,30 @@ contract EVM2EVMOffRampSetup is TokenSetup, PriceRegistrySetup, OCR2BaseSetup {
     return messages;
   }
 
-  function _generateReportFromMessages(
-    Internal.EVM2EVMMessage[] memory messages
-  ) internal pure returns (Internal.ExecutionReport memory) {
+  function _generateReportFromMessages(Internal.EVM2EVMMessage[] memory messages)
+    internal
+    pure
+    returns (Internal.ExecutionReport memory)
+  {
     bytes[][] memory offchainTokenData = new bytes[][](messages.length);
 
     for (uint256 i = 0; i < messages.length; ++i) {
       offchainTokenData[i] = new bytes[](messages[i].tokenAmounts.length);
     }
 
-    return
-      Internal.ExecutionReport({
-        proofs: new bytes32[](0),
-        proofFlagBits: 2 ** 256 - 1,
-        messages: messages,
-        offchainTokenData: offchainTokenData
-      });
+    return Internal.ExecutionReport({
+      proofs: new bytes32[](0),
+      proofFlagBits: 2 ** 256 - 1,
+      messages: messages,
+      offchainTokenData: offchainTokenData
+    });
   }
 
-  function _getGasLimitsFromMessages(
-    Internal.EVM2EVMMessage[] memory messages
-  ) internal pure returns (uint256[] memory) {
+  function _getGasLimitsFromMessages(Internal.EVM2EVMMessage[] memory messages)
+    internal
+    pure
+    returns (uint256[] memory)
+  {
     uint256[] memory gasLimits = new uint256[](messages.length);
     for (uint256 i = 0; i < messages.length; ++i) {
       gasLimits[i] = messages[i].gasLimit;

--- a/contracts/src/v0.8/ccip/test/offRamp/EVM2EVMOffRampSetup.t.sol
+++ b/contracts/src/v0.8/ccip/test/offRamp/EVM2EVMOffRampSetup.t.sol
@@ -1,22 +1,22 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.19;
 
-import {ICommitStore} from "../../interfaces/ICommitStore.sol";
 import {IAny2EVMMessageReceiver} from "../../interfaces/IAny2EVMMessageReceiver.sol";
+import {ICommitStore} from "../../interfaces/ICommitStore.sol";
 import {IPool} from "../../interfaces/pools/IPool.sol";
 
-import {Internal} from "../../libraries/Internal.sol";
-import {Client} from "../../libraries/Client.sol";
-import {PriceRegistrySetup} from "../priceRegistry/PriceRegistry.t.sol";
-import {MockCommitStore} from "../mocks/MockCommitStore.sol";
 import {Router} from "../../Router.sol";
+import {Client} from "../../libraries/Client.sol";
+import {Internal} from "../../libraries/Internal.sol";
 import {EVM2EVMOffRamp} from "../../offRamp/EVM2EVMOffRamp.sol";
-import {EVM2EVMOffRampHelper} from "../helpers/EVM2EVMOffRampHelper.sol";
-import {TokenSetup} from "../TokenSetup.t.sol";
-import {MaybeRevertMessageReceiver} from "../helpers/receivers/MaybeRevertMessageReceiver.sol";
 import {LockReleaseTokenPool} from "../../pools/LockReleaseTokenPool.sol";
 import {TokenPool} from "../../pools/TokenPool.sol";
+import {TokenSetup} from "../TokenSetup.t.sol";
+import {EVM2EVMOffRampHelper} from "../helpers/EVM2EVMOffRampHelper.sol";
+import {MaybeRevertMessageReceiver} from "../helpers/receivers/MaybeRevertMessageReceiver.sol";
+import {MockCommitStore} from "../mocks/MockCommitStore.sol";
 import {OCR2BaseSetup} from "../ocr/OCR2Base.t.sol";
+import {PriceRegistrySetup} from "../priceRegistry/PriceRegistry.t.sol";
 
 import {IERC20} from "../../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/src/v0.8/ccip/test/onRamp/EVM2EVMOnRamp.t.sol
+++ b/contracts/src/v0.8/ccip/test/onRamp/EVM2EVMOnRamp.t.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.19;
 
-import "./EVM2EVMOnRampSetup.t.sol";
-import {EVM2EVMOnRamp} from "../../onRamp/EVM2EVMOnRamp.sol";
-import {AggregateRateLimiter} from "../../AggregateRateLimiter.sol";
-import {USDPriceWith18Decimals} from "../../libraries/USDPriceWith18Decimals.sol";
-import {RateLimiter} from "../../libraries/RateLimiter.sol";
-import {MockTokenPool} from "../mocks/MockTokenPool.sol";
-import {MaybeRevertingBurnMintTokenPool} from "../helpers/MaybeRevertingBurnMintTokenPool.sol";
 import {BurnMintERC677} from "../../../shared/token/ERC677/BurnMintERC677.sol";
+import {AggregateRateLimiter} from "../../AggregateRateLimiter.sol";
+import {RateLimiter} from "../../libraries/RateLimiter.sol";
+import {USDPriceWith18Decimals} from "../../libraries/USDPriceWith18Decimals.sol";
+import {EVM2EVMOnRamp} from "../../onRamp/EVM2EVMOnRamp.sol";
+import {MaybeRevertingBurnMintTokenPool} from "../helpers/MaybeRevertingBurnMintTokenPool.sol";
+import {MockTokenPool} from "../mocks/MockTokenPool.sol";
+import "./EVM2EVMOnRampSetup.t.sol";
 
 /// @notice #constructor
 contract EVM2EVMOnRamp_constructor is EVM2EVMOnRampSetup {

--- a/contracts/src/v0.8/ccip/test/onRamp/EVM2EVMOnRamp.t.sol
+++ b/contracts/src/v0.8/ccip/test/onRamp/EVM2EVMOnRamp.t.sol
@@ -25,10 +25,8 @@ contract EVM2EVMOnRamp_constructor is EVM2EVMOnRampSetup {
       prevOnRamp: address(0),
       armProxy: address(s_mockARM)
     });
-    EVM2EVMOnRamp.DynamicConfig memory dynamicConfig = generateDynamicOnRampConfig(
-      address(s_sourceRouter),
-      address(s_priceRegistry)
-    );
+    EVM2EVMOnRamp.DynamicConfig memory dynamicConfig =
+      generateDynamicOnRampConfig(address(s_sourceRouter), address(s_priceRegistry));
     Internal.PoolUpdate[] memory tokensAndPools = getTokensAndPools(s_sourceTokens, getCastedSourcePools());
 
     vm.expectEmit();
@@ -279,10 +277,8 @@ contract EVM2EVMOnRamp_forwardFromRouter is EVM2EVMOnRampSetup {
 
   function testForwardFromRouterSuccessLegacyExtraArgs() public {
     Client.EVM2AnyMessage memory message = _generateEmptyMessage();
-    message.extraArgs = abi.encodeWithSelector(
-      Client.EVM_EXTRA_ARGS_V1_TAG,
-      LegacyExtraArgs({gasLimit: GAS_LIMIT * 2, strict: true})
-    );
+    message.extraArgs =
+      abi.encodeWithSelector(Client.EVM_EXTRA_ARGS_V1_TAG, LegacyExtraArgs({gasLimit: GAS_LIMIT * 2, strict: true}));
     uint256 feeAmount = 1234567890;
     IERC20(s_sourceFeeToken).transferFrom(OWNER, address(s_onRamp), feeAmount);
 
@@ -379,8 +375,7 @@ contract EVM2EVMOnRamp_forwardFromRouter is EVM2EVMOnRampSetup {
 
     // Assert the message Id is correct
     assertEq(
-      expectedEvent.messageId,
-      s_onRamp.forwardFromRouter(DEST_CHAIN_SELECTOR, message, feeTokenAmount, originalSender)
+      expectedEvent.messageId, s_onRamp.forwardFromRouter(DEST_CHAIN_SELECTOR, message, feeTokenAmount, originalSender)
     );
     // Assert the fee token amount is correctly assigned to the nop fee pool
     assertEq(feeTokenAmount, s_onRamp.getNopFeesJuels());
@@ -567,10 +562,7 @@ contract EVM2EVMOnRamp_forwardFromRouter is EVM2EVMOnRampSetup {
     vm.startPrank(OWNER);
 
     MaybeRevertingBurnMintTokenPool newPool = new MaybeRevertingBurnMintTokenPool(
-      BurnMintERC677(sourceETH),
-      new address[](0),
-      address(s_mockARM),
-      address(s_sourceRouter)
+      BurnMintERC677(sourceETH), new address[](0), address(s_mockARM), address(s_sourceRouter)
     );
     // Allow Pool to burn/mint Eth
     BurnMintERC677(sourceETH).grantMintAndBurnRoles(address(newPool));
@@ -578,8 +570,8 @@ contract EVM2EVMOnRamp_forwardFromRouter is EVM2EVMOnRampSetup {
     deal(address(sourceETH), address(newPool), type(uint256).max);
 
     // Set destBytesOverhead to 0, and let tokenPool return 1 byte
-    EVM2EVMOnRamp.TokenTransferFeeConfigArgs[]
-      memory tokenTransferFeeConfigArgs = new EVM2EVMOnRamp.TokenTransferFeeConfigArgs[](1);
+    EVM2EVMOnRamp.TokenTransferFeeConfigArgs[] memory tokenTransferFeeConfigArgs =
+      new EVM2EVMOnRamp.TokenTransferFeeConfigArgs[](1);
     tokenTransferFeeConfigArgs[0] = EVM2EVMOnRamp.TokenTransferFeeConfigArgs({
       token: sourceETH,
       minFeeUSDCents: 1,
@@ -724,22 +716,14 @@ contract EVM2EVMOnRamp_getFeeSetup is EVM2EVMOnRampSetup {
     Internal.PoolUpdate[] memory newRamps = new Internal.PoolUpdate[](2);
     address wrappedNativePool = address(
       new LockReleaseTokenPool(
-        IERC20(s_sourceRouter.getWrappedNative()),
-        new address[](0),
-        address(s_mockARM),
-        true,
-        address(s_sourceRouter)
+        IERC20(s_sourceRouter.getWrappedNative()), new address[](0), address(s_mockARM), true, address(s_sourceRouter)
       )
     );
     newRamps[0] = Internal.PoolUpdate({token: s_sourceRouter.getWrappedNative(), pool: wrappedNativePool});
 
     address customPool = address(
       new LockReleaseTokenPool(
-        IERC20(CUSTOM_TOKEN),
-        new address[](0),
-        address(s_mockARM),
-        true,
-        address(s_sourceRouter)
+        IERC20(CUSTOM_TOKEN), new address[](0), address(s_mockARM), true, address(s_sourceRouter)
       )
     );
     newRamps[1] = Internal.PoolUpdate({token: CUSTOM_TOKEN, pool: customPool});
@@ -770,13 +754,10 @@ contract EVM2EVMOnRamp_getDataAvailabilityCost is EVM2EVMOnRamp_getFeeSetup {
 
     EVM2EVMOnRamp.DynamicConfig memory dynamicConfig = s_onRamp.getDynamicConfig();
 
-    uint256 dataAvailabilityGas = dynamicConfig.destDataAvailabilityOverheadGas +
-      dynamicConfig.destGasPerDataAvailabilityByte *
-      Internal.MESSAGE_FIXED_BYTES;
-    uint256 expectedDataAvailabilityCostUSD = USD_PER_DATA_AVAILABILITY_GAS *
-      dataAvailabilityGas *
-      dynamicConfig.destDataAvailabilityMultiplierBps *
-      1e14;
+    uint256 dataAvailabilityGas = dynamicConfig.destDataAvailabilityOverheadGas
+      + dynamicConfig.destGasPerDataAvailabilityByte * Internal.MESSAGE_FIXED_BYTES;
+    uint256 expectedDataAvailabilityCostUSD =
+      USD_PER_DATA_AVAILABILITY_GAS * dataAvailabilityGas * dynamicConfig.destDataAvailabilityMultiplierBps * 1e14;
 
     assertEq(expectedDataAvailabilityCostUSD, dataAvailabilityCostUSD);
   }
@@ -786,17 +767,12 @@ contract EVM2EVMOnRamp_getDataAvailabilityCost is EVM2EVMOnRamp_getFeeSetup {
 
     EVM2EVMOnRamp.DynamicConfig memory dynamicConfig = s_onRamp.getDynamicConfig();
 
-    uint256 dataAvailabilityLengthBytes = Internal.MESSAGE_FIXED_BYTES +
-      100 +
-      (5 * Internal.MESSAGE_FIXED_BYTES_PER_TOKEN) +
-      50;
-    uint256 dataAvailabilityGas = dynamicConfig.destDataAvailabilityOverheadGas +
-      dynamicConfig.destGasPerDataAvailabilityByte *
-      dataAvailabilityLengthBytes;
-    uint256 expectedDataAvailabilityCostUSD = USD_PER_DATA_AVAILABILITY_GAS *
-      dataAvailabilityGas *
-      dynamicConfig.destDataAvailabilityMultiplierBps *
-      1e14;
+    uint256 dataAvailabilityLengthBytes =
+      Internal.MESSAGE_FIXED_BYTES + 100 + (5 * Internal.MESSAGE_FIXED_BYTES_PER_TOKEN) + 50;
+    uint256 dataAvailabilityGas = dynamicConfig.destDataAvailabilityOverheadGas
+      + dynamicConfig.destGasPerDataAvailabilityByte * dataAvailabilityLengthBytes;
+    uint256 expectedDataAvailabilityCostUSD =
+      USD_PER_DATA_AVAILABILITY_GAS * dataAvailabilityGas * dynamicConfig.destDataAvailabilityMultiplierBps * 1e14;
 
     assertEq(expectedDataAvailabilityCostUSD, dataAvailabilityCostUSD);
   }
@@ -806,12 +782,8 @@ contract EVM2EVMOnRamp_getDataAvailabilityCost is EVM2EVMOnRamp_getFeeSetup {
     uint32 numberOfTokens,
     uint32 tokenTransferBytesOverhead
   ) public {
-    uint256 dataAvailabilityCostUSD = s_onRamp.getDataAvailabilityCost(
-      0,
-      messageDataLength,
-      numberOfTokens,
-      tokenTransferBytesOverhead
-    );
+    uint256 dataAvailabilityCostUSD =
+      s_onRamp.getDataAvailabilityCost(0, messageDataLength, numberOfTokens, tokenTransferBytesOverhead);
 
     assertEq(0, dataAvailabilityCostUSD);
   }
@@ -832,24 +804,16 @@ contract EVM2EVMOnRamp_getDataAvailabilityCost is EVM2EVMOnRamp_getFeeSetup {
     s_onRamp.setDynamicConfig(dynamicConfig);
 
     uint256 dataAvailabilityCostUSD = s_onRamp.getDataAvailabilityCost(
-      dataAvailabilityGasPrice,
-      messageDataLength,
-      numberOfTokens,
-      tokenTransferBytesOverhead
+      dataAvailabilityGasPrice, messageDataLength, numberOfTokens, tokenTransferBytesOverhead
     );
 
-    uint256 dataAvailabilityLengthBytes = Internal.MESSAGE_FIXED_BYTES +
-      messageDataLength +
-      (numberOfTokens * Internal.MESSAGE_FIXED_BYTES_PER_TOKEN) +
-      tokenTransferBytesOverhead;
+    uint256 dataAvailabilityLengthBytes = Internal.MESSAGE_FIXED_BYTES + messageDataLength
+      + (numberOfTokens * Internal.MESSAGE_FIXED_BYTES_PER_TOKEN) + tokenTransferBytesOverhead;
 
-    uint256 dataAvailabilityGas = destDataAvailabilityOverheadGas +
-      destGasPerDataAvailabilityByte *
-      dataAvailabilityLengthBytes;
-    uint256 expectedDataAvailabilityCostUSD = dataAvailabilityGasPrice *
-      dataAvailabilityGas *
-      destDataAvailabilityMultiplierBps *
-      1e14;
+    uint256 dataAvailabilityGas =
+      destDataAvailabilityOverheadGas + destGasPerDataAvailabilityByte * dataAvailabilityLengthBytes;
+    uint256 expectedDataAvailabilityCostUSD =
+      dataAvailabilityGasPrice * dataAvailabilityGas * destDataAvailabilityMultiplierBps * 1e14;
 
     assertEq(expectedDataAvailabilityCostUSD, dataAvailabilityCostUSD);
   }
@@ -861,11 +825,8 @@ contract EVM2EVMOnRamp_getTokenTransferCost is EVM2EVMOnRamp_getFeeSetup {
 
   function testNoTokenTransferChargesZeroFeeSuccess() public {
     Client.EVM2AnyMessage memory message = _generateEmptyMessage();
-    (uint256 feeUSDWei, uint32 destGasOverhead, uint32 destBytesOverhead) = s_onRamp.getTokenTransferCost(
-      message.feeToken,
-      s_feeTokenPrice,
-      message.tokenAmounts
-    );
+    (uint256 feeUSDWei, uint32 destGasOverhead, uint32 destBytesOverhead) =
+      s_onRamp.getTokenTransferCost(message.feeToken, s_feeTokenPrice, message.tokenAmounts);
 
     assertEq(0, feeUSDWei);
     assertEq(0, destGasOverhead);
@@ -874,15 +835,11 @@ contract EVM2EVMOnRamp_getTokenTransferCost is EVM2EVMOnRamp_getFeeSetup {
 
   function testSmallTokenTransferChargesMinFeeAndGasSuccess() public {
     Client.EVM2AnyMessage memory message = _generateSingleTokenMessage(s_sourceFeeToken, 1000);
-    EVM2EVMOnRamp.TokenTransferFeeConfig memory transferFeeConfig = s_onRamp.getTokenTransferFeeConfig(
-      message.tokenAmounts[0].token
-    );
+    EVM2EVMOnRamp.TokenTransferFeeConfig memory transferFeeConfig =
+      s_onRamp.getTokenTransferFeeConfig(message.tokenAmounts[0].token);
 
-    (uint256 feeUSDWei, uint32 destGasOverhead, uint32 destBytesOverhead) = s_onRamp.getTokenTransferCost(
-      message.feeToken,
-      s_feeTokenPrice,
-      message.tokenAmounts
-    );
+    (uint256 feeUSDWei, uint32 destGasOverhead, uint32 destBytesOverhead) =
+      s_onRamp.getTokenTransferCost(message.feeToken, s_feeTokenPrice, message.tokenAmounts);
 
     assertEq(configUSDCentToWei(transferFeeConfig.minFeeUSDCents), feeUSDWei);
     assertEq(transferFeeConfig.destGasOverhead, destGasOverhead);
@@ -891,15 +848,11 @@ contract EVM2EVMOnRamp_getTokenTransferCost is EVM2EVMOnRamp_getFeeSetup {
 
   function testZeroAmountTokenTransferChargesMinFeeAndAgasSuccess() public {
     Client.EVM2AnyMessage memory message = _generateSingleTokenMessage(s_sourceFeeToken, 0);
-    EVM2EVMOnRamp.TokenTransferFeeConfig memory transferFeeConfig = s_onRamp.getTokenTransferFeeConfig(
-      message.tokenAmounts[0].token
-    );
+    EVM2EVMOnRamp.TokenTransferFeeConfig memory transferFeeConfig =
+      s_onRamp.getTokenTransferFeeConfig(message.tokenAmounts[0].token);
 
-    (uint256 feeUSDWei, uint32 destGasOverhead, uint32 destBytesOverhead) = s_onRamp.getTokenTransferCost(
-      message.feeToken,
-      s_feeTokenPrice,
-      message.tokenAmounts
-    );
+    (uint256 feeUSDWei, uint32 destGasOverhead, uint32 destBytesOverhead) =
+      s_onRamp.getTokenTransferCost(message.feeToken, s_feeTokenPrice, message.tokenAmounts);
 
     assertEq(configUSDCentToWei(transferFeeConfig.minFeeUSDCents), feeUSDWei);
     assertEq(transferFeeConfig.destGasOverhead, destGasOverhead);
@@ -908,15 +861,11 @@ contract EVM2EVMOnRamp_getTokenTransferCost is EVM2EVMOnRamp_getFeeSetup {
 
   function testLargeTokenTransferChargesMaxFeeAndGasSuccess() public {
     Client.EVM2AnyMessage memory message = _generateSingleTokenMessage(s_sourceFeeToken, 1e36);
-    EVM2EVMOnRamp.TokenTransferFeeConfig memory transferFeeConfig = s_onRamp.getTokenTransferFeeConfig(
-      message.tokenAmounts[0].token
-    );
+    EVM2EVMOnRamp.TokenTransferFeeConfig memory transferFeeConfig =
+      s_onRamp.getTokenTransferFeeConfig(message.tokenAmounts[0].token);
 
-    (uint256 feeUSDWei, uint32 destGasOverhead, uint32 destBytesOverhead) = s_onRamp.getTokenTransferCost(
-      message.feeToken,
-      s_feeTokenPrice,
-      message.tokenAmounts
-    );
+    (uint256 feeUSDWei, uint32 destGasOverhead, uint32 destBytesOverhead) =
+      s_onRamp.getTokenTransferCost(message.feeToken, s_feeTokenPrice, message.tokenAmounts);
 
     assertEq(configUSDCentToWei(transferFeeConfig.maxFeeUSDCents), feeUSDWei);
     assertEq(transferFeeConfig.destGasOverhead, destGasOverhead);
@@ -927,15 +876,11 @@ contract EVM2EVMOnRamp_getTokenTransferCost is EVM2EVMOnRamp_getFeeSetup {
     uint256 tokenAmount = 10000e18;
 
     Client.EVM2AnyMessage memory message = _generateSingleTokenMessage(s_sourceFeeToken, tokenAmount);
-    EVM2EVMOnRamp.TokenTransferFeeConfig memory transferFeeConfig = s_onRamp.getTokenTransferFeeConfig(
-      message.tokenAmounts[0].token
-    );
+    EVM2EVMOnRamp.TokenTransferFeeConfig memory transferFeeConfig =
+      s_onRamp.getTokenTransferFeeConfig(message.tokenAmounts[0].token);
 
-    (uint256 feeUSDWei, uint32 destGasOverhead, uint32 destBytesOverhead) = s_onRamp.getTokenTransferCost(
-      message.feeToken,
-      s_feeTokenPrice,
-      message.tokenAmounts
-    );
+    (uint256 feeUSDWei, uint32 destGasOverhead, uint32 destBytesOverhead) =
+      s_onRamp.getTokenTransferCost(message.feeToken, s_feeTokenPrice, message.tokenAmounts);
 
     uint256 usdWei = calcUSDValueFromTokenAmount(s_feeTokenPrice, tokenAmount);
     uint256 bpsUSDWei = applyBpsRatio(usdWei, s_tokenTransferFeeConfigArgs[0].deciBps);
@@ -957,15 +902,11 @@ contract EVM2EVMOnRamp_getTokenTransferCost is EVM2EVMOnRamp_getFeeSetup {
     });
     message.tokenAmounts[0] = Client.EVMTokenAmount({token: s_sourceRouter.getWrappedNative(), amount: tokenAmount});
 
-    EVM2EVMOnRamp.TokenTransferFeeConfig memory transferFeeConfig = s_onRamp.getTokenTransferFeeConfig(
-      message.tokenAmounts[0].token
-    );
+    EVM2EVMOnRamp.TokenTransferFeeConfig memory transferFeeConfig =
+      s_onRamp.getTokenTransferFeeConfig(message.tokenAmounts[0].token);
 
-    (uint256 feeUSDWei, uint32 destGasOverhead, uint32 destBytesOverhead) = s_onRamp.getTokenTransferCost(
-      message.feeToken,
-      s_wrappedTokenPrice,
-      message.tokenAmounts
-    );
+    (uint256 feeUSDWei, uint32 destGasOverhead, uint32 destBytesOverhead) =
+      s_onRamp.getTokenTransferCost(message.feeToken, s_wrappedTokenPrice, message.tokenAmounts);
 
     uint256 usdWei = calcUSDValueFromTokenAmount(s_wrappedTokenPrice, tokenAmount);
     uint256 bpsUSDWei = applyBpsRatio(usdWei, s_tokenTransferFeeConfigArgs[1].deciBps);
@@ -987,15 +928,11 @@ contract EVM2EVMOnRamp_getTokenTransferCost is EVM2EVMOnRamp_getFeeSetup {
     });
     message.tokenAmounts[0] = Client.EVMTokenAmount({token: CUSTOM_TOKEN, amount: tokenAmount});
 
-    EVM2EVMOnRamp.TokenTransferFeeConfig memory transferFeeConfig = s_onRamp.getTokenTransferFeeConfig(
-      message.tokenAmounts[0].token
-    );
+    EVM2EVMOnRamp.TokenTransferFeeConfig memory transferFeeConfig =
+      s_onRamp.getTokenTransferFeeConfig(message.tokenAmounts[0].token);
 
-    (uint256 feeUSDWei, uint32 destGasOverhead, uint32 destBytesOverhead) = s_onRamp.getTokenTransferCost(
-      message.feeToken,
-      s_feeTokenPrice,
-      message.tokenAmounts
-    );
+    (uint256 feeUSDWei, uint32 destGasOverhead, uint32 destBytesOverhead) =
+      s_onRamp.getTokenTransferCost(message.feeToken, s_feeTokenPrice, message.tokenAmounts);
 
     uint256 usdWei = calcUSDValueFromTokenAmount(s_customTokenPrice, tokenAmount);
     uint256 bpsUSDWei = applyBpsRatio(usdWei, s_tokenTransferFeeConfigArgs[2].deciBps);
@@ -1006,8 +943,8 @@ contract EVM2EVMOnRamp_getTokenTransferCost is EVM2EVMOnRamp_getFeeSetup {
   }
 
   function testZeroFeeConfigChargesMinFeeSuccess() public {
-    EVM2EVMOnRamp.TokenTransferFeeConfigArgs[]
-      memory tokenTransferFeeConfigArgs = new EVM2EVMOnRamp.TokenTransferFeeConfigArgs[](1);
+    EVM2EVMOnRamp.TokenTransferFeeConfigArgs[] memory tokenTransferFeeConfigArgs =
+      new EVM2EVMOnRamp.TokenTransferFeeConfigArgs[](1);
     tokenTransferFeeConfigArgs[0] = EVM2EVMOnRamp.TokenTransferFeeConfigArgs({
       token: s_sourceFeeToken,
       minFeeUSDCents: 1,
@@ -1019,11 +956,8 @@ contract EVM2EVMOnRamp_getTokenTransferCost is EVM2EVMOnRamp_getFeeSetup {
     s_onRamp.setTokenTransferFeeConfig(tokenTransferFeeConfigArgs);
 
     Client.EVM2AnyMessage memory message = _generateSingleTokenMessage(s_sourceFeeToken, 1e36);
-    (uint256 feeUSDWei, uint32 destGasOverhead, uint32 destBytesOverhead) = s_onRamp.getTokenTransferCost(
-      message.feeToken,
-      s_feeTokenPrice,
-      message.tokenAmounts
-    );
+    (uint256 feeUSDWei, uint32 destGasOverhead, uint32 destBytesOverhead) =
+      s_onRamp.getTokenTransferCost(message.feeToken, s_feeTokenPrice, message.tokenAmounts);
 
     // if token charges 0 bps, it should cost minFee to transfer
     assertEq(configUSDCentToWei(tokenTransferFeeConfigArgs[0].minFeeUSDCents), feeUSDWei);
@@ -1050,13 +984,10 @@ contract EVM2EVMOnRamp_getTokenTransferCost is EVM2EVMOnRamp_getFeeSetup {
 
     address feeToken = s_sourceRouter.getWrappedNative();
 
-    (uint256 feeSingleUSDWei, uint32 gasOverheadSingle, uint32 bytesOverheadSingle) = s_onRamp.getTokenTransferCost(
-      feeToken,
-      s_wrappedTokenPrice,
-      single
-    );
-    (uint256 feeMultipleUSDWei, uint32 gasOverheadMultiple, uint32 bytesOverheadMultiple) = s_onRamp
-      .getTokenTransferCost(feeToken, s_wrappedTokenPrice, multiple);
+    (uint256 feeSingleUSDWei, uint32 gasOverheadSingle, uint32 bytesOverheadSingle) =
+      s_onRamp.getTokenTransferCost(feeToken, s_wrappedTokenPrice, single);
+    (uint256 feeMultipleUSDWei, uint32 gasOverheadMultiple, uint32 bytesOverheadMultiple) =
+      s_onRamp.getTokenTransferCost(feeToken, s_wrappedTokenPrice, multiple);
 
     // Note that there can be a rounding error once per split.
     assertTrue(feeMultipleUSDWei >= (feeSingleUSDWei - dynamicConfig.maxNumberOfTokensPerMsg));
@@ -1089,11 +1020,8 @@ contract EVM2EVMOnRamp_getTokenTransferCost is EVM2EVMOnRamp_getFeeSetup {
       expectedTotalGas += s_onRamp.getTokenTransferFeeConfig(testTokens[i]).destGasOverhead;
       expectedTotalBytes += s_onRamp.getTokenTransferFeeConfig(testTokens[i]).destBytesOverhead;
     }
-    (uint256 feeUSDWei, uint32 destGasOverhead, uint32 destBytesOverhead) = s_onRamp.getTokenTransferCost(
-      message.feeToken,
-      s_wrappedTokenPrice,
-      message.tokenAmounts
-    );
+    (uint256 feeUSDWei, uint32 destGasOverhead, uint32 destBytesOverhead) =
+      s_onRamp.getTokenTransferCost(message.feeToken, s_wrappedTokenPrice, message.tokenAmounts);
 
     uint256 expectedFeeUSDWei = 0;
     for (uint256 i = 0; i < testTokens.length; ++i) {
@@ -1107,14 +1035,10 @@ contract EVM2EVMOnRamp_getTokenTransferCost is EVM2EVMOnRamp_getFeeSetup {
     // Set 1st token transfer to a meaningful amount so its bps fee is now between min and max fee
     message.tokenAmounts[0] = Client.EVMTokenAmount({token: testTokens[0], amount: 10000e18});
 
-    (feeUSDWei, destGasOverhead, destBytesOverhead) = s_onRamp.getTokenTransferCost(
-      message.feeToken,
-      s_wrappedTokenPrice,
-      message.tokenAmounts
-    );
+    (feeUSDWei, destGasOverhead, destBytesOverhead) =
+      s_onRamp.getTokenTransferCost(message.feeToken, s_wrappedTokenPrice, message.tokenAmounts);
     expectedFeeUSDWei = applyBpsRatio(
-      calcUSDValueFromTokenAmount(tokenPrices[0], message.tokenAmounts[0].amount),
-      tokenTransferFeeConfigs[0].deciBps
+      calcUSDValueFromTokenAmount(tokenPrices[0], message.tokenAmounts[0].amount), tokenTransferFeeConfigs[0].deciBps
     );
     expectedFeeUSDWei += configUSDCentToWei(tokenTransferFeeConfigs[1].minFeeUSDCents);
     expectedFeeUSDWei += configUSDCentToWei(tokenTransferFeeConfigs[2].minFeeUSDCents);
@@ -1126,14 +1050,10 @@ contract EVM2EVMOnRamp_getTokenTransferCost is EVM2EVMOnRamp_getFeeSetup {
     // Set 2nd token transfer to a large amount that is higher than maxFeeUSD
     message.tokenAmounts[1] = Client.EVMTokenAmount({token: testTokens[1], amount: 1e36});
 
-    (feeUSDWei, destGasOverhead, destBytesOverhead) = s_onRamp.getTokenTransferCost(
-      message.feeToken,
-      s_wrappedTokenPrice,
-      message.tokenAmounts
-    );
+    (feeUSDWei, destGasOverhead, destBytesOverhead) =
+      s_onRamp.getTokenTransferCost(message.feeToken, s_wrappedTokenPrice, message.tokenAmounts);
     expectedFeeUSDWei = applyBpsRatio(
-      calcUSDValueFromTokenAmount(tokenPrices[0], message.tokenAmounts[0].amount),
-      tokenTransferFeeConfigs[0].deciBps
+      calcUSDValueFromTokenAmount(tokenPrices[0], message.tokenAmounts[0].amount), tokenTransferFeeConfigs[0].deciBps
     );
     expectedFeeUSDWei += configUSDCentToWei(tokenTransferFeeConfigs[1].maxFeeUSDCents);
     expectedFeeUSDWei += configUSDCentToWei(tokenTransferFeeConfigs[2].minFeeUSDCents);
@@ -1190,13 +1110,10 @@ contract EVM2EVMOnRamp_getFee is EVM2EVMOnRamp_getFeeSetup {
 
       uint256 gasUsed = GAS_LIMIT + DEST_GAS_OVERHEAD;
       uint256 gasFeeUSD = (gasUsed * feeTokenConfig.gasMultiplierWeiPerEth * USD_PER_GAS);
-      uint256 messageFeeUSD = (configUSDCentToWei(feeTokenConfig.networkFeeUSDCents) *
-        feeTokenConfig.premiumMultiplierWeiPerEth);
+      uint256 messageFeeUSD =
+        (configUSDCentToWei(feeTokenConfig.networkFeeUSDCents) * feeTokenConfig.premiumMultiplierWeiPerEth);
       uint256 dataAvailabilityFeeUSD = s_onRamp.getDataAvailabilityCost(
-        USD_PER_DATA_AVAILABILITY_GAS,
-        message.data.length,
-        message.tokenAmounts.length,
-        0
+        USD_PER_DATA_AVAILABILITY_GAS, message.data.length, message.tokenAmounts.length, 0
       );
 
       uint256 totalPriceInFeeToken = (gasFeeUSD + messageFeeUSD + dataAvailabilityFeeUSD) / feeTokenPrices[i];
@@ -1216,8 +1133,8 @@ contract EVM2EVMOnRamp_getFee is EVM2EVMOnRamp_getFeeSetup {
 
     uint256 gasUsed = GAS_LIMIT + DEST_GAS_OVERHEAD;
     uint256 gasFeeUSD = (gasUsed * feeTokenConfig.gasMultiplierWeiPerEth * USD_PER_GAS);
-    uint256 messageFeeUSD = (configUSDCentToWei(feeTokenConfig.networkFeeUSDCents) *
-      feeTokenConfig.premiumMultiplierWeiPerEth);
+    uint256 messageFeeUSD =
+      (configUSDCentToWei(feeTokenConfig.networkFeeUSDCents) * feeTokenConfig.premiumMultiplierWeiPerEth);
 
     uint256 totalPriceInFeeToken = (gasFeeUSD + messageFeeUSD) / s_feeTokenPrice;
     assertEq(totalPriceInFeeToken, feeAmount);
@@ -1243,13 +1160,10 @@ contract EVM2EVMOnRamp_getFee is EVM2EVMOnRamp_getFeeSetup {
 
       uint256 gasUsed = customGasLimit + DEST_GAS_OVERHEAD + customDataSize * DEST_GAS_PER_PAYLOAD_BYTE;
       uint256 gasFeeUSD = (gasUsed * feeTokenConfig.gasMultiplierWeiPerEth * USD_PER_GAS);
-      uint256 messageFeeUSD = (configUSDCentToWei(feeTokenConfig.networkFeeUSDCents) *
-        feeTokenConfig.premiumMultiplierWeiPerEth);
+      uint256 messageFeeUSD =
+        (configUSDCentToWei(feeTokenConfig.networkFeeUSDCents) * feeTokenConfig.premiumMultiplierWeiPerEth);
       uint256 dataAvailabilityFeeUSD = s_onRamp.getDataAvailabilityCost(
-        USD_PER_DATA_AVAILABILITY_GAS,
-        message.data.length,
-        message.tokenAmounts.length,
-        0
+        USD_PER_DATA_AVAILABILITY_GAS, message.data.length, message.tokenAmounts.length, 0
       );
 
       uint256 totalPriceInFeeToken = (gasFeeUSD + messageFeeUSD + dataAvailabilityFeeUSD) / feeTokenPrices[i];
@@ -1273,17 +1187,11 @@ contract EVM2EVMOnRamp_getFee is EVM2EVMOnRamp_getFeeSetup {
 
       uint256 gasUsed = GAS_LIMIT + DEST_GAS_OVERHEAD + tokenGasOverhead;
       uint256 gasFeeUSD = (gasUsed * feeTokenConfig.gasMultiplierWeiPerEth * USD_PER_GAS);
-      (uint256 transferFeeUSD, , ) = s_onRamp.getTokenTransferCost(
-        message.feeToken,
-        feeTokenPrices[i],
-        message.tokenAmounts
-      );
+      (uint256 transferFeeUSD,,) =
+        s_onRamp.getTokenTransferCost(message.feeToken, feeTokenPrices[i], message.tokenAmounts);
       uint256 messageFeeUSD = (transferFeeUSD * feeTokenConfig.premiumMultiplierWeiPerEth);
       uint256 dataAvailabilityFeeUSD = s_onRamp.getDataAvailabilityCost(
-        USD_PER_DATA_AVAILABILITY_GAS,
-        message.data.length,
-        message.tokenAmounts.length,
-        tokenBytesOverhead
+        USD_PER_DATA_AVAILABILITY_GAS, message.data.length, message.tokenAmounts.length, tokenBytesOverhead
       );
 
       uint256 totalPriceInFeeToken = (gasFeeUSD + messageFeeUSD + dataAvailabilityFeeUSD) / feeTokenPrices[i];
@@ -1321,23 +1229,14 @@ contract EVM2EVMOnRamp_getFee is EVM2EVMOnRamp_getFeeSetup {
 
       uint256 feeAmount = s_onRamp.getFee(DEST_CHAIN_SELECTOR, message);
 
-      uint256 gasUsed = customGasLimit +
-        DEST_GAS_OVERHEAD +
-        message.data.length *
-        DEST_GAS_PER_PAYLOAD_BYTE +
-        tokenGasOverhead;
+      uint256 gasUsed =
+        customGasLimit + DEST_GAS_OVERHEAD + message.data.length * DEST_GAS_PER_PAYLOAD_BYTE + tokenGasOverhead;
       uint256 gasFeeUSD = (gasUsed * feeTokenConfig.gasMultiplierWeiPerEth * USD_PER_GAS);
-      (uint256 transferFeeUSD, , ) = s_onRamp.getTokenTransferCost(
-        message.feeToken,
-        feeTokenPrices[i],
-        message.tokenAmounts
-      );
+      (uint256 transferFeeUSD,,) =
+        s_onRamp.getTokenTransferCost(message.feeToken, feeTokenPrices[i], message.tokenAmounts);
       uint256 messageFeeUSD = (transferFeeUSD * feeTokenConfig.premiumMultiplierWeiPerEth);
       uint256 dataAvailabilityFeeUSD = s_onRamp.getDataAvailabilityCost(
-        USD_PER_DATA_AVAILABILITY_GAS,
-        message.data.length,
-        message.tokenAmounts.length,
-        tokenBytesOverhead
+        USD_PER_DATA_AVAILABILITY_GAS, message.data.length, message.tokenAmounts.length, tokenBytesOverhead
       );
 
       uint256 totalPriceInFeeToken = (gasFeeUSD + messageFeeUSD + dataAvailabilityFeeUSD) / feeTokenPrices[i];
@@ -1398,7 +1297,7 @@ contract EVM2EVMOnRamp_setNops is EVM2EVMOnRampSetup {
 
     s_onRamp.setNops(nopsAndWeights);
 
-    (EVM2EVMOnRamp.NopAndWeight[] memory actual, ) = s_onRamp.getNops();
+    (EVM2EVMOnRamp.NopAndWeight[] memory actual,) = s_onRamp.getNops();
     for (uint256 i = 0; i < actual.length; ++i) {
       assertEq(actual[i].weight, s_nopsToWeights[actual[i].nop]);
     }
@@ -1440,7 +1339,7 @@ contract EVM2EVMOnRamp_setNops is EVM2EVMOnRampSetup {
 
     s_onRamp.setNops(nopsAndWeights);
 
-    (EVM2EVMOnRamp.NopAndWeight[] memory actual, ) = s_onRamp.getNops();
+    (EVM2EVMOnRamp.NopAndWeight[] memory actual,) = s_onRamp.getNops();
     for (uint256 i = 0; i < actual.length; ++i) {
       assertEq(actual[i].weight, s_nopsToWeights[actual[i].nop]);
     }
@@ -1640,8 +1539,8 @@ contract EVM2EVMOnRamp_setTokenTransferFeeConfig is EVM2EVMOnRampSetup {
   event TokenTransferFeeConfigSet(EVM2EVMOnRamp.TokenTransferFeeConfigArgs[] transferFeeConfig);
 
   function testSetTokenTransferFeeSuccess() public {
-    EVM2EVMOnRamp.TokenTransferFeeConfigArgs[]
-      memory tokenTransferFeeConfigArgs = new EVM2EVMOnRamp.TokenTransferFeeConfigArgs[](2);
+    EVM2EVMOnRamp.TokenTransferFeeConfigArgs[] memory tokenTransferFeeConfigArgs =
+      new EVM2EVMOnRamp.TokenTransferFeeConfigArgs[](2);
     tokenTransferFeeConfigArgs[0] = EVM2EVMOnRamp.TokenTransferFeeConfigArgs({
       token: address(0),
       minFeeUSDCents: 0,
@@ -1664,18 +1563,14 @@ contract EVM2EVMOnRamp_setTokenTransferFeeConfig is EVM2EVMOnRampSetup {
 
     s_onRamp.setTokenTransferFeeConfig(tokenTransferFeeConfigArgs);
 
-    EVM2EVMOnRamp.TokenTransferFeeConfig memory tokenTransferFeeConfig0 = s_onRamp.getTokenTransferFeeConfig(
-      address(0)
-    );
+    EVM2EVMOnRamp.TokenTransferFeeConfig memory tokenTransferFeeConfig0 = s_onRamp.getTokenTransferFeeConfig(address(0));
     assertEq(0, tokenTransferFeeConfig0.minFeeUSDCents);
     assertEq(0, tokenTransferFeeConfig0.maxFeeUSDCents);
     assertEq(0, tokenTransferFeeConfig0.deciBps);
     assertEq(0, tokenTransferFeeConfig0.destGasOverhead);
     assertEq(0, tokenTransferFeeConfig0.destBytesOverhead);
 
-    EVM2EVMOnRamp.TokenTransferFeeConfig memory tokenTransferFeeConfig1 = s_onRamp.getTokenTransferFeeConfig(
-      address(1)
-    );
+    EVM2EVMOnRamp.TokenTransferFeeConfig memory tokenTransferFeeConfig1 = s_onRamp.getTokenTransferFeeConfig(address(1));
     assertEq(1, tokenTransferFeeConfig1.minFeeUSDCents);
     assertEq(1, tokenTransferFeeConfig1.maxFeeUSDCents);
     assertEq(1, tokenTransferFeeConfig1.deciBps);

--- a/contracts/src/v0.8/ccip/test/onRamp/EVM2EVMOnRampSetup.t.sol
+++ b/contracts/src/v0.8/ccip/test/onRamp/EVM2EVMOnRampSetup.t.sol
@@ -144,14 +144,13 @@ contract EVM2EVMOnRampSetup is TokenSetup, PriceRegistrySetup {
     Client.EVMTokenAmount[] memory tokenAmounts = getCastedSourceEVMTokenAmountsWithZeroAmounts();
     tokenAmounts[0].amount = i_tokenAmount0;
     tokenAmounts[1].amount = i_tokenAmount1;
-    return
-      Client.EVM2AnyMessage({
-        receiver: abi.encode(OWNER),
-        data: "",
-        tokenAmounts: tokenAmounts,
-        feeToken: s_sourceFeeToken,
-        extraArgs: Client._argsToBytes(Client.EVMExtraArgsV1({gasLimit: GAS_LIMIT}))
-      });
+    return Client.EVM2AnyMessage({
+      receiver: abi.encode(OWNER),
+      data: "",
+      tokenAmounts: tokenAmounts,
+      feeToken: s_sourceFeeToken,
+      extraArgs: Client._argsToBytes(Client.EVMExtraArgsV1({gasLimit: GAS_LIMIT}))
+    });
   }
 
   function _generateSingleTokenMessage(
@@ -161,25 +160,23 @@ contract EVM2EVMOnRampSetup is TokenSetup, PriceRegistrySetup {
     Client.EVMTokenAmount[] memory tokenAmounts = new Client.EVMTokenAmount[](1);
     tokenAmounts[0] = Client.EVMTokenAmount({token: token, amount: amount});
 
-    return
-      Client.EVM2AnyMessage({
-        receiver: abi.encode(OWNER),
-        data: "",
-        tokenAmounts: tokenAmounts,
-        feeToken: s_sourceFeeToken,
-        extraArgs: Client._argsToBytes(Client.EVMExtraArgsV1({gasLimit: GAS_LIMIT}))
-      });
+    return Client.EVM2AnyMessage({
+      receiver: abi.encode(OWNER),
+      data: "",
+      tokenAmounts: tokenAmounts,
+      feeToken: s_sourceFeeToken,
+      extraArgs: Client._argsToBytes(Client.EVMExtraArgsV1({gasLimit: GAS_LIMIT}))
+    });
   }
 
   function _generateEmptyMessage() public view returns (Client.EVM2AnyMessage memory) {
-    return
-      Client.EVM2AnyMessage({
-        receiver: abi.encode(OWNER),
-        data: "",
-        tokenAmounts: new Client.EVMTokenAmount[](0),
-        feeToken: s_sourceFeeToken,
-        extraArgs: Client._argsToBytes(Client.EVMExtraArgsV1({gasLimit: GAS_LIMIT}))
-      });
+    return Client.EVM2AnyMessage({
+      receiver: abi.encode(OWNER),
+      data: "",
+      tokenAmounts: new Client.EVMTokenAmount[](0),
+      feeToken: s_sourceFeeToken,
+      extraArgs: Client._argsToBytes(Client.EVMExtraArgsV1({gasLimit: GAS_LIMIT}))
+    });
   }
 
   function _messageToEvent(

--- a/contracts/src/v0.8/ccip/test/onRamp/EVM2EVMOnRampSetup.t.sol
+++ b/contracts/src/v0.8/ccip/test/onRamp/EVM2EVMOnRampSetup.t.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.19;
 
-import {EVM2EVMOnRamp} from "../../onRamp/EVM2EVMOnRamp.sol";
-import {Router} from "../../Router.sol";
-import {TokenPool} from "../../pools/TokenPool.sol";
-import {LockReleaseTokenPool} from "../../pools/LockReleaseTokenPool.sol";
 import {PriceRegistry} from "../../PriceRegistry.sol";
-import {PriceRegistrySetup} from "../priceRegistry/PriceRegistry.t.sol";
-import {Internal} from "../../libraries/Internal.sol";
+import {Router} from "../../Router.sol";
 import {Client} from "../../libraries/Client.sol";
-import {EVM2EVMOnRampHelper} from "../helpers/EVM2EVMOnRampHelper.sol";
+import {Internal} from "../../libraries/Internal.sol";
+import {EVM2EVMOnRamp} from "../../onRamp/EVM2EVMOnRamp.sol";
+import {LockReleaseTokenPool} from "../../pools/LockReleaseTokenPool.sol";
+import {TokenPool} from "../../pools/TokenPool.sol";
 import {TokenSetup} from "../TokenSetup.t.sol";
+import {EVM2EVMOnRampHelper} from "../helpers/EVM2EVMOnRampHelper.sol";
+import {PriceRegistrySetup} from "../priceRegistry/PriceRegistry.t.sol";
 
 import {IERC20} from "../../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/src/v0.8/ccip/test/pools/BurnFromMintTokenPool.t.sol
+++ b/contracts/src/v0.8/ccip/test/pools/BurnFromMintTokenPool.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.19;
 
-import {BaseTest} from "../BaseTest.t.sol";
 import {EVM2EVMOnRamp} from "../../onRamp/EVM2EVMOnRamp.sol";
-import {TokenPool} from "../../pools/TokenPool.sol";
-import {BurnMintSetup} from "./BurnMintSetup.t.sol";
 import {BurnFromMintTokenPool} from "../../pools/BurnFromMintTokenPool.sol";
+import {TokenPool} from "../../pools/TokenPool.sol";
+import {BaseTest} from "../BaseTest.t.sol";
+import {BurnMintSetup} from "./BurnMintSetup.t.sol";
 
 contract BurnFromMintTokenPoolSetup is BurnMintSetup {
   BurnFromMintTokenPool internal s_pool;

--- a/contracts/src/v0.8/ccip/test/pools/BurnMintSetup.t.sol
+++ b/contracts/src/v0.8/ccip/test/pools/BurnMintSetup.t.sol
@@ -2,9 +2,9 @@
 pragma solidity 0.8.19;
 
 import {BurnMintERC677} from "../../../shared/token/ERC677/BurnMintERC677.sol";
+import {Router} from "../../Router.sol";
 import {BurnMintTokenPool} from "../../pools/BurnMintTokenPool.sol";
 import {TokenPool} from "../../pools/TokenPool.sol";
-import {Router} from "../../Router.sol";
 import {RouterSetup} from "../router/RouterSetup.t.sol";
 
 contract BurnMintSetup is RouterSetup {

--- a/contracts/src/v0.8/ccip/test/pools/BurnMintTokenPool.t.sol
+++ b/contracts/src/v0.8/ccip/test/pools/BurnMintTokenPool.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.19;
 
-import {BaseTest} from "../BaseTest.t.sol";
-import {TokenPool} from "../../pools/TokenPool.sol";
-import {EVM2EVMOnRamp} from "../../onRamp/EVM2EVMOnRamp.sol";
 import {EVM2EVMOffRamp} from "../../offRamp/EVM2EVMOffRamp.sol";
+import {EVM2EVMOnRamp} from "../../onRamp/EVM2EVMOnRamp.sol";
 import {BurnMintTokenPool} from "../../pools/BurnMintTokenPool.sol";
+import {TokenPool} from "../../pools/TokenPool.sol";
+import {BaseTest} from "../BaseTest.t.sol";
 import {BurnMintSetup} from "./BurnMintSetup.t.sol";
 
 contract BurnMintTokenPoolSetup is BurnMintSetup {

--- a/contracts/src/v0.8/ccip/test/pools/BurnWithFromMintTokenPool.t.sol
+++ b/contracts/src/v0.8/ccip/test/pools/BurnWithFromMintTokenPool.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.19;
 
-import {BaseTest} from "../BaseTest.t.sol";
-import {TokenPool} from "../../pools/TokenPool.sol";
 import {EVM2EVMOnRamp} from "../../onRamp/EVM2EVMOnRamp.sol";
-import {BurnMintSetup} from "./BurnMintSetup.t.sol";
 import {BurnWithFromMintTokenPool} from "../../pools/BurnWithFromMintTokenPool.sol";
+import {TokenPool} from "../../pools/TokenPool.sol";
+import {BaseTest} from "../BaseTest.t.sol";
+import {BurnMintSetup} from "./BurnMintSetup.t.sol";
 
 contract BurnWithFromMintTokenPoolSetup is BurnMintSetup {
   BurnWithFromMintTokenPool internal s_pool;

--- a/contracts/src/v0.8/ccip/test/pools/BurnWithFromMintTokenPool.t.sol
+++ b/contracts/src/v0.8/ccip/test/pools/BurnWithFromMintTokenPool.t.sol
@@ -13,12 +13,8 @@ contract BurnWithFromMintTokenPoolSetup is BurnMintSetup {
   function setUp() public virtual override {
     BurnMintSetup.setUp();
 
-    s_pool = new BurnWithFromMintTokenPool(
-      s_burnMintERC677,
-      new address[](0),
-      address(s_mockARM),
-      address(s_sourceRouter)
-    );
+    s_pool =
+      new BurnWithFromMintTokenPool(s_burnMintERC677, new address[](0), address(s_mockARM), address(s_sourceRouter));
     s_burnMintERC677.grantMintAndBurnRoles(address(s_pool));
 
     _applyChainUpdates(address(s_pool));

--- a/contracts/src/v0.8/ccip/test/pools/LockReleaseTokenPool.t.sol
+++ b/contracts/src/v0.8/ccip/test/pools/LockReleaseTokenPool.t.sol
@@ -29,23 +29,13 @@ contract LockReleaseTokenPoolSetup is RouterSetup {
     RouterSetup.setUp();
     s_token = new BurnMintERC677("LINK", "LNK", 18, 0);
     deal(address(s_token), OWNER, type(uint256).max);
-    s_lockReleaseTokenPool = new LockReleaseTokenPool(
-      s_token,
-      new address[](0),
-      address(s_mockARM),
-      true,
-      address(s_sourceRouter)
-    );
+    s_lockReleaseTokenPool =
+      new LockReleaseTokenPool(s_token, new address[](0), address(s_mockARM), true, address(s_sourceRouter));
 
     s_allowedList.push(USER_1);
     s_allowedList.push(DUMMY_CONTRACT_ADDRESS);
-    s_lockReleaseTokenPoolWithAllowList = new LockReleaseTokenPool(
-      s_token,
-      s_allowedList,
-      address(s_mockARM),
-      true,
-      address(s_sourceRouter)
-    );
+    s_lockReleaseTokenPoolWithAllowList =
+      new LockReleaseTokenPool(s_token, s_allowedList, address(s_mockARM), true, address(s_sourceRouter));
 
     TokenPool.ChainUpdate[] memory chainUpdate = new TokenPool.ChainUpdate[](1);
     chainUpdate[0] = TokenPool.ChainUpdate({
@@ -233,13 +223,8 @@ contract LockReleaseTokenPool_canAcceptLiquidity is LockReleaseTokenPoolSetup {
   function test_CanAcceptLiquiditySuccess() public {
     assertEq(true, s_lockReleaseTokenPool.canAcceptLiquidity());
 
-    s_lockReleaseTokenPool = new LockReleaseTokenPool(
-      s_token,
-      new address[](0),
-      address(s_mockARM),
-      false,
-      address(s_sourceRouter)
-    );
+    s_lockReleaseTokenPool =
+      new LockReleaseTokenPool(s_token, new address[](0), address(s_mockARM), false, address(s_sourceRouter));
     assertEq(false, s_lockReleaseTokenPool.canAcceptLiquidity());
   }
 }
@@ -271,13 +256,8 @@ contract LockReleaseTokenPool_provideLiquidity is LockReleaseTokenPoolSetup {
   }
 
   function testLiquidityNotAcceptedReverts() public {
-    s_lockReleaseTokenPool = new LockReleaseTokenPool(
-      s_token,
-      new address[](0),
-      address(s_mockARM),
-      false,
-      address(s_sourceRouter)
-    );
+    s_lockReleaseTokenPool =
+      new LockReleaseTokenPool(s_token, new address[](0), address(s_mockARM), false, address(s_sourceRouter));
 
     vm.expectRevert(LockReleaseTokenPool.LiquidityNotAccepted.selector);
     s_lockReleaseTokenPool.provideLiquidity(1);
@@ -329,9 +309,7 @@ contract LockReleaseTokenPool_supportsInterface is LockReleaseTokenPoolSetup {
 contract LockReleaseTokenPool_setChainRateLimiterConfig is LockReleaseTokenPoolSetup {
   event ConfigChanged(RateLimiter.Config);
   event ChainConfigured(
-    uint64 chainSelector,
-    RateLimiter.Config outboundRateLimiterConfig,
-    RateLimiter.Config inboundRateLimiterConfig
+    uint64 chainSelector, RateLimiter.Config outboundRateLimiterConfig, RateLimiter.Config inboundRateLimiterConfig
   );
 
   uint64 internal s_remoteChainSelector;
@@ -362,11 +340,8 @@ contract LockReleaseTokenPool_setChainRateLimiterConfig is LockReleaseTokenPoolS
     uint256 oldInboundTokens = s_lockReleaseTokenPool.getCurrentInboundRateLimiterState(s_remoteChainSelector).tokens;
 
     RateLimiter.Config memory newOutboundConfig = RateLimiter.Config({isEnabled: true, capacity: capacity, rate: rate});
-    RateLimiter.Config memory newInboundConfig = RateLimiter.Config({
-      isEnabled: true,
-      capacity: capacity / 2,
-      rate: rate / 2
-    });
+    RateLimiter.Config memory newInboundConfig =
+      RateLimiter.Config({isEnabled: true, capacity: capacity / 2, rate: rate / 2});
 
     vm.expectEmit();
     emit ConfigChanged(newOutboundConfig);
@@ -379,9 +354,8 @@ contract LockReleaseTokenPool_setChainRateLimiterConfig is LockReleaseTokenPoolS
 
     uint256 expectedTokens = RateLimiter._min(newOutboundConfig.capacity, oldOutboundTokens);
 
-    RateLimiter.TokenBucket memory bucket = s_lockReleaseTokenPool.getCurrentOutboundRateLimiterState(
-      s_remoteChainSelector
-    );
+    RateLimiter.TokenBucket memory bucket =
+      s_lockReleaseTokenPool.getCurrentOutboundRateLimiterState(s_remoteChainSelector);
     assertEq(bucket.capacity, newOutboundConfig.capacity);
     assertEq(bucket.rate, newOutboundConfig.rate);
     assertEq(bucket.tokens, expectedTokens);
@@ -404,17 +378,13 @@ contract LockReleaseTokenPool_setChainRateLimiterConfig is LockReleaseTokenPoolS
     vm.startPrank(rateLimiterAdmin);
 
     s_lockReleaseTokenPool.setChainRateLimiterConfig(
-      s_remoteChainSelector,
-      getOutboundRateLimiterConfig(),
-      getInboundRateLimiterConfig()
+      s_remoteChainSelector, getOutboundRateLimiterConfig(), getInboundRateLimiterConfig()
     );
 
     vm.startPrank(OWNER);
 
     s_lockReleaseTokenPool.setChainRateLimiterConfig(
-      s_remoteChainSelector,
-      getOutboundRateLimiterConfig(),
-      getInboundRateLimiterConfig()
+      s_remoteChainSelector, getOutboundRateLimiterConfig(), getInboundRateLimiterConfig()
     );
   }
 
@@ -425,9 +395,7 @@ contract LockReleaseTokenPool_setChainRateLimiterConfig is LockReleaseTokenPoolS
 
     vm.expectRevert(abi.encodeWithSelector(LockReleaseTokenPool.Unauthorized.selector, STRANGER));
     s_lockReleaseTokenPool.setChainRateLimiterConfig(
-      s_remoteChainSelector,
-      getOutboundRateLimiterConfig(),
-      getInboundRateLimiterConfig()
+      s_remoteChainSelector, getOutboundRateLimiterConfig(), getInboundRateLimiterConfig()
     );
   }
 
@@ -436,9 +404,7 @@ contract LockReleaseTokenPool_setChainRateLimiterConfig is LockReleaseTokenPoolS
 
     vm.expectRevert(abi.encodeWithSelector(TokenPool.NonExistentChain.selector, wrongChainSelector));
     s_lockReleaseTokenPool.setChainRateLimiterConfig(
-      wrongChainSelector,
-      getOutboundRateLimiterConfig(),
-      getInboundRateLimiterConfig()
+      wrongChainSelector, getOutboundRateLimiterConfig(), getInboundRateLimiterConfig()
     );
   }
 }

--- a/contracts/src/v0.8/ccip/test/pools/LockReleaseTokenPool.t.sol
+++ b/contracts/src/v0.8/ccip/test/pools/LockReleaseTokenPool.t.sol
@@ -3,17 +3,17 @@ pragma solidity 0.8.19;
 
 import {IPool} from "../../interfaces/pools/IPool.sol";
 
-import {BaseTest} from "../BaseTest.t.sol";
-import {LockReleaseTokenPool} from "../../pools/LockReleaseTokenPool.sol";
-import {TokenPool} from "../../pools/TokenPool.sol";
-import {EVM2EVMOnRamp} from "../../onRamp/EVM2EVMOnRamp.sol";
-import {EVM2EVMOffRamp} from "../../offRamp/EVM2EVMOffRamp.sol";
-import {RateLimiter} from "../../libraries/RateLimiter.sol";
 import {BurnMintERC677} from "../../../shared/token/ERC677/BurnMintERC677.sol";
 import {Router} from "../../Router.sol";
+import {RateLimiter} from "../../libraries/RateLimiter.sol";
+import {EVM2EVMOffRamp} from "../../offRamp/EVM2EVMOffRamp.sol";
+import {EVM2EVMOnRamp} from "../../onRamp/EVM2EVMOnRamp.sol";
+import {LockReleaseTokenPool} from "../../pools/LockReleaseTokenPool.sol";
+import {TokenPool} from "../../pools/TokenPool.sol";
+import {BaseTest} from "../BaseTest.t.sol";
 
-import {IERC165} from "../../../vendor/openzeppelin-solidity/v4.8.3/contracts/utils/introspection/IERC165.sol";
 import {IERC20} from "../../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/IERC20.sol";
+import {IERC165} from "../../../vendor/openzeppelin-solidity/v4.8.3/contracts/utils/introspection/IERC165.sol";
 import {RouterSetup} from "../router/RouterSetup.t.sol";
 
 contract LockReleaseTokenPoolSetup is RouterSetup {

--- a/contracts/src/v0.8/ccip/test/pools/TokenPool.t.sol
+++ b/contracts/src/v0.8/ccip/test/pools/TokenPool.t.sol
@@ -36,20 +36,13 @@ contract TokenPool_constructor is TokenPoolSetup {
   function testZeroAddressNotAllowedReverts() public {
     vm.expectRevert(TokenPool.ZeroAddressNotAllowed.selector);
 
-    s_tokenPool = new TokenPoolHelper(
-      IERC20(address(0)),
-      new address[](0),
-      address(s_mockARM),
-      address(s_sourceRouter)
-    );
+    s_tokenPool = new TokenPoolHelper(IERC20(address(0)), new address[](0), address(s_mockARM), address(s_sourceRouter));
   }
 }
 
 contract TokenPool_applyChainUpdates is TokenPoolSetup {
   event ChainAdded(
-    uint64 chainSelector,
-    RateLimiter.Config outboundRateLimiterConfig,
-    RateLimiter.Config inboundRateLimiterConfig
+    uint64 chainSelector, RateLimiter.Config outboundRateLimiterConfig, RateLimiter.Config inboundRateLimiterConfig
   );
   event ChainRemoved(uint64 chainSelector);
 
@@ -61,9 +54,8 @@ contract TokenPool_applyChainUpdates is TokenPoolSetup {
 
     for (uint256 i = 0; i < chainUpdates.length; ++i) {
       assertTrue(s_tokenPool.isSupportedChain(chainUpdates[i].remoteChainSelector));
-      RateLimiter.TokenBucket memory bkt = s_tokenPool.getCurrentOutboundRateLimiterState(
-        chainUpdates[i].remoteChainSelector
-      );
+      RateLimiter.TokenBucket memory bkt =
+        s_tokenPool.getCurrentOutboundRateLimiterState(chainUpdates[i].remoteChainSelector);
       assertEq(bkt.capacity, chainUpdates[i].outboundRateLimiterConfig.capacity);
       assertEq(bkt.rate, chainUpdates[i].outboundRateLimiterConfig.rate);
       assertEq(bkt.isEnabled, chainUpdates[i].outboundRateLimiterConfig.isEnabled);
@@ -261,9 +253,7 @@ contract TokenPool_applyChainUpdates is TokenPoolSetup {
 contract TokenPool_setChainRateLimiterConfig is TokenPoolSetup {
   event ConfigChanged(RateLimiter.Config);
   event ChainConfigured(
-    uint64 chainSelector,
-    RateLimiter.Config outboundRateLimiterConfig,
-    RateLimiter.Config inboundRateLimiterConfig
+    uint64 chainSelector, RateLimiter.Config outboundRateLimiterConfig, RateLimiter.Config inboundRateLimiterConfig
   );
 
   uint64 internal s_remoteChainSelector;
@@ -294,11 +284,8 @@ contract TokenPool_setChainRateLimiterConfig is TokenPoolSetup {
     uint256 oldInboundTokens = s_tokenPool.getCurrentInboundRateLimiterState(s_remoteChainSelector).tokens;
 
     RateLimiter.Config memory newOutboundConfig = RateLimiter.Config({isEnabled: true, capacity: capacity, rate: rate});
-    RateLimiter.Config memory newInboundConfig = RateLimiter.Config({
-      isEnabled: true,
-      capacity: capacity / 2,
-      rate: rate / 2
-    });
+    RateLimiter.Config memory newInboundConfig =
+      RateLimiter.Config({isEnabled: true, capacity: capacity / 2, rate: rate / 2});
 
     vm.expectEmit();
     emit ConfigChanged(newOutboundConfig);
@@ -333,9 +320,7 @@ contract TokenPool_setChainRateLimiterConfig is TokenPoolSetup {
 
     vm.expectRevert("Only callable by owner");
     s_tokenPool.setChainRateLimiterConfig(
-      s_remoteChainSelector,
-      getOutboundRateLimiterConfig(),
-      getInboundRateLimiterConfig()
+      s_remoteChainSelector, getOutboundRateLimiterConfig(), getInboundRateLimiterConfig()
     );
   }
 
@@ -344,9 +329,7 @@ contract TokenPool_setChainRateLimiterConfig is TokenPoolSetup {
 
     vm.expectRevert(abi.encodeWithSelector(TokenPool.NonExistentChain.selector, wrongChainSelector));
     s_tokenPool.setChainRateLimiterConfig(
-      wrongChainSelector,
-      getOutboundRateLimiterConfig(),
-      getInboundRateLimiterConfig()
+      wrongChainSelector, getOutboundRateLimiterConfig(), getInboundRateLimiterConfig()
     );
   }
 }

--- a/contracts/src/v0.8/ccip/test/pools/TokenPool.t.sol
+++ b/contracts/src/v0.8/ccip/test/pools/TokenPool.t.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.19;
 
+import {BurnMintERC677} from "../../../shared/token/ERC677/BurnMintERC677.sol";
+import {Router} from "../../Router.sol";
+import {RateLimiter} from "../../libraries/RateLimiter.sol";
+import {TokenPool} from "../../pools/TokenPool.sol";
 import {BaseTest} from "../BaseTest.t.sol";
 import {TokenPoolHelper} from "../helpers/TokenPoolHelper.sol";
-import {TokenPool} from "../../pools/TokenPool.sol";
-import {RateLimiter} from "../../libraries/RateLimiter.sol";
-import {BurnMintERC677} from "../../../shared/token/ERC677/BurnMintERC677.sol";
 import {RouterSetup} from "../router/RouterSetup.t.sol";
-import {Router} from "../../Router.sol";
 
 import {IERC20} from "../../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/src/v0.8/ccip/test/pools/USDCTokenPool.t.sol
+++ b/contracts/src/v0.8/ccip/test/pools/USDCTokenPool.t.sol
@@ -4,15 +4,15 @@ pragma solidity 0.8.19;
 import {IBurnMintERC20} from "../../../shared/token/ERC20/IBurnMintERC20.sol";
 import {IPool} from "../../interfaces/pools/IPool.sol";
 
-import {BaseTest} from "../BaseTest.t.sol";
-import {MockUSDCTransmitter} from "../mocks/MockUSDCTransmitter.sol";
-import {TokenPool} from "../../pools/TokenPool.sol";
+import {BurnMintERC677} from "../../../shared/token/ERC677/BurnMintERC677.sol";
 import {Router} from "../../Router.sol";
 import {RateLimiter} from "../../libraries/RateLimiter.sol";
+import {TokenPool} from "../../pools/TokenPool.sol";
 import {USDCTokenPool} from "../../pools/USDC/USDCTokenPool.sol";
-import {BurnMintERC677} from "../../../shared/token/ERC677/BurnMintERC677.sol";
-import {MockUSDCTokenMessenger} from "../mocks/MockUSDCTokenMessenger.sol";
+import {BaseTest} from "../BaseTest.t.sol";
 import {USDCTokenPoolHelper} from "../helpers/USDCTokenPoolHelper.sol";
+import {MockUSDCTokenMessenger} from "../mocks/MockUSDCTokenMessenger.sol";
+import {MockUSDCTransmitter} from "../mocks/MockUSDCTransmitter.sol";
 
 import {IERC165} from "../../../vendor/openzeppelin-solidity/v4.8.3/contracts/utils/introspection/IERC165.sol";
 

--- a/contracts/src/v0.8/ccip/test/pools/USDCTokenPool.t.sol
+++ b/contracts/src/v0.8/ccip/test/pools/USDCTokenPool.t.sol
@@ -56,23 +56,13 @@ contract USDCTokenPoolSetup is BaseTest {
     s_mockUSDCTransmitter = new MockUSDCTransmitter(0, DEST_DOMAIN_IDENTIFIER);
     s_mockUSDC = new MockUSDCTokenMessenger(0, address(s_mockUSDCTransmitter));
 
-    s_usdcTokenPool = new USDCTokenPoolHelper(
-      s_mockUSDC,
-      s_token,
-      new address[](0),
-      address(s_mockARM),
-      address(s_router)
-    );
+    s_usdcTokenPool =
+      new USDCTokenPoolHelper(s_mockUSDC, s_token, new address[](0), address(s_mockARM), address(s_router));
     linkToken.grantMintAndBurnRoles(address(s_mockUSDC));
 
     s_allowedList.push(USER_1);
-    s_usdcTokenPoolWithAllowList = new USDCTokenPoolHelper(
-      s_mockUSDC,
-      s_token,
-      s_allowedList,
-      address(s_mockARM),
-      address(s_router)
-    );
+    s_usdcTokenPoolWithAllowList =
+      new USDCTokenPoolHelper(s_mockUSDC, s_token, s_allowedList, address(s_mockARM), address(s_router));
 
     TokenPool.ChainUpdate[] memory chainUpdates = new TokenPool.ChainUpdate[](2);
     chainUpdates[0] = TokenPool.ChainUpdate({
@@ -117,17 +107,16 @@ contract USDCTokenPoolSetup is BaseTest {
   }
 
   function _generateUSDCMessage(USDCMessage memory usdcMessage) internal pure returns (bytes memory) {
-    return
-      abi.encodePacked(
-        usdcMessage.version,
-        usdcMessage.sourceDomain,
-        usdcMessage.destinationDomain,
-        usdcMessage.nonce,
-        usdcMessage.sender,
-        usdcMessage.recipient,
-        usdcMessage.destinationCaller,
-        usdcMessage.messageBody
-      );
+    return abi.encodePacked(
+      usdcMessage.version,
+      usdcMessage.sourceDomain,
+      usdcMessage.destinationDomain,
+      usdcMessage.nonce,
+      usdcMessage.sender,
+      usdcMessage.recipient,
+      usdcMessage.destinationCaller,
+      usdcMessage.messageBody
+    );
   }
 }
 
@@ -174,13 +163,8 @@ contract USDCTokenPool_lockOrBurn is USDCTokenPoolSetup {
     vm.expectEmit();
     emit Burned(s_routerAllowedOnRamp, amount);
 
-    bytes memory encodedNonce = s_usdcTokenPool.lockOrBurn(
-      OWNER,
-      abi.encodePacked(receiver),
-      amount,
-      DEST_CHAIN_SELECTOR,
-      bytes("")
-    );
+    bytes memory encodedNonce =
+      s_usdcTokenPool.lockOrBurn(OWNER, abi.encodePacked(receiver), amount, DEST_CHAIN_SELECTOR, bytes(""));
     uint64 nonce = abi.decode(encodedNonce, (uint64));
     assertEq(s_mockUSDC.s_nonce() - 1, nonce);
   }
@@ -211,13 +195,8 @@ contract USDCTokenPool_lockOrBurn is USDCTokenPoolSetup {
     vm.expectEmit();
     emit Burned(s_routerAllowedOnRamp, amount);
 
-    bytes memory encodedNonce = s_usdcTokenPool.lockOrBurn(
-      OWNER,
-      abi.encodePacked(destinationReceiver),
-      amount,
-      DEST_CHAIN_SELECTOR,
-      bytes("")
-    );
+    bytes memory encodedNonce =
+      s_usdcTokenPool.lockOrBurn(OWNER, abi.encodePacked(destinationReceiver), amount, DEST_CHAIN_SELECTOR, bytes(""));
     uint64 nonce = abi.decode(encodedNonce, (uint64));
     assertEq(s_mockUSDC.s_nonce() - 1, nonce);
   }
@@ -247,11 +226,7 @@ contract USDCTokenPool_lockOrBurn is USDCTokenPoolSetup {
     emit Burned(s_routerAllowedOnRamp, amount);
 
     bytes memory encodedNonce = s_usdcTokenPoolWithAllowList.lockOrBurn(
-      s_allowedList[0],
-      abi.encodePacked(destinationReceiver),
-      amount,
-      DEST_CHAIN_SELECTOR,
-      bytes("")
+      s_allowedList[0], abi.encodePacked(destinationReceiver), amount, DEST_CHAIN_SELECTOR, bytes("")
     );
     uint64 nonce = abi.decode(encodedNonce, (uint64));
     assertEq(s_mockUSDC.s_nonce() - 1, nonce);
@@ -297,11 +272,7 @@ contract USDCTokenPool_lockOrBurn is USDCTokenPoolSetup {
     vm.expectRevert(abi.encodeWithSelector(SenderNotAllowed.selector, STRANGER));
 
     s_usdcTokenPoolWithAllowList.lockOrBurn(
-      STRANGER,
-      abi.encodePacked(address(0)),
-      1000,
-      DEST_CHAIN_SELECTOR,
-      bytes("")
+      STRANGER, abi.encodePacked(address(0)), 1000, DEST_CHAIN_SELECTOR, bytes("")
     );
   }
 }
@@ -347,8 +318,8 @@ contract USDCTokenPool_releaseOrMint is USDCTokenPoolSetup {
 
   // https://etherscan.io/tx/0xac9f501fe0b76df1f07a22e1db30929fd12524bc7068d74012dff948632f0883
   function testReleaseOrMintRealTxSuccess() public {
-    bytes
-      memory encodedUsdcMessage = hex"000000000000000300000000000000000000127a00000000000000000000000019330d10d9cc8751218eaf51e8885d058642e08a000000000000000000000000bd3fa81b58ba92a82136038b25adec7066af3155000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000af88d065e77c8cc2239327c5edb3a432268e58310000000000000000000000004af08f56978be7dce2d1be3c65c005b41e79401c000000000000000000000000000000000000000000000000000000002057ff7a0000000000000000000000003a23f943181408eac424116af7b7790c94cb97a50000000000000000000000000000000000000000000000000000000000000000000000000000008274119237535fd659626b090f87e365ff89ebc7096bb32e8b0e85f155626b73ae7c4bb2485c184b7cc3cf7909045487890b104efb62ae74a73e32901bdcec91df1bb9ee08ccb014fcbcfe77b74d1263fd4e0b0e8de05d6c9a5913554364abfd5ea768b222f50c715908183905d74044bb2b97527c7e70ae7983c443a603557cac3b1c000000000000000000000000000000000000000000000000000000000000";
+    bytes memory encodedUsdcMessage =
+      hex"000000000000000300000000000000000000127a00000000000000000000000019330d10d9cc8751218eaf51e8885d058642e08a000000000000000000000000bd3fa81b58ba92a82136038b25adec7066af3155000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000af88d065e77c8cc2239327c5edb3a432268e58310000000000000000000000004af08f56978be7dce2d1be3c65c005b41e79401c000000000000000000000000000000000000000000000000000000002057ff7a0000000000000000000000003a23f943181408eac424116af7b7790c94cb97a50000000000000000000000000000000000000000000000000000000000000000000000000000008274119237535fd659626b090f87e365ff89ebc7096bb32e8b0e85f155626b73ae7c4bb2485c184b7cc3cf7909045487890b104efb62ae74a73e32901bdcec91df1bb9ee08ccb014fcbcfe77b74d1263fd4e0b0e8de05d6c9a5913554364abfd5ea768b222f50c715908183905d74044bb2b97527c7e70ae7983c443a603557cac3b1c000000000000000000000000000000000000000000000000000000000000";
     bytes memory attestation = bytes("attestation bytes");
 
     uint32 nonce = 4730;
@@ -406,9 +377,8 @@ contract USDCTokenPool_releaseOrMint is USDCTokenPoolSetup {
     address recipient = address(1);
     vm.startPrank(s_routerAllowedOffRamp);
 
-    bytes memory extraData = abi.encode(
-      USDCTokenPool.MessageAndAttestation({message: bytes(""), attestation: bytes("")})
-    );
+    bytes memory extraData =
+      abi.encode(USDCTokenPool.MessageAndAttestation({message: bytes(""), attestation: bytes("")}));
 
     vm.expectRevert(
       abi.encodeWithSelector(RateLimiter.TokenMaxCapacityExceeded.selector, capacity, amount, address(s_token))
@@ -451,11 +421,8 @@ contract USDCTokenPool_setDomains is USDCTokenPoolSetup {
         enabled: true
       });
 
-      s_chainToDomain[destChainSelectors[i]] = USDCTokenPool.Domain({
-        domainIdentifier: domainIdentifiers[i],
-        allowedCaller: allowedCallers[i],
-        enabled: true
-      });
+      s_chainToDomain[destChainSelectors[i]] =
+        USDCTokenPool.Domain({domainIdentifier: domainIdentifiers[i], allowedCaller: allowedCallers[i], enabled: true});
     }
 
     vm.expectEmit();
@@ -530,8 +497,7 @@ contract USDCTokenPool__validateMessage is USDCTokenPoolSetup {
 
     vm.resumeGasMetering();
     s_usdcTokenPool.validateMessage(
-      encodedUsdcMessage,
-      USDCTokenPool.SourceTokenDataPayload({nonce: nonce, sourceDomain: sourceDomain})
+      encodedUsdcMessage, USDCTokenPool.SourceTokenDataPayload({nonce: nonce, sourceDomain: sourceDomain})
     );
   }
 
@@ -549,10 +515,8 @@ contract USDCTokenPool__validateMessage is USDCTokenPoolSetup {
       messageBody: bytes("")
     });
 
-    USDCTokenPool.SourceTokenDataPayload memory sourceTokenData = USDCTokenPool.SourceTokenDataPayload({
-      nonce: usdcMessage.nonce,
-      sourceDomain: usdcMessage.sourceDomain
-    });
+    USDCTokenPool.SourceTokenDataPayload memory sourceTokenData =
+      USDCTokenPool.SourceTokenDataPayload({nonce: usdcMessage.nonce, sourceDomain: usdcMessage.sourceDomain});
 
     bytes memory encodedUsdcMessage = _generateUSDCMessage(usdcMessage);
 
@@ -579,9 +543,7 @@ contract USDCTokenPool__validateMessage is USDCTokenPoolSetup {
     usdcMessage.destinationDomain = DEST_DOMAIN_IDENTIFIER + 1;
     vm.expectRevert(
       abi.encodeWithSelector(
-        USDCTokenPool.InvalidDestinationDomain.selector,
-        DEST_DOMAIN_IDENTIFIER,
-        usdcMessage.destinationDomain
+        USDCTokenPool.InvalidDestinationDomain.selector, DEST_DOMAIN_IDENTIFIER, usdcMessage.destinationDomain
       )
     );
 

--- a/contracts/src/v0.8/ccip/test/priceRegistry/PriceRegistry.t.sol
+++ b/contracts/src/v0.8/ccip/test/priceRegistry/PriceRegistry.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.19;
 
+import {PriceRegistry} from "../../PriceRegistry.sol";
 import {Internal} from "../../libraries/Internal.sol";
 import {TokenSetup} from "../TokenSetup.t.sol";
-import {PriceRegistry} from "../../PriceRegistry.sol";
 
 contract PriceRegistrySetup is TokenSetup {
   uint112 internal constant USD_PER_GAS = 1e6; // 0.001 gwei

--- a/contracts/src/v0.8/ccip/test/priceRegistry/PriceRegistry.t.sol
+++ b/contracts/src/v0.8/ccip/test/priceRegistry/PriceRegistry.t.sol
@@ -67,8 +67,8 @@ contract PriceRegistrySetup is TokenSetup {
     }
 
     Internal.PriceUpdates memory priceUpdates = getPriceUpdatesStruct(pricedTokens, tokenPrices);
-    priceUpdates.gasPriceUpdates = getSingleGasPriceUpdateStruct(DEST_CHAIN_SELECTOR, PACKED_USD_PER_GAS)
-      .gasPriceUpdates;
+    priceUpdates.gasPriceUpdates =
+      getSingleGasPriceUpdateStruct(DEST_CHAIN_SELECTOR, PACKED_USD_PER_GAS).gasPriceUpdates;
 
     s_encodedInitialPriceUpdates = abi.encode(priceUpdates);
     address[] memory priceUpdaters = new address[](0);
@@ -239,9 +239,7 @@ contract PriceRegistry_updatePrices is PriceRegistrySetup {
 
     vm.expectEmit();
     emit UsdPerTokenUpdated(
-      update.tokenPriceUpdates[0].sourceToken,
-      update.tokenPriceUpdates[0].usdPerToken,
-      block.timestamp
+      update.tokenPriceUpdates[0].sourceToken, update.tokenPriceUpdates[0].usdPerToken, block.timestamp
     );
 
     s_priceRegistry.updatePrices(update);
@@ -254,23 +252,18 @@ contract PriceRegistry_updatePrices is PriceRegistrySetup {
       tokenPriceUpdates: new Internal.TokenPriceUpdate[](0),
       gasPriceUpdates: new Internal.GasPriceUpdate[](1)
     });
-    update.gasPriceUpdates[0] = Internal.GasPriceUpdate({
-      destChainSelector: DEST_CHAIN_SELECTOR,
-      usdPerUnitGas: 2000e18
-    });
+    update.gasPriceUpdates[0] =
+      Internal.GasPriceUpdate({destChainSelector: DEST_CHAIN_SELECTOR, usdPerUnitGas: 2000e18});
 
     vm.expectEmit();
     emit UsdPerUnitGasUpdated(
-      update.gasPriceUpdates[0].destChainSelector,
-      update.gasPriceUpdates[0].usdPerUnitGas,
-      block.timestamp
+      update.gasPriceUpdates[0].destChainSelector, update.gasPriceUpdates[0].usdPerUnitGas, block.timestamp
     );
 
     s_priceRegistry.updatePrices(update);
 
     assertEq(
-      s_priceRegistry.getDestinationChainGasPrice(DEST_CHAIN_SELECTOR).value,
-      update.gasPriceUpdates[0].usdPerUnitGas
+      s_priceRegistry.getDestinationChainGasPrice(DEST_CHAIN_SELECTOR).value, update.gasPriceUpdates[0].usdPerUnitGas
     );
   }
 
@@ -285,25 +278,19 @@ contract PriceRegistry_updatePrices is PriceRegistrySetup {
     gasPriceUpdates[1] = Internal.GasPriceUpdate({destChainSelector: SOURCE_CHAIN_SELECTOR, usdPerUnitGas: 2000e18});
     gasPriceUpdates[2] = Internal.GasPriceUpdate({destChainSelector: 12345, usdPerUnitGas: 1e18});
 
-    Internal.PriceUpdates memory update = Internal.PriceUpdates({
-      tokenPriceUpdates: tokenPriceUpdates,
-      gasPriceUpdates: gasPriceUpdates
-    });
+    Internal.PriceUpdates memory update =
+      Internal.PriceUpdates({tokenPriceUpdates: tokenPriceUpdates, gasPriceUpdates: gasPriceUpdates});
 
     for (uint256 i = 0; i < tokenPriceUpdates.length; ++i) {
       vm.expectEmit();
       emit UsdPerTokenUpdated(
-        update.tokenPriceUpdates[i].sourceToken,
-        update.tokenPriceUpdates[i].usdPerToken,
-        block.timestamp
+        update.tokenPriceUpdates[i].sourceToken, update.tokenPriceUpdates[i].usdPerToken, block.timestamp
       );
     }
     for (uint256 i = 0; i < gasPriceUpdates.length; ++i) {
       vm.expectEmit();
       emit UsdPerUnitGasUpdated(
-        update.gasPriceUpdates[i].destChainSelector,
-        update.gasPriceUpdates[i].usdPerUnitGas,
-        block.timestamp
+        update.gasPriceUpdates[i].destChainSelector, update.gasPriceUpdates[i].usdPerUnitGas, block.timestamp
       );
     }
 
@@ -311,8 +298,7 @@ contract PriceRegistry_updatePrices is PriceRegistrySetup {
 
     for (uint256 i = 0; i < tokenPriceUpdates.length; ++i) {
       assertEq(
-        s_priceRegistry.getTokenPrice(update.tokenPriceUpdates[i].sourceToken).value,
-        tokenPriceUpdates[i].usdPerToken
+        s_priceRegistry.getTokenPrice(update.tokenPriceUpdates[i].sourceToken).value, tokenPriceUpdates[i].usdPerToken
       );
     }
     for (uint256 i = 0; i < gasPriceUpdates.length; ++i) {
@@ -339,13 +325,10 @@ contract PriceRegistry_updatePrices is PriceRegistrySetup {
 
 contract PriceRegistry_convertTokenAmount is PriceRegistrySetup {
   function testConvertTokenAmountSuccess() public {
-    Internal.PriceUpdates memory initialPriceUpdates = abi.decode(
-      s_encodedInitialPriceUpdates,
-      (Internal.PriceUpdates)
-    );
+    Internal.PriceUpdates memory initialPriceUpdates = abi.decode(s_encodedInitialPriceUpdates, (Internal.PriceUpdates));
     uint256 amount = 3e16;
-    uint256 conversionRate = (uint256(initialPriceUpdates.tokenPriceUpdates[2].usdPerToken) * 1e18) /
-      uint256(initialPriceUpdates.tokenPriceUpdates[0].usdPerToken);
+    uint256 conversionRate = (uint256(initialPriceUpdates.tokenPriceUpdates[2].usdPerToken) * 1e18)
+      / uint256(initialPriceUpdates.tokenPriceUpdates[0].usdPerToken);
     uint256 expected = (amount * conversionRate) / 1e18;
     assertEq(s_priceRegistry.convertTokenAmount(s_weth, amount, s_sourceTokens[0]), expected);
   }
@@ -372,15 +355,10 @@ contract PriceRegistry_convertTokenAmount is PriceRegistrySetup {
     tokenPriceUpdates[1] = Internal.TokenPriceUpdate({sourceToken: linkToken, usdPerToken: usdPerLinkToken});
 
     Internal.GasPriceUpdate[] memory gasPriceUpdates = new Internal.GasPriceUpdate[](1);
-    gasPriceUpdates[0] = Internal.GasPriceUpdate({
-      destChainSelector: DEST_CHAIN_SELECTOR,
-      usdPerUnitGas: usdPerUnitGas
-    });
+    gasPriceUpdates[0] = Internal.GasPriceUpdate({destChainSelector: DEST_CHAIN_SELECTOR, usdPerUnitGas: usdPerUnitGas});
 
-    Internal.PriceUpdates memory priceUpdates = Internal.PriceUpdates({
-      tokenPriceUpdates: tokenPriceUpdates,
-      gasPriceUpdates: gasPriceUpdates
-    });
+    Internal.PriceUpdates memory priceUpdates =
+      Internal.PriceUpdates({tokenPriceUpdates: tokenPriceUpdates, gasPriceUpdates: gasPriceUpdates});
 
     s_priceRegistry.updatePrices(priceUpdates);
 
@@ -395,18 +373,13 @@ contract PriceRegistry_convertTokenAmount is PriceRegistrySetup {
 
     Internal.TokenPriceUpdate[] memory tokenPriceUpdates = new Internal.TokenPriceUpdate[](1);
     tokenPriceUpdates[0] = Internal.TokenPriceUpdate({sourceToken: s_sourceTokens[0], usdPerToken: 4e18});
-    Internal.PriceUpdates memory priceUpdates = Internal.PriceUpdates({
-      tokenPriceUpdates: tokenPriceUpdates,
-      gasPriceUpdates: new Internal.GasPriceUpdate[](0)
-    });
+    Internal.PriceUpdates memory priceUpdates =
+      Internal.PriceUpdates({tokenPriceUpdates: tokenPriceUpdates, gasPriceUpdates: new Internal.GasPriceUpdate[](0)});
     s_priceRegistry.updatePrices(priceUpdates);
 
     vm.expectRevert(
       abi.encodeWithSelector(
-        PriceRegistry.StaleTokenPrice.selector,
-        s_weth,
-        uint128(TWELVE_HOURS),
-        uint128(TWELVE_HOURS + 1)
+        PriceRegistry.StaleTokenPrice.selector, s_weth, uint128(TWELVE_HOURS), uint128(TWELVE_HOURS + 1)
       )
     );
     s_priceRegistry.convertTokenAmount(s_weth, 3e16, s_sourceTokens[0]);
@@ -425,18 +398,13 @@ contract PriceRegistry_convertTokenAmount is PriceRegistrySetup {
 
     Internal.TokenPriceUpdate[] memory tokenPriceUpdates = new Internal.TokenPriceUpdate[](1);
     tokenPriceUpdates[0] = Internal.TokenPriceUpdate({sourceToken: s_weth, usdPerToken: 18e17});
-    Internal.PriceUpdates memory priceUpdates = Internal.PriceUpdates({
-      tokenPriceUpdates: tokenPriceUpdates,
-      gasPriceUpdates: new Internal.GasPriceUpdate[](0)
-    });
+    Internal.PriceUpdates memory priceUpdates =
+      Internal.PriceUpdates({tokenPriceUpdates: tokenPriceUpdates, gasPriceUpdates: new Internal.GasPriceUpdate[](0)});
     s_priceRegistry.updatePrices(priceUpdates);
 
     vm.expectRevert(
       abi.encodeWithSelector(
-        PriceRegistry.StaleTokenPrice.selector,
-        s_sourceTokens[0],
-        uint128(TWELVE_HOURS),
-        uint128(TWELVE_HOURS + 1)
+        PriceRegistry.StaleTokenPrice.selector, s_sourceTokens[0], uint128(TWELVE_HOURS), uint128(TWELVE_HOURS + 1)
       )
     );
     s_priceRegistry.convertTokenAmount(s_weth, 3e16, s_sourceTokens[0]);
@@ -445,10 +413,8 @@ contract PriceRegistry_convertTokenAmount is PriceRegistrySetup {
 
 contract PriceRegistry_getTokenAndGasPrices is PriceRegistrySetup {
   function testGetFeeTokenAndGasPricesSuccess() public {
-    (uint224 feeTokenPrice, uint224 gasPrice) = s_priceRegistry.getTokenAndGasPrices(
-      s_sourceFeeToken,
-      DEST_CHAIN_SELECTOR
-    );
+    (uint224 feeTokenPrice, uint224 gasPrice) =
+      s_priceRegistry.getTokenAndGasPrices(s_sourceFeeToken, DEST_CHAIN_SELECTOR);
 
     Internal.PriceUpdates memory priceUpdates = abi.decode(s_encodedInitialPriceUpdates, (Internal.PriceUpdates));
 
@@ -461,10 +427,8 @@ contract PriceRegistry_getTokenAndGasPrices is PriceRegistrySetup {
     Internal.GasPriceUpdate[] memory gasPriceUpdates = new Internal.GasPriceUpdate[](1);
     gasPriceUpdates[0] = Internal.GasPriceUpdate({destChainSelector: zeroGasDestChainSelector, usdPerUnitGas: 0});
 
-    Internal.PriceUpdates memory priceUpdates = Internal.PriceUpdates({
-      tokenPriceUpdates: new Internal.TokenPriceUpdate[](0),
-      gasPriceUpdates: gasPriceUpdates
-    });
+    Internal.PriceUpdates memory priceUpdates =
+      Internal.PriceUpdates({tokenPriceUpdates: new Internal.TokenPriceUpdate[](0), gasPriceUpdates: gasPriceUpdates});
     s_priceRegistry.updatePrices(priceUpdates);
 
     (, uint224 gasPrice) = s_priceRegistry.getTokenAndGasPrices(s_sourceFeeToken, zeroGasDestChainSelector);
@@ -491,15 +455,11 @@ contract PriceRegistry_getTokenAndGasPrices is PriceRegistrySetup {
     vm.warp(block.timestamp + diff);
 
     Internal.GasPriceUpdate[] memory gasPriceUpdates = new Internal.GasPriceUpdate[](1);
-    gasPriceUpdates[0] = Internal.GasPriceUpdate({
-      destChainSelector: DEST_CHAIN_SELECTOR,
-      usdPerUnitGas: PACKED_USD_PER_GAS
-    });
+    gasPriceUpdates[0] =
+      Internal.GasPriceUpdate({destChainSelector: DEST_CHAIN_SELECTOR, usdPerUnitGas: PACKED_USD_PER_GAS});
 
-    Internal.PriceUpdates memory priceUpdates = Internal.PriceUpdates({
-      tokenPriceUpdates: new Internal.TokenPriceUpdate[](0),
-      gasPriceUpdates: gasPriceUpdates
-    });
+    Internal.PriceUpdates memory priceUpdates =
+      Internal.PriceUpdates({tokenPriceUpdates: new Internal.TokenPriceUpdate[](0), gasPriceUpdates: gasPriceUpdates});
     s_priceRegistry.updatePrices(priceUpdates);
 
     vm.expectRevert(

--- a/contracts/src/v0.8/ccip/test/rateLimiter/AggregateRateLimiter.t.sol
+++ b/contracts/src/v0.8/ccip/test/rateLimiter/AggregateRateLimiter.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.19;
 
-import {RateLimiter} from "../../libraries/RateLimiter.sol";
-import {Internal} from "../../libraries/Internal.sol";
-import {Client} from "../../libraries/Client.sol";
-import {AggregateRateLimiterHelper} from "../helpers/AggregateRateLimiterHelper.sol";
 import {AggregateRateLimiter} from "../../AggregateRateLimiter.sol";
+import {Client} from "../../libraries/Client.sol";
+import {Internal} from "../../libraries/Internal.sol";
+import {RateLimiter} from "../../libraries/RateLimiter.sol";
+import {AggregateRateLimiterHelper} from "../helpers/AggregateRateLimiterHelper.sol";
 import {PriceRegistrySetup} from "../priceRegistry/PriceRegistry.t.sol";
 
 import {BaseTest, stdError} from "../BaseTest.t.sol";

--- a/contracts/src/v0.8/ccip/test/router/Router.t.sol
+++ b/contracts/src/v0.8/ccip/test/router/Router.t.sol
@@ -269,12 +269,8 @@ contract Router_ccipSend is EVM2EVMOnRampSetup {
     s_priceRegistry.applyFeeTokensUpdates(feeTokens, new address[](0));
 
     // Update the price of the newly set feeToken
-    Internal.PriceUpdates memory priceUpdates = getSingleTokenAndGasPriceUpdateStruct(
-      feeTokenWithZeroFeeAndGas,
-      2_000 ether,
-      DEST_CHAIN_SELECTOR,
-      0
-    );
+    Internal.PriceUpdates memory priceUpdates =
+      getSingleTokenAndGasPriceUpdateStruct(feeTokenWithZeroFeeAndGas, 2_000 ether, DEST_CHAIN_SELECTOR, 0);
     s_priceRegistry.updatePrices(priceUpdates);
 
     // Set the feeToken args on the onRamp
@@ -412,10 +408,7 @@ contract Router_applyRampUpdates is RouterSetup {
 
     vm.expectRevert(IRouter.OnlyOffRamp.selector);
     s_sourceRouter.routeMessage(
-      generateReceiverMessage(offRamp.sourceChainSelector),
-      GAS_FOR_CALL_EXACT_CHECK,
-      100_000,
-      address(s_receiver)
+      generateReceiverMessage(offRamp.sourceChainSelector), GAS_FOR_CALL_EXACT_CHECK, 100_000, address(s_receiver)
     );
   }
 
@@ -833,7 +826,7 @@ contract Router_routeMessage is EVM2EVMOffRampSetup {
       expectedRetData = abi.encodeWithSelector(MaybeRevertMessageReceiver.CustomError.selector, error);
     }
 
-    (bool success, bytes memory retData, ) = s_destRouter.routeMessage(
+    (bool success, bytes memory retData,) = s_destRouter.routeMessage(
       generateReceiverMessage(SOURCE_CHAIN_SELECTOR),
       GAS_FOR_CALL_EXACT_CHECK,
       generateManualGasLimit(message.data.length),
@@ -845,20 +838,14 @@ contract Router_routeMessage is EVM2EVMOffRampSetup {
   }
 
   function testAutoExecSuccess() public {
-    (bool success, , ) = s_destRouter.routeMessage(
-      generateReceiverMessage(SOURCE_CHAIN_SELECTOR),
-      GAS_FOR_CALL_EXACT_CHECK,
-      100_000,
-      address(s_receiver)
+    (bool success,,) = s_destRouter.routeMessage(
+      generateReceiverMessage(SOURCE_CHAIN_SELECTOR), GAS_FOR_CALL_EXACT_CHECK, 100_000, address(s_receiver)
     );
 
     assertTrue(success);
 
-    (success, , ) = s_destRouter.routeMessage(
-      generateReceiverMessage(SOURCE_CHAIN_SELECTOR),
-      GAS_FOR_CALL_EXACT_CHECK,
-      1,
-      address(s_receiver)
+    (success,,) = s_destRouter.routeMessage(
+      generateReceiverMessage(SOURCE_CHAIN_SELECTOR), GAS_FOR_CALL_EXACT_CHECK, 1, address(s_receiver)
     );
 
     // Can run out of gas, should return false
@@ -872,10 +859,7 @@ contract Router_routeMessage is EVM2EVMOffRampSetup {
 
     vm.expectRevert(IRouter.OnlyOffRamp.selector);
     s_destRouter.routeMessage(
-      generateReceiverMessage(SOURCE_CHAIN_SELECTOR),
-      GAS_FOR_CALL_EXACT_CHECK,
-      100_000,
-      address(s_receiver)
+      generateReceiverMessage(SOURCE_CHAIN_SELECTOR), GAS_FOR_CALL_EXACT_CHECK, 100_000, address(s_receiver)
     );
   }
 
@@ -883,10 +867,7 @@ contract Router_routeMessage is EVM2EVMOffRampSetup {
     s_mockARM.voteToCurse(bytes32(0));
     vm.expectRevert(Router.BadARMSignal.selector);
     s_destRouter.routeMessage(
-      generateReceiverMessage(SOURCE_CHAIN_SELECTOR),
-      GAS_FOR_CALL_EXACT_CHECK,
-      100_000,
-      address(s_receiver)
+      generateReceiverMessage(SOURCE_CHAIN_SELECTOR), GAS_FOR_CALL_EXACT_CHECK, 100_000, address(s_receiver)
     );
   }
 }

--- a/contracts/src/v0.8/ccip/test/router/Router.t.sol
+++ b/contracts/src/v0.8/ccip/test/router/Router.t.sol
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.19;
 
-import {IRouter} from "../../interfaces/IRouter.sol";
-import {IWrappedNative} from "../../interfaces/IWrappedNative.sol";
-import {IRouterClient} from "../../interfaces/IRouterClient.sol";
 import {IAny2EVMMessageReceiver} from "../../interfaces/IAny2EVMMessageReceiver.sol";
+import {IRouter} from "../../interfaces/IRouter.sol";
+import {IRouterClient} from "../../interfaces/IRouterClient.sol";
+import {IWrappedNative} from "../../interfaces/IWrappedNative.sol";
 
-import {EVM2EVMOnRamp} from "../../onRamp/EVM2EVMOnRamp.sol";
-import {EVM2EVMOnRampSetup} from "../onRamp/EVM2EVMOnRampSetup.t.sol";
-import {EVM2EVMOffRampSetup} from "../offRamp/EVM2EVMOffRampSetup.t.sol";
 import {Router} from "../../Router.sol";
-import {RouterSetup} from "../router/RouterSetup.t.sol";
-import {MaybeRevertMessageReceiver} from "../helpers/receivers/MaybeRevertMessageReceiver.sol";
 import {Client} from "../../libraries/Client.sol";
 import {Internal} from "../../libraries/Internal.sol";
+import {EVM2EVMOnRamp} from "../../onRamp/EVM2EVMOnRamp.sol";
+import {MaybeRevertMessageReceiver} from "../helpers/receivers/MaybeRevertMessageReceiver.sol";
+import {EVM2EVMOffRampSetup} from "../offRamp/EVM2EVMOffRampSetup.t.sol";
+import {EVM2EVMOnRampSetup} from "../onRamp/EVM2EVMOnRampSetup.t.sol";
+import {RouterSetup} from "../router/RouterSetup.t.sol";
 
 import {IERC20} from "../../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/src/v0.8/ccip/test/router/RouterSetup.t.sol
+++ b/contracts/src/v0.8/ccip/test/router/RouterSetup.t.sol
@@ -27,13 +27,12 @@ contract RouterSetup is BaseTest {
 
   function generateReceiverMessage(uint64 chainSelector) internal pure returns (Client.Any2EVMMessage memory) {
     Client.EVMTokenAmount[] memory ta = new Client.EVMTokenAmount[](0);
-    return
-      Client.Any2EVMMessage({
-        messageId: bytes32("a"),
-        sourceChainSelector: chainSelector,
-        sender: bytes("a"),
-        data: bytes("a"),
-        destTokenAmounts: ta
-      });
+    return Client.Any2EVMMessage({
+      messageId: bytes32("a"),
+      sourceChainSelector: chainSelector,
+      sender: bytes("a"),
+      data: bytes("a"),
+      destTokenAmounts: ta
+    });
   }
 }

--- a/contracts/src/v0.8/ccip/test/router/RouterSetup.t.sol
+++ b/contracts/src/v0.8/ccip/test/router/RouterSetup.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.19;
 
-import {BaseTest} from "../BaseTest.t.sol";
 import {Router} from "../../Router.sol";
-import {WETH9} from "../WETH9.sol";
 import {Client} from "../../libraries/Client.sol";
+import {BaseTest} from "../BaseTest.t.sol";
+import {WETH9} from "../WETH9.sol";
 
 contract RouterSetup is BaseTest {
   Router internal s_sourceRouter;


### PR DESCRIPTION
## Motivation
Forge fmt is in line with replacing NPM logic with Foundry logic. It is also significantly faster.

## Solution
Move CCIP to forge fmt, leaving all other teams on prettier for now. 