### PR TITLE
(refactor): Remove commit plugin checks that error on empty token prices

### DIFF
--- a/core/services/ocr2/plugins/ccip/ccipcommit/ocr2_test.go
+++ b/core/services/ocr2/plugins/ccip/ccipcommit/ocr2_test.go
@@ -55,17 +55,20 @@ func TestCommitReportingPlugin_Observation(t *testing.T) {
 	bridgedTokens := []cciptypes.Address{
 		ccipcalc.HexToAddress("2000"),
 		ccipcalc.HexToAddress("3000"),
+		ccipcalc.HexToAddress("4000"),
 	}
 
 	// Token price in 1e18 USD precision
 	bridgedTokenPrices := map[cciptypes.Address]*big.Int{
 		bridgedTokens[0]: big.NewInt(1),
 		bridgedTokens[1]: big.NewInt(2e18),
+		bridgedTokens[2]: big.NewInt(45),
 	}
 
 	bridgedTokenDecimals := map[cciptypes.Address]uint8{
 		bridgedTokens[0]: 8,
 		bridgedTokens[1]: 18,
+		bridgedTokens[2]: 18,
 	}
 
 	// Token price of 1e18 token amount in 1e18 USD precision


### PR DESCRIPTION
## Motivation
Self service token pools will enable many new TransferTokens to be used across CCIP, most of which may not have a readily available price.

## Context
The current procedure (as of [batched price updates](https://github.com/smartcontractkit/ccip/pull/623)) is for a single lane to be designated as the "leader lane". It reports all prices that other lanes use. Other lanes have their price reporting disabled. To support this, the leader lane has all supported tokens configured in the CommitJobSpec.

The source of truth for which tokens are supported comes from on-chain. The supported tokens are queried from the leader lane's destination price registry (FeeTokens) and from each OffRamp's `supportedTokens`. The combined set is given to the `price getter`, and if the number of resulting prices is different from the CommitJobSpec's  tokens then the observation is thrown out.

## Solution

### _For v1.4 (current) contracts:_
Use the `CommitJobSpec`'s configured tokens as the source of truth for which tokens need a price update.

1. Remove errors and throwing out observations if there is not a price given for the token
2. Replace with warnings logs and possibly monitoring

Risks:
- Increased likelihood of misconfiguration. The leader lane will need to be closely watched for warning logs indicating that a price is not being reported on.
- Compatability with [shared job specs](https://github.com/smartcontractkit/ccip/pull/683)

### _For v1.5 (next) contracts:_
Return to on-chain being the source of truth for which tokens need a price update.
The list of TransferTokens that need pricing will be created from querying the OnRamps for tokens that have either BPS set and/or Aggregate Rate Limits. FeeTokens will still be taken from the destination Price Registry.


