### PR TITLE
(refactor): Filter out destination chain bridgeable tokens that are not configured on pricegetter

### DIFF
--- a/.changeset/weak-months-turn.md
+++ b/.changeset/weak-months-turn.md
@@ -1,0 +1,5 @@
+---
+"ccip": minor
+---
+
+Filter out destination chain bridgeable tokens that are not configured on pricegetter

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -149,7 +149,7 @@ telemetry-protobuf: $(telemetry-protobuf) ## Generate telemetry protocol buffers
 config-docs: ## Generate core node configuration documentation
 	go run ./core/config/docs/cmd/generate -o ./docs/
 
-.PHONY: golangci-lint
+.PHONY: golintlangci-
 golangci-lint: ## Run golangci-lint for all issues.
 	[ -d "./golangci-lint" ] || mkdir ./golangci-lint && \
 	docker run --rm -v $(shell pwd):/app -w /app golangci/golangci-lint:v1.56.2 golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 > ./golangci-lint/$(shell date +%Y-%m-%d_%H:%M:%S).txt

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -149,7 +149,7 @@ telemetry-protobuf: $(telemetry-protobuf) ## Generate telemetry protocol buffers
 config-docs: ## Generate core node configuration documentation
 	go run ./core/config/docs/cmd/generate -o ./docs/
 
-.PHONY: golintlangci-
+.PHONY: golangci-lint
 golangci-lint: ## Run golangci-lint for all issues.
 	[ -d "./golangci-lint" ] || mkdir ./golangci-lint && \
 	docker run --rm -v $(shell pwd):/app -w /app golangci/golangci-lint:v1.56.2 golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 > ./golangci-lint/$(shell date +%Y-%m-%d_%H:%M:%S).txt

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/smartcontractkit/chain-selectors v1.0.13
 	github.com/smartcontractkit/chainlink-automation v1.0.2
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405201435-e1e054309e35
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240410191726-b8a7349cd5d3
 	github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/libocr v0.0.0-20240326191951-2bbe9382d052

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/smartcontractkit/chain-selectors v1.0.13
 	github.com/smartcontractkit/chainlink-automation v1.0.2
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240404141006-77085a02ce25
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405201435-e1e054309e35
 	github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/libocr v0.0.0-20240326191951-2bbe9382d052

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1182,8 +1182,8 @@ github.com/smartcontractkit/chain-selectors v1.0.13 h1:vHMbh7Wu+W+/DSD88feiwMMSX
 github.com/smartcontractkit/chain-selectors v1.0.13/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.2 h1:xsfyuswL15q2YBGQT3qn2SBz6fnSKiSW7XZ8IZQLpnI=
 github.com/smartcontractkit/chainlink-automation v1.0.2/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405201435-e1e054309e35 h1:mGQ7j5fK8d/ZRIJMgWZkfOb/84zLcmXjdRlkhuE80a0=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405201435-e1e054309e35/go.mod h1:kstYjAGqBswdZpl7YkSPeXBDVwaY1VaR6tUMPWl8ykA=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240410191726-b8a7349cd5d3 h1:W8XC1b0GDM0OSzvHvUEFTaZUtognWVkEjCSW2nKQ1mc=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240410191726-b8a7349cd5d3/go.mod h1:kstYjAGqBswdZpl7YkSPeXBDVwaY1VaR6tUMPWl8ykA=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240213120401-01a23955f9f8 h1:I326nw5GwHQHsLKHwtu5Sb9EBLylC8CfUd7BFAS0jtg=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240213120401-01a23955f9f8/go.mod h1:a65NtrK4xZb01mf0dDNghPkN2wXgcqFQ55ADthVBgMc=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1182,8 +1182,6 @@ github.com/smartcontractkit/chain-selectors v1.0.13 h1:vHMbh7Wu+W+/DSD88feiwMMSX
 github.com/smartcontractkit/chain-selectors v1.0.13/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.2 h1:xsfyuswL15q2YBGQT3qn2SBz6fnSKiSW7XZ8IZQLpnI=
 github.com/smartcontractkit/chainlink-automation v1.0.2/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240404141006-77085a02ce25 h1:fY2wMtlr/VQxPyVVQdi1jFvQHi0VbDnGGVXzLKOZTOY=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240404141006-77085a02ce25/go.mod h1:kstYjAGqBswdZpl7YkSPeXBDVwaY1VaR6tUMPWl8ykA=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405201435-e1e054309e35 h1:mGQ7j5fK8d/ZRIJMgWZkfOb/84zLcmXjdRlkhuE80a0=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405201435-e1e054309e35/go.mod h1:kstYjAGqBswdZpl7YkSPeXBDVwaY1VaR6tUMPWl8ykA=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240213120401-01a23955f9f8 h1:I326nw5GwHQHsLKHwtu5Sb9EBLylC8CfUd7BFAS0jtg=

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1184,6 +1184,8 @@ github.com/smartcontractkit/chainlink-automation v1.0.2 h1:xsfyuswL15q2YBGQT3qn2
 github.com/smartcontractkit/chainlink-automation v1.0.2/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240404141006-77085a02ce25 h1:fY2wMtlr/VQxPyVVQdi1jFvQHi0VbDnGGVXzLKOZTOY=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240404141006-77085a02ce25/go.mod h1:kstYjAGqBswdZpl7YkSPeXBDVwaY1VaR6tUMPWl8ykA=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405201435-e1e054309e35 h1:mGQ7j5fK8d/ZRIJMgWZkfOb/84zLcmXjdRlkhuE80a0=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405201435-e1e054309e35/go.mod h1:kstYjAGqBswdZpl7YkSPeXBDVwaY1VaR6tUMPWl8ykA=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240213120401-01a23955f9f8 h1:I326nw5GwHQHsLKHwtu5Sb9EBLylC8CfUd7BFAS0jtg=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240213120401-01a23955f9f8/go.mod h1:a65NtrK4xZb01mf0dDNghPkN2wXgcqFQ55ADthVBgMc=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=

--- a/core/services/ocr2/plugins/ccip/ccipcommit/ocr2.go
+++ b/core/services/ocr2/plugins/ccip/ccipcommit/ocr2.go
@@ -184,7 +184,7 @@ func (r *CommitReportingPlugin) observePriceUpdates(
 		return nil, nil, nil
 	}
 
-	sortedChainTokens, err := ccipcommon.GetSortedChainTokens(ctx, r.offRampReaders, r.destPriceRegistryReader)
+	sortedChainTokens, err := ccipcommon.GetSortedChainTokens(ctx, r.offRampReaders, r.destPriceRegistryReader, r.priceGetter)
 	if err != nil {
 		return nil, nil, fmt.Errorf("get destination tokens: %w", err)
 	}
