### PR TITLE
fixes for new token pool version in upgrade tests

### DIFF
--- a/integration-tests/ccip-tests/actions/ccip_helpers.go
+++ b/integration-tests/ccip-tests/actions/ccip_helpers.go
@@ -907,12 +907,12 @@ func (ccipModule *CCIPCommon) DeployContracts(noOfTokens int,
 	}
 	// find out the pool version
 	// We assume all pools are of the same version as the first pool , if test is
-	_, version, err := config.TypeAndVersion(ccipModule.BridgeTokenPools[0].EthAddress, ccipModule.ChainClient.Backend())
+	version, err := cd.TypeAndVersion(ccipModule.BridgeTokenPools[0].EthAddress)
 	if err != nil {
 		return err
 	}
 	// if the version is for LockReleaseTokenPool 1.4.0, we need to deploy TokenAdminRegistry
-	if version.String() == "LockReleaseTokenPool 1.4.0" {
+	if version == "LockReleaseTokenPool 1.4.0" {
 		if ccipModule.TokenAdminRegistry == nil {
 			if ccipModule.ExistingDeployment {
 				return fmt.Errorf("token admin registry contract address is not provided in lane config")

--- a/integration-tests/ccip-tests/contracts/contract_deployer.go
+++ b/integration-tests/ccip-tests/contracts/contract_deployer.go
@@ -24,8 +24,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink-testing-framework/blockchain"
 
-	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/token_admin_registry"
-
 	"github.com/smartcontractkit/chainlink/integration-tests/client"
 	"github.com/smartcontractkit/chainlink/integration-tests/contracts"
 	"github.com/smartcontractkit/chainlink/integration-tests/wrappers"
@@ -41,6 +39,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/mock_v3_aggregator_contract"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/price_registry"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/router"
+	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/token_admin_registry"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/token_pool"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/usdc_token_pool"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/weth9"

--- a/integration-tests/ccip-tests/contracts/contract_deployer.go
+++ b/integration-tests/ccip-tests/contracts/contract_deployer.go
@@ -44,6 +44,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/usdc_token_pool"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/weth9"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/link_token_interface"
+	type_and_version "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/type_and_version_interface_wrapper"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/shared/generated/burn_mint_erc677"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/shared/generated/erc20"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/abihelpers"
@@ -755,6 +756,23 @@ func (e *CCIPContractsDeployer) NewMockAggregator(addr common.Address) (*MockAgg
 		Instance:        ins,
 		ContractAddress: addr,
 	}, nil
+}
+
+func (e *CCIPContractsDeployer) TypeAndVersion(addr common.Address) (string, error) {
+	tv, err := type_and_version.NewTypeAndVersionInterface(addr, wrappers.MustNewWrappedContractBackend(e.evmClient, nil))
+	if err != nil {
+		return "", err
+	}
+	tvStr, err := tv.TypeAndVersion(nil)
+	if err != nil {
+		return "", fmt.Errorf("error calling typeAndVersion on addr: %s %w", addr.Hex(), err)
+	}
+	log.Info().
+		Str("TypeAndVersion", tvStr).
+		Str("Contract Address", addr.Hex()).
+		Msg("TypeAndVersion")
+
+	return tvStr, nil
 }
 
 var OCR2ParamsForCommit = contracts.OffChainAggregatorV2Config{

--- a/integration-tests/ccip-tests/contracts/contract_deployer.go
+++ b/integration-tests/ccip-tests/contracts/contract_deployer.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -772,7 +773,15 @@ func (e *CCIPContractsDeployer) TypeAndVersion(addr common.Address) (string, err
 		Str("Contract Address", addr.Hex()).
 		Msg("TypeAndVersion")
 
-	return tvStr, nil
+	_, versionStr, err := ccipconfig.ParseTypeAndVersion(tvStr)
+	if err != nil {
+		return versionStr, err
+	}
+	v, err := semver.NewVersion(versionStr)
+	if err != nil {
+		return "", fmt.Errorf("failed parsing version %s: %w", versionStr, err)
+	}
+	return v.String(), nil
 }
 
 var OCR2ParamsForCommit = contracts.OffChainAggregatorV2Config{

--- a/integration-tests/ccip-tests/contracts/laneconfig/parse_contracts.go
+++ b/integration-tests/ccip-tests/contracts/laneconfig/parse_contracts.go
@@ -34,6 +34,7 @@ type CommonContracts struct {
 	TokenTransmitter   string            `json:"token_transmitter,omitempty"`
 	TokenMessenger     string            `json:"token_messenger,omitempty"`
 	TokenAdminRegistry string            `json:"token_admin_registry,omitempty"`
+	Version            string            `json:"version,omitempty"`
 }
 
 type SourceContracts struct {
@@ -82,6 +83,9 @@ func (l *LaneConfig) Validate() error {
 	}
 	if l.PriceRegistry == "" || !common.IsHexAddress(l.PriceRegistry) {
 		laneConfigError = multierr.Append(laneConfigError, errors.New("must set proper address for price_registry"))
+	}
+	if l.Version != "" && (l.TokenAdminRegistry == "" || !common.IsHexAddress(l.TokenAdminRegistry)) {
+		laneConfigError = multierr.Append(laneConfigError, errors.New("must set proper address for token_admin_registry"))
 	}
 	if l.WrappedNative == "" || !common.IsHexAddress(l.WrappedNative) {
 		laneConfigError = multierr.Append(laneConfigError, errors.New("must set proper address for wrapped_native"))

--- a/integration-tests/ccip-tests/contracts/laneconfig/parse_contracts.go
+++ b/integration-tests/ccip-tests/contracts/laneconfig/parse_contracts.go
@@ -83,9 +83,6 @@ func (l *LaneConfig) Validate() error {
 	if l.PriceRegistry == "" || !common.IsHexAddress(l.PriceRegistry) {
 		laneConfigError = multierr.Append(laneConfigError, errors.New("must set proper address for price_registry"))
 	}
-	if l.TokenAdminRegistry == "" || !common.IsHexAddress(l.TokenAdminRegistry) {
-		laneConfigError = multierr.Append(laneConfigError, errors.New("must set proper address for token_admin_registry"))
-	}
 	if l.WrappedNative == "" || !common.IsHexAddress(l.WrappedNative) {
 		laneConfigError = multierr.Append(laneConfigError, errors.New("must set proper address for wrapped_native"))
 	}

--- a/integration-tests/ccip-tests/testsetups/ccip.go
+++ b/integration-tests/ccip-tests/testsetups/ccip.go
@@ -762,7 +762,8 @@ func CCIPDefaultTestSetUp(
 	chainByChainID := setUpArgs.CreateEnvironment(lggr, envName, reportPath)
 	// if test is run in remote runner, register a clean-up to copy the laneconfig file
 	if value, set := os.LookupEnv(config.EnvVarJobImage); set && value != "" &&
-		(setUpArgs.Env != nil && setUpArgs.Env.K8Env != nil) {
+		(setUpArgs.Env != nil && setUpArgs.Env.K8Env != nil) &&
+		pointer.GetBool(setUpArgs.Cfg.TestGroupInput.StoreLaneConfig) {
 		t.Cleanup(func() {
 			path := fmt.Sprintf("reports/%s/%s", reportPath, reportFile)
 			dir, err := os.Getwd()

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -8,6 +8,7 @@ replace github.com/smartcontractkit/chainlink/v2 => ../
 require (
 	dario.cat/mergo v1.0.0
 	github.com/AlekSi/pointer v1.1.0
+	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df
 	github.com/cli/go-gh/v2 v2.0.0
 	github.com/ethereum/go-ethereum v1.13.8
@@ -86,7 +87,6 @@ require (
 	github.com/K-Phoen/sdk v0.12.4 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/Microsoft/hcsshim v0.11.4 // indirect


### PR DESCRIPTION
## Motivation
Make test compatible with previous contract versions

## Solution
Token Admin registry is only needed for version 1.5 and after. Added a check to validate the contract version.