### PR TITLE
Bump golang tool version to fix devspace build

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.21.7
+golang 1.21.8
 mockery 2.38.0
 nodejs 16.16.0
 pnpm 8.11.0


### PR DESCRIPTION
## Motivation
The devspace build didn't work for me, was throwing an error, something about mismatch of go binaries in goreleaser_utils -> before_hook

## Solution
After bumping patch version it started working fine