@@ -324,7 +324,7 @@ func (r *CommitReportingPlugin) Report(ctx context.Context, epochAndRound types.
 
 	parsableObservations := ccip.GetParsableObservations[ccip.CommitObservation](lggr, observations)
 
-	sortedChainTokens, err := ccipcommon.GetSortedChainTokens(ctx, r.offRampReaders, r.destPriceRegistryReader)
+	sortedChainTokens, err := ccipcommon.GetSortedChainTokens(ctx, r.offRampReaders, r.destPriceRegistryReader, r.priceGetter)
 	if err != nil {
 		return false, nil, fmt.Errorf("get destination tokens: %w", err)
 	}

--- a/core/services/ocr2/plugins/ccip/ccipcommit/ocr2.go
+++ b/core/services/ocr2/plugins/ccip/ccipcommit/ocr2.go
@@ -184,7 +184,9 @@ func (r *CommitReportingPlugin) observePriceUpdates(
 		return nil, nil, nil
 	}
 
-	sortedChainTokens, err := ccipcommon.GetSortedChainTokens(ctx, r.offRampReaders, r.destPriceRegistryReader, r.priceGetter)
+	sortedChainTokens, filteredChainTokens, err := ccipcommon.GetFilteredSortedChainTokens(ctx, r.offRampReaders, r.destPriceRegistryReader, r.priceGetter)
+	lggr.Debugw("Filtered bridgeable tokens with no configured price getter", filteredChainTokens)
+
 	if err != nil {
 		return nil, nil, fmt.Errorf("get destination tokens: %w", err)
 	}
@@ -324,7 +326,7 @@ func (r *CommitReportingPlugin) Report(ctx context.Context, epochAndRound types.
 
 	parsableObservations := ccip.GetParsableObservations[ccip.CommitObservation](lggr, observations)
 
-	sortedChainTokens, err := ccipcommon.GetSortedChainTokens(ctx, r.offRampReaders, r.destPriceRegistryReader, r.priceGetter)
+	sortedChainTokens, _, err := ccipcommon.GetFilteredSortedChainTokens(ctx, r.offRampReaders, r.destPriceRegistryReader, r.priceGetter)
 	if err != nil {
 		return false, nil, fmt.Errorf("get destination tokens: %w", err)
 	}

--- a/core/services/ocr2/plugins/ccip/ccipcommit/ocr2_test.go
+++ b/core/services/ocr2/plugins/ccip/ccipcommit/ocr2_test.go
@@ -82,6 +82,7 @@ func TestCommitReportingPlugin_Observation(t *testing.T) {
 		sourceChainCursed      bool
 		commitStoreSeqNum      uint64
 		tokenPrices            map[cciptypes.Address]*big.Int
+		priceGetterConfTokens  []cciptypes.Address
 		sendReqs               []cciptypes.EVM2EVMMessageWithTxMeta
 		tokenDecimals          map[cciptypes.Address]uint8
 		fee                    *big.Int
@@ -98,6 +99,10 @@ func TestCommitReportingPlugin_Observation(t *testing.T) {
 				bridgedTokens[0]:      bridgedTokenPrices[bridgedTokens[0]],
 				bridgedTokens[1]:      bridgedTokenPrices[bridgedTokens[1]],
 				sourceNativeTokenAddr: big.NewInt(2e18),
+			},
+			priceGetterConfTokens: []cciptypes.Address{
+				bridgedTokens[0],
+				bridgedTokens[1],
 			},
 			sendReqs: []cciptypes.EVM2EVMMessageWithTxMeta{
 				{EVM2EVMMessage: cciptypes.EVM2EVMMessage{SequenceNumber: 54}},
@@ -122,6 +127,10 @@ func TestCommitReportingPlugin_Observation(t *testing.T) {
 				bridgedTokens[1]:      bridgedTokenPrices[bridgedTokens[1]],
 				sourceNativeTokenAddr: big.NewInt(2e18),
 			},
+			priceGetterConfTokens: []cciptypes.Address{
+				bridgedTokens[0],
+				bridgedTokens[1],
+			},
 			sendReqs: []cciptypes.EVM2EVMMessageWithTxMeta{
 				{EVM2EVMMessage: cciptypes.EVM2EVMMessage{SequenceNumber: 54}},
 				{EVM2EVMMessage: cciptypes.EVM2EVMMessage{SequenceNumber: 55}},
@@ -145,6 +154,11 @@ func TestCommitReportingPlugin_Observation(t *testing.T) {
 				bridgedTokens[0]:      bridgedTokenPrices[bridgedTokens[0]],
 				bridgedTokens[1]:      bridgedTokenPrices[bridgedTokens[1]],
 				sourceNativeTokenAddr: big.NewInt(2e18),
+			},
+			priceGetterConfTokens: []cciptypes.Address{
+				sourceNativeTokenAddr,
+				bridgedTokens[0],
+				bridgedTokens[1],
 			},
 			sendReqs: []cciptypes.EVM2EVMMessageWithTxMeta{
 				{EVM2EVMMessage: cciptypes.EVM2EVMMessage{SequenceNumber: 54}},
@@ -211,6 +225,9 @@ func TestCommitReportingPlugin_Observation(t *testing.T) {
 			if !tc.priceReportingDisabled && len(tc.tokenPrices) > 0 {
 				queryTokens := ccipcommon.FlattenUniqueSlice([]cciptypes.Address{sourceNativeTokenAddr}, destTokens)
 				priceGet.On("TokenPricesUSD", mock.Anything, queryTokens).Return(tc.tokenPrices, nil)
+				for _, confToken := range tc.priceGetterConfTokens {
+					priceGet.On("IsTokenConfigured", mock.Anything, confToken).Return(true, nil)
+				}
 			}
 
 			gasPriceEstimator := prices.NewMockGasPriceEstimatorCommit(t)

--- a/core/services/ocr2/plugins/ccip/internal/ccipcommon/shortcuts.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipcommon/shortcuts.go
@@ -54,31 +54,12 @@ func GetFilteredSortedChainTokens(ctx context.Context, offRamps []ccipdata.OffRa
 		return nil, nil, fmt.Errorf("get tokens with batch limit: %w", err)
 	}
 
-	destTokensWithPrice, destTokensWithoutPrice, err := filterForPricedTokens(ctx, destBridgeableTokens, priceGetter)
+	destTokensWithPrice, destTokensWithoutPrice, err := priceGetter.FilterConfiguredTokens(ctx, destBridgeableTokens)
 	if err != nil {
 		return nil, nil, fmt.Errorf("filter for priced tokens: %w", err)
 	}
 
 	return flattenedAndSortedChainTokens(destFeeTokens, destTokensWithPrice), destTokensWithoutPrice, nil
-}
-
-func filterForPricedTokens(ctx context.Context, chainTokens []cciptypes.Address, priceGetter cciptypes.PriceGetter) (tokensWithPrice []cciptypes.Address, tokensWithoutPrice []cciptypes.Address, err error) {
-	tokensWithPrice = []cciptypes.Address{}
-	tokensWithoutPrice = []cciptypes.Address{}
-
-	for _, token := range chainTokens {
-		isConfigured, err := priceGetter.IsTokenConfigured(ctx, token)
-		if err != nil {
-			return nil, nil, fmt.Errorf("unable to check if token configured: %w", err)
-		}
-		if isConfigured {
-			tokensWithPrice = append(tokensWithPrice, token)
-		} else {
-			tokensWithoutPrice = append(tokensWithoutPrice, token)
-		}
-	}
-
-	return tokensWithPrice, tokensWithoutPrice, nil
 }
 
 func flattenedAndSortedChainTokens(slices ...[]cciptypes.Address) (chainTokens []cciptypes.Address) {

--- a/core/services/ocr2/plugins/ccip/internal/ccipcommon/shortcuts.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipcommon/shortcuts.go
@@ -33,22 +33,51 @@ type BackfillArgs struct {
 	SourceStartBlock, DestStartBlock uint64
 }
 
-func GetSortedChainTokens(ctx context.Context, offRamps []ccipdata.OffRampReader, priceRegistry cciptypes.PriceRegistryReader) (chainTokens []cciptypes.Address, err error) {
-	return getSortedChainTokensWithBatchLimit(ctx, offRamps, priceRegistry, offRampBatchSizeLimit)
-}
-
 // GetChainTokens returns union of all tokens supported on the destination chain, including fee tokens from the provided price registry
 // and the bridgeable tokens from all the offRamps living on the chain.
-func getSortedChainTokensWithBatchLimit(ctx context.Context, offRamps []ccipdata.OffRampReader, priceRegistry cciptypes.PriceRegistryReader, batchSize int) (chainTokens []cciptypes.Address, err error) {
+// Bridgeable tokens are only included if they are configured on the pricegetter
+func GetSortedChainTokens(ctx context.Context, offRamps []ccipdata.OffRampReader, priceRegistry cciptypes.PriceRegistryReader, priceGetter cciptypes.PriceGetter) (chainTokens []cciptypes.Address, err error) {
+	destFeeTokens, destBridgeableTokens, err := getTokensWithBatchLimit(ctx, offRamps, priceRegistry, offRampBatchSizeLimit)
+	if err != nil {
+		return nil, err
+	}
+
+	// Only include destination bridgeable tokens if they are configured on the price getter
+	var dbtWithPriceGetter []cciptypes.Address
+	for _, dbt := range destBridgeableTokens {
+		isConfigured, _ := priceGetter.IsTokenConfigured(ctx, dbt)
+		fmt.Println(isConfigured)
+		fmt.Println(dbt)
+
+		if isConfigured {
+			dbtWithPriceGetter = append(dbtWithPriceGetter, dbt)
+		}
+	}
+	fmt.Println(dbtWithPriceGetter)
+	return flattenedAndSortedChainTokens(destFeeTokens, dbtWithPriceGetter)
+}
+
+func flattenedAndSortedChainTokens(destFeeTokens []cciptypes.Address, destBridgeableTokens []cciptypes.Address) (chainTokens []cciptypes.Address, err error) {
+	// same token can be returned by multiple offRamps, and fee token can overlap with bridgeable tokens,
+	// we need to dedup them to arrive at chain token set
+	chainTokens = FlattenUniqueSlice(destFeeTokens, destBridgeableTokens)
+
+	// return the tokens in deterministic order to aid with testing and debugging
+	sort.Slice(chainTokens, func(i, j int) bool {
+		return chainTokens[i] < chainTokens[j]
+	})
+
+	return chainTokens, nil
+}
+
+func getTokensWithBatchLimit(ctx context.Context, offRamps []ccipdata.OffRampReader, priceRegistry cciptypes.PriceRegistryReader, batchSize int) (destFeeTokens []cciptypes.Address, destBridgeableTokens []cciptypes.Address, err error) {
 	if batchSize == 0 {
-		return nil, fmt.Errorf("batch size must be greater than 0")
+		return nil, nil, fmt.Errorf("batch size must be greater than 0")
 	}
 
 	eg := new(errgroup.Group)
 	eg.SetLimit(batchSize)
 
-	var destFeeTokens []cciptypes.Address
-	var destBridgeableTokens []cciptypes.Address
 	mu := &sync.RWMutex{}
 
 	eg.Go(func() error {
@@ -75,19 +104,10 @@ func getSortedChainTokensWithBatchLimit(ctx context.Context, offRamps []ccipdata
 	}
 
 	if err := eg.Wait(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	// same token can be returned by multiple offRamps, and fee token can overlap with bridgeable tokens,
-	// we need to dedup them to arrive at chain token set
-	chainTokens = FlattenUniqueSlice(destFeeTokens, destBridgeableTokens)
-
-	// return the tokens in deterministic order to aid with testing and debugging
-	sort.Slice(chainTokens, func(i, j int) bool {
-		return chainTokens[i] < chainTokens[j]
-	})
-
-	return chainTokens, nil
+	return destFeeTokens, destBridgeableTokens, nil
 }
 
 // GetDestinationTokens returns the destination chain fee tokens from the provided price registry

--- a/core/services/ocr2/plugins/ccip/internal/ccipcommon/shortcuts_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipcommon/shortcuts_test.go
@@ -221,10 +221,17 @@ func TestGetFilteredChainTokens(t *testing.T) {
 			priceRegistry := ccipdatamocks.NewPriceRegistryReader(t)
 			priceRegistry.On("GetFeeTokens", ctx).Return(tc.feeTokens, nil).Once()
 
-			priceGet := pricegetter.NewMockPriceGetter(t)
+			cfgTokens := []cciptypes.Address{}
+			uncfgTokens := []cciptypes.Address{}
 			for i, token := range tokens {
-				priceGet.On("IsTokenConfigured", mock.Anything, token).Return(tc.tokenHasPriceGetter[i], nil).Maybe()
+				if tc.tokenHasPriceGetter[i] {
+					cfgTokens = append(cfgTokens, token)
+				} else {
+					uncfgTokens = append(uncfgTokens, token)
+				}
 			}
+			priceGet := pricegetter.NewMockPriceGetter(t)
+			priceGet.On("FilterConfiguredTokens", mock.Anything, tokens).Return(cfgTokens, uncfgTokens, nil)
 
 			var offRamps []ccipdata.OffRampReader
 			for _, destTokens := range tc.destTokens {

--- a/core/services/ocr2/plugins/ccip/internal/ccipcommon/shortcuts_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipcommon/shortcuts_test.go
@@ -80,14 +80,12 @@ func TestGetChainTokens(t *testing.T) {
 		name                string
 		feeTokens           []cciptypes.Address
 		destTokens          [][]cciptypes.Address
-		confTokens          []cciptypes.Address
 		expectedChainTokens []cciptypes.Address
 	}{
 		{
 			name:                "empty",
 			feeTokens:           []cciptypes.Address{},
 			destTokens:          [][]cciptypes.Address{{}},
-			confTokens:          []cciptypes.Address{},
 			expectedChainTokens: []cciptypes.Address{},
 		},
 		{
@@ -96,7 +94,6 @@ func TestGetChainTokens(t *testing.T) {
 			destTokens: [][]cciptypes.Address{
 				{tokens[1], tokens[2], tokens[3]},
 			},
-			confTokens:          []cciptypes.Address{tokens[0], tokens[1], tokens[2], tokens[3]},
 			expectedChainTokens: []cciptypes.Address{tokens[0], tokens[1], tokens[2], tokens[3]},
 		},
 		{
@@ -107,7 +104,6 @@ func TestGetChainTokens(t *testing.T) {
 				{tokens[3], tokens[4]},
 				{tokens[5]},
 			},
-			confTokens:          []cciptypes.Address{tokens[0], tokens[1], tokens[2], tokens[3], tokens[4], tokens[5]},
 			expectedChainTokens: []cciptypes.Address{tokens[0], tokens[1], tokens[2], tokens[3], tokens[4], tokens[5]},
 		},
 		{
@@ -118,8 +114,91 @@ func TestGetChainTokens(t *testing.T) {
 				{tokens[0], tokens[2], tokens[3], tokens[4], tokens[5]},
 				{tokens[5]},
 			},
-			confTokens:          []cciptypes.Address{tokens[0], tokens[1], tokens[2], tokens[3], tokens[4], tokens[5]},
 			expectedChainTokens: []cciptypes.Address{tokens[0], tokens[1], tokens[2], tokens[3], tokens[4], tokens[5]},
+		},
+	}
+
+	ctx := testutils.Context(t)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			priceRegistry := ccipdatamocks.NewPriceRegistryReader(t)
+			priceRegistry.On("GetFeeTokens", ctx).Return(tc.feeTokens, nil).Once()
+
+			var offRamps []ccipdata.OffRampReader
+			for _, destTokens := range tc.destTokens {
+				offRamp := ccipdatamocks.NewOffRampReader(t)
+				offRamp.On("GetTokens", ctx).Return(cciptypes.OffRampTokens{DestinationTokens: destTokens}, nil).Once()
+				offRamps = append(offRamps, offRamp)
+			}
+
+			chainTokens, err := GetSortedChainTokens(ctx, offRamps, priceRegistry)
+			assert.NoError(t, err)
+
+			sort.Slice(tc.expectedChainTokens, func(i, j int) bool {
+				return tc.expectedChainTokens[i] < tc.expectedChainTokens[j]
+			})
+			assert.Equal(t, tc.expectedChainTokens, chainTokens)
+		})
+	}
+}
+
+func TestGetFilteredChainTokens(t *testing.T) {
+	const numTokens = 6
+	var tokens []cciptypes.Address
+	for i := 0; i < numTokens; i++ {
+		tokens = append(tokens, ccipcalc.EvmAddrToGeneric(utils.RandomAddress()))
+	}
+
+	testCases := []struct {
+		name                   string
+		feeTokens              []cciptypes.Address
+		destTokens             [][]cciptypes.Address
+		tokenHasPriceGetter    [numTokens]bool
+		expectedChainTokens    []cciptypes.Address
+		expectedFilteredTokens []cciptypes.Address
+	}{
+		{
+			name:                   "empty",
+			feeTokens:              []cciptypes.Address{},
+			destTokens:             [][]cciptypes.Address{{}},
+			tokenHasPriceGetter:    [numTokens]bool{false, false, false, false, false, false},
+			expectedChainTokens:    []cciptypes.Address{},
+			expectedFilteredTokens: []cciptypes.Address{},
+		},
+		{
+			name:      "single offRamp",
+			feeTokens: []cciptypes.Address{tokens[0]},
+			destTokens: [][]cciptypes.Address{
+				{tokens[1], tokens[2], tokens[3]},
+			},
+			tokenHasPriceGetter:    [numTokens]bool{true, true, true, true, false, false},
+			expectedChainTokens:    []cciptypes.Address{tokens[0], tokens[1], tokens[2], tokens[3]},
+			expectedFilteredTokens: []cciptypes.Address{},
+		},
+		{
+			name:      "multiple offRamps with distinct tokens",
+			feeTokens: []cciptypes.Address{tokens[0]},
+			destTokens: [][]cciptypes.Address{
+				{tokens[1], tokens[2]},
+				{tokens[3], tokens[4]},
+				{tokens[5]},
+			},
+			tokenHasPriceGetter:    [numTokens]bool{true, true, true, true, true, true},
+			expectedChainTokens:    []cciptypes.Address{tokens[0], tokens[1], tokens[2], tokens[3], tokens[4], tokens[5]},
+			expectedFilteredTokens: []cciptypes.Address{},
+		},
+		{
+			name:      "overlapping tokens",
+			feeTokens: []cciptypes.Address{tokens[0]},
+			destTokens: [][]cciptypes.Address{
+				{tokens[0], tokens[1], tokens[2], tokens[3]},
+				{tokens[0], tokens[2], tokens[3], tokens[4], tokens[5]},
+				{tokens[5]},
+			},
+			tokenHasPriceGetter:    [numTokens]bool{true, true, true, true, true, true},
+			expectedChainTokens:    []cciptypes.Address{tokens[0], tokens[1], tokens[2], tokens[3], tokens[4], tokens[5]},
+			expectedFilteredTokens: []cciptypes.Address{},
 		},
 		{
 			name:      "unconfigured tokens",
@@ -129,8 +208,9 @@ func TestGetChainTokens(t *testing.T) {
 				{tokens[0], tokens[2], tokens[3], tokens[4], tokens[5]},
 				{tokens[5]},
 			},
-			confTokens:          []cciptypes.Address{tokens[0], tokens[1], tokens[2], tokens[3], tokens[4]},
-			expectedChainTokens: []cciptypes.Address{tokens[0], tokens[1], tokens[2], tokens[3], tokens[4]},
+			tokenHasPriceGetter:    [numTokens]bool{true, true, true, true, true, false},
+			expectedChainTokens:    []cciptypes.Address{tokens[0], tokens[1], tokens[2], tokens[3], tokens[4]},
+			expectedFilteredTokens: []cciptypes.Address{tokens[5]},
 		},
 	}
 
@@ -142,8 +222,8 @@ func TestGetChainTokens(t *testing.T) {
 			priceRegistry.On("GetFeeTokens", ctx).Return(tc.feeTokens, nil).Once()
 
 			priceGet := pricegetter.NewMockPriceGetter(t)
-			for _, confToken := range tc.confTokens {
-				priceGet.On("IsTokenConfigured", mock.Anything, confToken).Return(true, nil)
+			for i, token := range tokens {
+				priceGet.On("IsTokenConfigured", mock.Anything, token).Return(tc.tokenHasPriceGetter[i], nil).Maybe()
 			}
 
 			var offRamps []ccipdata.OffRampReader
@@ -153,34 +233,38 @@ func TestGetChainTokens(t *testing.T) {
 				offRamps = append(offRamps, offRamp)
 			}
 
-			chainTokens, err := GetSortedChainTokens(ctx, offRamps, priceRegistry, priceGet)
+			chainTokens, filteredTokens, err := GetFilteredSortedChainTokens(ctx, offRamps, priceRegistry, priceGet)
 			assert.NoError(t, err)
 
 			sort.Slice(tc.expectedChainTokens, func(i, j int) bool {
 				return tc.expectedChainTokens[i] < tc.expectedChainTokens[j]
 			})
 			assert.Equal(t, tc.expectedChainTokens, chainTokens)
+			assert.Equal(t, tc.expectedFilteredTokens, filteredTokens)
 		})
 	}
 }
 
 func TestGetChainTokensWithBatchLimit(t *testing.T) {
 	numTokens := 100
+	numFeeTokens := 10
 	var tokens []cciptypes.Address
 	for i := 0; i < numTokens; i++ {
 		tokens = append(tokens, ccipcalc.EvmAddrToGeneric(utils.RandomAddress()))
 	}
 
-	expectedTokens := make([]cciptypes.Address, numTokens)
-	copy(expectedTokens, tokens)
-	sort.Slice(expectedTokens, func(i, j int) bool {
-		return expectedTokens[i] < expectedTokens[j]
+	expectedFeeTokens := make([]cciptypes.Address, numFeeTokens)
+	copy(expectedFeeTokens, tokens[0:numFeeTokens])
+	expectedBridgeableTokens := make([]cciptypes.Address, numTokens)
+	copy(expectedBridgeableTokens, tokens)
+	sort.Slice(expectedBridgeableTokens, func(i, j int) bool {
+		return expectedBridgeableTokens[i] < expectedBridgeableTokens[j]
 	})
 
 	testCases := []struct {
 		name        string
 		batchSize   int
-		numOffRamps uint
+		numOffRamps int
 		expectError bool
 	}{
 		{
@@ -226,23 +310,24 @@ func TestGetChainTokensWithBatchLimit(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 
 			priceRegistry := ccipdatamocks.NewPriceRegistryReader(t)
-			priceRegistry.On("GetFeeTokens", ctx).Return(tokens[0:10], nil).Maybe()
+			priceRegistry.On("GetFeeTokens", ctx).Return(expectedFeeTokens, nil).Maybe()
 
 			var offRamps []ccipdata.OffRampReader
-			for i := 0; i < int(tc.numOffRamps); i++ {
+			for i := 0; i < tc.numOffRamps; i++ {
 				offRamp := ccipdatamocks.NewOffRampReader(t)
 				offRamp.On("GetTokens", ctx).Return(cciptypes.OffRampTokens{DestinationTokens: tokens[i%numTokens:]}, nil).Maybe()
 				offRamps = append(offRamps, offRamp)
 			}
 
-			chainTokens, err := getSortedChainTokensWithBatchLimit(ctx, offRamps, priceRegistry, tc.batchSize)
+			destFeeTokens, destBridgeableTokens, err := getTokensWithBatchLimit(ctx, offRamps, priceRegistry, tc.batchSize)
 			if tc.expectError {
 				assert.Error(t, err)
 				return
 			}
 
 			assert.NoError(t, err)
-			assert.Equal(t, expectedTokens, chainTokens)
+			assert.Equal(t, expectedFeeTokens, destFeeTokens)
+			assert.Equal(t, expectedBridgeableTokens, destBridgeableTokens)
 		})
 	}
 }

--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/evm.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/evm.go
@@ -74,6 +74,23 @@ func NewDynamicPriceGetter(cfg config.DynamicPriceGetterConfig, evmClients map[u
 	return &priceGetter, nil
 }
 
+// IsTokenConfigured implements the PriceGetter interface.
+// It returns if a token has a price resolution rule configured on the PriceGetterConfig
+func (d *DynamicPriceGetter) IsTokenConfigured(ctx context.Context, token cciptypes.Address) (bool, error) {
+	evmAddr, err := ccipcalc.GenericAddrToEvm(token)
+	if err != nil {
+		return false, err
+	}
+
+	if _, isAgg := d.cfg.AggregatorPrices[evmAddr]; isAgg {
+		return isAgg, nil
+	} else if _, isStatic := d.cfg.StaticPrices[evmAddr]; isStatic {
+		return isStatic, nil
+	} else {
+		return false, nil
+	}
+}
+
 // TokenPricesUSD implements the PriceGetter interface.
 // It returns static prices stored in the price getter, and batch calls to aggregators (on per chain) for aggregator-based prices.
 func (d *DynamicPriceGetter) TokenPricesUSD(ctx context.Context, tokens []cciptypes.Address) (map[cciptypes.Address]*big.Int, error) {

--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/evm.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/evm.go
@@ -86,9 +86,9 @@ func (d *DynamicPriceGetter) IsTokenConfigured(ctx context.Context, token ccipty
 		return isAgg, nil
 	} else if _, isStatic := d.cfg.StaticPrices[evmAddr]; isStatic {
 		return isStatic, nil
-	} else {
-		return false, nil
 	}
+
+	return false, nil
 }
 
 // TokenPricesUSD implements the PriceGetter interface.

--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/evm_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/evm_test.go
@@ -72,10 +72,6 @@ func TestDynamicPriceGetter(t *testing.T) {
 			for tk := range test.param.expectedTokenPrices {
 				tokenAddr := cciptypes.Address(tk.String())
 				tokens = append(tokens, tokenAddr)
-				// Expect that token is configured
-				isConfigured, err2 := pg.IsTokenConfigured(ctx, tokenAddr)
-				require.NoError(t, err2)
-				assert.True(t, isConfigured)
 			}
 			prices, err := pg.TokenPricesUSD(ctx, tokens)
 			if test.param.priceResolutionErrorExpected {

--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/evm_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/evm_test.go
@@ -73,8 +73,8 @@ func TestDynamicPriceGetter(t *testing.T) {
 				tokenAddr := cciptypes.Address(tk.String())
 				tokens = append(tokens, tokenAddr)
 				// Expect that token is configured
-				isConfigured, err := pg.IsTokenConfigured(ctx, tokenAddr)
-				require.NoError(t, err)
+				isConfigured, err2 := pg.IsTokenConfigured(ctx, tokenAddr)
+				require.NoError(t, err2)
 				assert.True(t, isConfigured)
 			}
 			prices, err := pg.TokenPricesUSD(ctx, tokens)

--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/evm_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/evm_test.go
@@ -62,11 +62,12 @@ func TestDynamicPriceGetter(t *testing.T) {
 			}
 			require.NoError(t, err)
 			ctx := testutils.Context(t)
-			// Check unconfigured token
+			// Check configured token
 			unconfiguredTk := cciptypes.Address(utils.RandomAddress().String())
-			isConfigured, err := pg.IsTokenConfigured(ctx, unconfiguredTk)
+			cfgTokens, uncfgTokens, err := pg.FilterConfiguredTokens(ctx, []cciptypes.Address{unconfiguredTk})
 			require.NoError(t, err)
-			assert.False(t, isConfigured)
+			assert.Equal(t, []cciptypes.Address{}, cfgTokens)
+			assert.Equal(t, []cciptypes.Address{unconfiguredTk}, uncfgTokens)
 			// Build list of tokens to query.
 			tokens := make([]cciptypes.Address, 0, len(test.param.expectedTokenPrices))
 			for tk := range test.param.expectedTokenPrices {

--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/evm_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/evm_test.go
@@ -62,10 +62,20 @@ func TestDynamicPriceGetter(t *testing.T) {
 			}
 			require.NoError(t, err)
 			ctx := testutils.Context(t)
+			// Check unconfigured token
+			unconfiguredTk := cciptypes.Address(utils.RandomAddress().String())
+			isConfigured, err := pg.IsTokenConfigured(ctx, unconfiguredTk)
+			require.NoError(t, err)
+			assert.False(t, isConfigured)
 			// Build list of tokens to query.
 			tokens := make([]cciptypes.Address, 0, len(test.param.expectedTokenPrices))
 			for tk := range test.param.expectedTokenPrices {
-				tokens = append(tokens, cciptypes.Address(tk.String()))
+				tokenAddr := cciptypes.Address(tk.String())
+				tokens = append(tokens, tokenAddr)
+				// Expect that token is configured
+				isConfigured, err := pg.IsTokenConfigured(ctx, tokenAddr)
+				require.NoError(t, err)
+				assert.True(t, isConfigured)
 			}
 			prices, err := pg.TokenPricesUSD(ctx, tokens)
 			if test.param.priceResolutionErrorExpected {

--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/mock.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/mock.go
@@ -34,6 +34,34 @@ func (_m *MockPriceGetter) Close() error {
 	return r0
 }
 
+// IsTokenConfigured provides a mock function with given fields: token
+func (_m *MockPriceGetter) IsTokenConfigured(ctx context.Context, token ccip.Address) (bool, error) {
+	ret := _m.Called(token)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsTokenConfigured")
+	}
+
+	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(ccip.Address) (bool, error)); ok {
+		return rf(token)
+	}
+	if rf, ok := ret.Get(0).(func(ccip.Address) bool); ok {
+		r0 = rf(token)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	if rf, ok := ret.Get(1).(func(ccip.Address) error); ok {
+		r1 = rf(token)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // TokenPricesUSD provides a mock function with given fields: ctx, tokens
 func (_m *MockPriceGetter) TokenPricesUSD(ctx context.Context, tokens []ccip.Address) (map[ccip.Address]*big.Int, error) {
 	ret := _m.Called(ctx, tokens)

--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/mock.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/mock.go
@@ -34,32 +34,43 @@ func (_m *MockPriceGetter) Close() error {
 	return r0
 }
 
-// IsTokenConfigured provides a mock function with given fields: ctx, token
-func (_m *MockPriceGetter) IsTokenConfigured(ctx context.Context, token ccip.Address) (bool, error) {
-	ret := _m.Called(ctx, token)
+// FilterConfiguredTokens provides a mock function with given fields: ctx, tokens
+func (_m *MockPriceGetter) FilterConfiguredTokens(ctx context.Context, tokens []ccip.Address) ([]ccip.Address, []ccip.Address, error) {
+	ret := _m.Called(ctx, tokens)
 
 	if len(ret) == 0 {
-		panic("no return value specified for IsTokenConfigured")
+		panic("no return value specified for FilterConfiguredTokens")
 	}
 
-	var r0 bool
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, ccip.Address) (bool, error)); ok {
-		return rf(ctx, token)
+	var r0 []ccip.Address
+	var r1 []ccip.Address
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, []ccip.Address) ([]ccip.Address, []ccip.Address, error)); ok {
+		return rf(ctx, tokens)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, ccip.Address) bool); ok {
-		r0 = rf(ctx, token)
+	if rf, ok := ret.Get(0).(func(context.Context, []ccip.Address) []ccip.Address); ok {
+		r0 = rf(ctx, tokens)
 	} else {
-		r0 = ret.Get(0).(bool)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]ccip.Address)
+		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, ccip.Address) error); ok {
-		r1 = rf(ctx, token)
+	if rf, ok := ret.Get(1).(func(context.Context, []ccip.Address) []ccip.Address); ok {
+		r1 = rf(ctx, tokens)
 	} else {
-		r1 = ret.Error(1)
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).([]ccip.Address)
+		}
 	}
 
-	return r0, r1
+	if rf, ok := ret.Get(2).(func(context.Context, []ccip.Address) error); ok {
+		r2 = rf(ctx, tokens)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // TokenPricesUSD provides a mock function with given fields: ctx, tokens

--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/mock.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/mock.go
@@ -34,9 +34,9 @@ func (_m *MockPriceGetter) Close() error {
 	return r0
 }
 
-// IsTokenConfigured provides a mock function with given fields: token
+// IsTokenConfigured provides a mock function with given fields: ctx, token
 func (_m *MockPriceGetter) IsTokenConfigured(ctx context.Context, token ccip.Address) (bool, error) {
-	ret := _m.Called(token)
+	ret := _m.Called(ctx, token)
 
 	if len(ret) == 0 {
 		panic("no return value specified for IsTokenConfigured")
@@ -44,17 +44,17 @@ func (_m *MockPriceGetter) IsTokenConfigured(ctx context.Context, token ccip.Add
 
 	var r0 bool
 	var r1 error
-	if rf, ok := ret.Get(0).(func(ccip.Address) (bool, error)); ok {
-		return rf(token)
+	if rf, ok := ret.Get(0).(func(context.Context, ccip.Address) (bool, error)); ok {
+		return rf(ctx, token)
 	}
-	if rf, ok := ret.Get(0).(func(ccip.Address) bool); ok {
-		r0 = rf(token)
+	if rf, ok := ret.Get(0).(func(context.Context, ccip.Address) bool); ok {
+		r0 = rf(ctx, token)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
-	if rf, ok := ret.Get(1).(func(ccip.Address) error); ok {
-		r1 = rf(token)
+	if rf, ok := ret.Get(1).(func(context.Context, ccip.Address) error); ok {
+		r1 = rf(ctx, token)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/pipeline.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/pipeline.go
@@ -45,11 +45,19 @@ func NewPipelineGetter(source string, runner pipeline.Runner, jobID int32, exter
 	}, nil
 }
 
-// IsTokenConfigured implements the PriceGetter interface.
-// It returns if a token has a pipeline job configured on the TokenPricesUSDPipeline
-func (d *PipelineGetter) IsTokenConfigured(ctx context.Context, token cciptypes.Address) (bool, error) {
-	contains := strings.Contains(d.source, string(token))
-	return contains, nil
+// FilterForConfiguredTokens implements the PriceGetter interface.
+// It filters a list of token addresses for only those that have a pipeline job configured on the TokenPricesUSDPipeline
+func (d *PipelineGetter) FilterConfiguredTokens(ctx context.Context, tokens []cciptypes.Address) (configured []cciptypes.Address, unconfigured []cciptypes.Address, err error) {
+	lcSource := strings.ToLower(d.source)
+	for _, tk := range tokens {
+		lcToken := strings.ToLower(string(tk))
+		if strings.Contains(lcSource, lcToken) {
+			configured = append(configured, tk)
+		} else {
+			unconfigured = append(unconfigured, tk)
+		}
+	}
+	return configured, unconfigured, nil
 }
 
 func (d *PipelineGetter) TokenPricesUSD(ctx context.Context, tokens []cciptypes.Address) (map[cciptypes.Address]*big.Int, error) {

--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/pipeline.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/pipeline.go
@@ -3,6 +3,7 @@ package pricegetter
 import (
 	"context"
 	"math/big"
+	"strings"
 	"time"
 
 	mapset "github.com/deckarep/golang-set/v2"
@@ -42,6 +43,13 @@ func NewPipelineGetter(source string, runner pipeline.Runner, jobID int32, exter
 		name:          name,
 		lggr:          lggr,
 	}, nil
+}
+
+// IsTokenConfigured implements the PriceGetter interface.
+// It returns if a token has a pipeline job configured on the TokenPricesUSDPipeline
+func (d *PipelineGetter) IsTokenConfigured(ctx context.Context, token cciptypes.Address) (bool, error) {
+	contains := strings.Contains(d.source, string(token))
+	return contains, nil
 }
 
 func (d *PipelineGetter) TokenPricesUSD(ctx context.Context, tokens []cciptypes.Address) (map[cciptypes.Address]*big.Int, error) {

--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/pipeline_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/pipeline_test.go
@@ -56,6 +56,17 @@ func TestDataSource(t *testing.T) {
 `, linkEth.URL, usdcEth.URL, linkTokenAddress, usdcTokenAddress)
 
 	priceGetter := newTestPipelineGetter(t, source)
+
+	// Link token is configured
+	hasLinkToken, err := priceGetter.IsTokenConfigured(context.Background(), linkTokenAddress)
+	require.NoError(t, err)
+	assert.True(t, hasLinkToken)
+
+	// USDC token is configured
+	hasUSDCToken, err := priceGetter.IsTokenConfigured(context.Background(), usdcTokenAddress)
+	require.NoError(t, err)
+	assert.True(t, hasUSDCToken)
+
 	// Ask for all prices present in spec.
 	prices, err := priceGetter.TokenPricesUSD(context.Background(), []cciptypes.Address{
 		linkTokenAddress,

--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/pipeline_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/pipeline_test.go
@@ -57,15 +57,11 @@ func TestDataSource(t *testing.T) {
 
 	priceGetter := newTestPipelineGetter(t, source)
 
-	// Link token is configured
-	hasLinkToken, err := priceGetter.IsTokenConfigured(context.Background(), linkTokenAddress)
+	// USDC & LINK are configured
+	confTokens, _, err := priceGetter.FilterConfiguredTokens(context.Background(), []cciptypes.Address{linkTokenAddress, usdcTokenAddress})
 	require.NoError(t, err)
-	assert.True(t, hasLinkToken)
-
-	// USDC token is configured
-	hasUSDCToken, err := priceGetter.IsTokenConfigured(context.Background(), usdcTokenAddress)
-	require.NoError(t, err)
-	assert.True(t, hasUSDCToken)
+	assert.Equal(t, linkTokenAddress, confTokens[0])
+	assert.Equal(t, usdcTokenAddress, confTokens[1])
 
 	// Ask for all prices present in spec.
 	prices, err := priceGetter.TokenPricesUSD(context.Background(), []cciptypes.Address{

--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/smartcontractkit/chain-selectors v1.0.13
 	github.com/smartcontractkit/chainlink-automation v1.0.2
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240404141006-77085a02ce25
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405201435-e1e054309e35
 	github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240213120401-01a23955f9f8
 	github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540
 	github.com/smartcontractkit/chainlink-feeds v0.0.0-20240119021347-3c541a78cdb8

--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/smartcontractkit/chain-selectors v1.0.13
 	github.com/smartcontractkit/chainlink-automation v1.0.2
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405201435-e1e054309e35
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240410191726-b8a7349cd5d3
 	github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240213120401-01a23955f9f8
 	github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540
 	github.com/smartcontractkit/chainlink-feeds v0.0.0-20240119021347-3c541a78cdb8

--- a/go.sum
+++ b/go.sum
@@ -1176,8 +1176,6 @@ github.com/smartcontractkit/chain-selectors v1.0.13 h1:vHMbh7Wu+W+/DSD88feiwMMSX
 github.com/smartcontractkit/chain-selectors v1.0.13/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.2 h1:xsfyuswL15q2YBGQT3qn2SBz6fnSKiSW7XZ8IZQLpnI=
 github.com/smartcontractkit/chainlink-automation v1.0.2/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240404141006-77085a02ce25 h1:fY2wMtlr/VQxPyVVQdi1jFvQHi0VbDnGGVXzLKOZTOY=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240404141006-77085a02ce25/go.mod h1:kstYjAGqBswdZpl7YkSPeXBDVwaY1VaR6tUMPWl8ykA=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405201435-e1e054309e35 h1:mGQ7j5fK8d/ZRIJMgWZkfOb/84zLcmXjdRlkhuE80a0=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405201435-e1e054309e35/go.mod h1:kstYjAGqBswdZpl7YkSPeXBDVwaY1VaR6tUMPWl8ykA=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240213120401-01a23955f9f8 h1:I326nw5GwHQHsLKHwtu5Sb9EBLylC8CfUd7BFAS0jtg=

--- a/go.sum
+++ b/go.sum
@@ -1178,6 +1178,8 @@ github.com/smartcontractkit/chainlink-automation v1.0.2 h1:xsfyuswL15q2YBGQT3qn2
 github.com/smartcontractkit/chainlink-automation v1.0.2/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240404141006-77085a02ce25 h1:fY2wMtlr/VQxPyVVQdi1jFvQHi0VbDnGGVXzLKOZTOY=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240404141006-77085a02ce25/go.mod h1:kstYjAGqBswdZpl7YkSPeXBDVwaY1VaR6tUMPWl8ykA=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405201435-e1e054309e35 h1:mGQ7j5fK8d/ZRIJMgWZkfOb/84zLcmXjdRlkhuE80a0=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405201435-e1e054309e35/go.mod h1:kstYjAGqBswdZpl7YkSPeXBDVwaY1VaR6tUMPWl8ykA=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240213120401-01a23955f9f8 h1:I326nw5GwHQHsLKHwtu5Sb9EBLylC8CfUd7BFAS0jtg=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240213120401-01a23955f9f8/go.mod h1:a65NtrK4xZb01mf0dDNghPkN2wXgcqFQ55ADthVBgMc=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=

--- a/go.sum
+++ b/go.sum
@@ -1176,8 +1176,8 @@ github.com/smartcontractkit/chain-selectors v1.0.13 h1:vHMbh7Wu+W+/DSD88feiwMMSX
 github.com/smartcontractkit/chain-selectors v1.0.13/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.2 h1:xsfyuswL15q2YBGQT3qn2SBz6fnSKiSW7XZ8IZQLpnI=
 github.com/smartcontractkit/chainlink-automation v1.0.2/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405201435-e1e054309e35 h1:mGQ7j5fK8d/ZRIJMgWZkfOb/84zLcmXjdRlkhuE80a0=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405201435-e1e054309e35/go.mod h1:kstYjAGqBswdZpl7YkSPeXBDVwaY1VaR6tUMPWl8ykA=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240410191726-b8a7349cd5d3 h1:W8XC1b0GDM0OSzvHvUEFTaZUtognWVkEjCSW2nKQ1mc=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240410191726-b8a7349cd5d3/go.mod h1:kstYjAGqBswdZpl7YkSPeXBDVwaY1VaR6tUMPWl8ykA=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240213120401-01a23955f9f8 h1:I326nw5GwHQHsLKHwtu5Sb9EBLylC8CfUd7BFAS0jtg=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240213120401-01a23955f9f8/go.mod h1:a65NtrK4xZb01mf0dDNghPkN2wXgcqFQ55ADthVBgMc=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/slack-go/slack v0.12.2
 	github.com/smartcontractkit/chain-selectors v1.0.13
 	github.com/smartcontractkit/chainlink-automation v1.0.2
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240404141006-77085a02ce25
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405201435-e1e054309e35
 	github.com/smartcontractkit/chainlink-testing-framework v1.28.1
 	github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868
 	github.com/smartcontractkit/chainlink/integration-tests v0.0.0-00010101000000-000000000000

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/slack-go/slack v0.12.2
 	github.com/smartcontractkit/chain-selectors v1.0.13
 	github.com/smartcontractkit/chainlink-automation v1.0.2
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405201435-e1e054309e35
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240410191726-b8a7349cd5d3
 	github.com/smartcontractkit/chainlink-testing-framework v1.28.1
 	github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868
 	github.com/smartcontractkit/chainlink/integration-tests v0.0.0-00010101000000-000000000000

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1523,6 +1523,8 @@ github.com/smartcontractkit/chainlink-automation v1.0.2 h1:xsfyuswL15q2YBGQT3qn2
 github.com/smartcontractkit/chainlink-automation v1.0.2/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240404141006-77085a02ce25 h1:fY2wMtlr/VQxPyVVQdi1jFvQHi0VbDnGGVXzLKOZTOY=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240404141006-77085a02ce25/go.mod h1:kstYjAGqBswdZpl7YkSPeXBDVwaY1VaR6tUMPWl8ykA=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405201435-e1e054309e35 h1:mGQ7j5fK8d/ZRIJMgWZkfOb/84zLcmXjdRlkhuE80a0=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405201435-e1e054309e35/go.mod h1:kstYjAGqBswdZpl7YkSPeXBDVwaY1VaR6tUMPWl8ykA=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240213120401-01a23955f9f8 h1:I326nw5GwHQHsLKHwtu5Sb9EBLylC8CfUd7BFAS0jtg=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240213120401-01a23955f9f8/go.mod h1:a65NtrK4xZb01mf0dDNghPkN2wXgcqFQ55ADthVBgMc=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1521,8 +1521,8 @@ github.com/smartcontractkit/chain-selectors v1.0.13 h1:vHMbh7Wu+W+/DSD88feiwMMSX
 github.com/smartcontractkit/chain-selectors v1.0.13/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.2 h1:xsfyuswL15q2YBGQT3qn2SBz6fnSKiSW7XZ8IZQLpnI=
 github.com/smartcontractkit/chainlink-automation v1.0.2/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405201435-e1e054309e35 h1:mGQ7j5fK8d/ZRIJMgWZkfOb/84zLcmXjdRlkhuE80a0=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405201435-e1e054309e35/go.mod h1:kstYjAGqBswdZpl7YkSPeXBDVwaY1VaR6tUMPWl8ykA=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240410191726-b8a7349cd5d3 h1:W8XC1b0GDM0OSzvHvUEFTaZUtognWVkEjCSW2nKQ1mc=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240410191726-b8a7349cd5d3/go.mod h1:kstYjAGqBswdZpl7YkSPeXBDVwaY1VaR6tUMPWl8ykA=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240213120401-01a23955f9f8 h1:I326nw5GwHQHsLKHwtu5Sb9EBLylC8CfUd7BFAS0jtg=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240213120401-01a23955f9f8/go.mod h1:a65NtrK4xZb01mf0dDNghPkN2wXgcqFQ55ADthVBgMc=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1521,8 +1521,6 @@ github.com/smartcontractkit/chain-selectors v1.0.13 h1:vHMbh7Wu+W+/DSD88feiwMMSX
 github.com/smartcontractkit/chain-selectors v1.0.13/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.2 h1:xsfyuswL15q2YBGQT3qn2SBz6fnSKiSW7XZ8IZQLpnI=
 github.com/smartcontractkit/chainlink-automation v1.0.2/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240404141006-77085a02ce25 h1:fY2wMtlr/VQxPyVVQdi1jFvQHi0VbDnGGVXzLKOZTOY=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240404141006-77085a02ce25/go.mod h1:kstYjAGqBswdZpl7YkSPeXBDVwaY1VaR6tUMPWl8ykA=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405201435-e1e054309e35 h1:mGQ7j5fK8d/ZRIJMgWZkfOb/84zLcmXjdRlkhuE80a0=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405201435-e1e054309e35/go.mod h1:kstYjAGqBswdZpl7YkSPeXBDVwaY1VaR6tUMPWl8ykA=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240213120401-01a23955f9f8 h1:I326nw5GwHQHsLKHwtu5Sb9EBLylC8CfUd7BFAS0jtg=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/rs/zerolog v1.30.0
 	github.com/slack-go/slack v0.12.2
 	github.com/smartcontractkit/chainlink-automation v1.0.2
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405201435-e1e054309e35
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240410191726-b8a7349cd5d3
 	github.com/smartcontractkit/chainlink-testing-framework v1.28.1
 	github.com/smartcontractkit/chainlink/integration-tests v0.0.0-20240214231432-4ad5eb95178c
 	github.com/smartcontractkit/chainlink/v2 v2.9.0-beta0.0.20240216210048-da02459ddad8

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/rs/zerolog v1.30.0
 	github.com/slack-go/slack v0.12.2
 	github.com/smartcontractkit/chainlink-automation v1.0.2
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240404141006-77085a02ce25
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405201435-e1e054309e35
 	github.com/smartcontractkit/chainlink-testing-framework v1.28.1
 	github.com/smartcontractkit/chainlink/integration-tests v0.0.0-20240214231432-4ad5eb95178c
 	github.com/smartcontractkit/chainlink/v2 v2.9.0-beta0.0.20240216210048-da02459ddad8

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1504,8 +1504,8 @@ github.com/smartcontractkit/chain-selectors v1.0.13 h1:vHMbh7Wu+W+/DSD88feiwMMSX
 github.com/smartcontractkit/chain-selectors v1.0.13/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.2 h1:xsfyuswL15q2YBGQT3qn2SBz6fnSKiSW7XZ8IZQLpnI=
 github.com/smartcontractkit/chainlink-automation v1.0.2/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405201435-e1e054309e35 h1:mGQ7j5fK8d/ZRIJMgWZkfOb/84zLcmXjdRlkhuE80a0=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405201435-e1e054309e35/go.mod h1:kstYjAGqBswdZpl7YkSPeXBDVwaY1VaR6tUMPWl8ykA=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240410191726-b8a7349cd5d3 h1:W8XC1b0GDM0OSzvHvUEFTaZUtognWVkEjCSW2nKQ1mc=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240410191726-b8a7349cd5d3/go.mod h1:kstYjAGqBswdZpl7YkSPeXBDVwaY1VaR6tUMPWl8ykA=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240213120401-01a23955f9f8 h1:I326nw5GwHQHsLKHwtu5Sb9EBLylC8CfUd7BFAS0jtg=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240213120401-01a23955f9f8/go.mod h1:a65NtrK4xZb01mf0dDNghPkN2wXgcqFQ55ADthVBgMc=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1504,8 +1504,8 @@ github.com/smartcontractkit/chain-selectors v1.0.13 h1:vHMbh7Wu+W+/DSD88feiwMMSX
 github.com/smartcontractkit/chain-selectors v1.0.13/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.2 h1:xsfyuswL15q2YBGQT3qn2SBz6fnSKiSW7XZ8IZQLpnI=
 github.com/smartcontractkit/chainlink-automation v1.0.2/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240404141006-77085a02ce25 h1:fY2wMtlr/VQxPyVVQdi1jFvQHi0VbDnGGVXzLKOZTOY=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240404141006-77085a02ce25/go.mod h1:kstYjAGqBswdZpl7YkSPeXBDVwaY1VaR6tUMPWl8ykA=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405201435-e1e054309e35 h1:mGQ7j5fK8d/ZRIJMgWZkfOb/84zLcmXjdRlkhuE80a0=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405201435-e1e054309e35/go.mod h1:kstYjAGqBswdZpl7YkSPeXBDVwaY1VaR6tUMPWl8ykA=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240213120401-01a23955f9f8 h1:I326nw5GwHQHsLKHwtu5Sb9EBLylC8CfUd7BFAS0jtg=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240213120401-01a23955f9f8/go.mod h1:a65NtrK4xZb01mf0dDNghPkN2wXgcqFQ55ADthVBgMc=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=


### PR DESCRIPTION
## Motivation
Self serve token pools will enable many new TransferTokens to be used across CCIP, most of which may not have a readily available price.

## Context
The current procedure (as of [batched price updates](https://github.com/smartcontractkit/ccip/pull/623)) is for a single lane to be designated as the "leader lane". It reports all prices that other lanes use. Other lanes have their price reporting disabled. To enable this, the leader lane has all supported tokens configured in the CommitJobSpec.

The source of truth for which tokens are supported comes from on-chain: queried from the leader lane's destination price registry (FeeTokens) and from each OffRamp's `supportedTokens`. The combined set is given to the `price getter`, and if the number of resulting prices is different from the CommitJobSpec's  tokens then the observation is thrown out.

## Solution

### _For v1.4 (current) contracts:_
Use the `CommitJobSpec`'s configured tokens as the source of truth for which TransferTokens need a price update. Filter out TransferTokens that are not configured on the `pricegetter` before they reach `pricegetter.TokenPricesUSD()`.

