### PR TITLE
Ccip 2060 use 1.2 ramps in upgrade tests

### DIFF
--- a/.github/workflows/ccip-offchain-upgrade-tests.yml
+++ b/.github/workflows/ccip-offchain-upgrade-tests.yml
@@ -256,7 +256,7 @@ jobs:
           # uncomment this later for next release
           # ENV_JOB_IMAGE: ${{ env.ENV_JOB_IMAGE_BASE }}:${{ env.RELEASE_SHA }}
           # for now we run test with a specific test image pertaining to previous release with some added fixes
-          ENV_JOB_IMAGE: ${{ env.ENV_JOB_IMAGE_BASE }}:test-updates-v2.9.1-ccip-1.4.0
+          ENV_JOB_IMAGE: ${{ env.ENV_JOB_IMAGE_BASE }}:release/v2.10.0-ccip1.4
           TEST_SUITE: smoke
           TEST_ARGS: -test.timeout 30m
           TEST_LOG_LEVEL: info

--- a/.github/workflows/ccip-offchain-upgrade-tests.yml
+++ b/.github/workflows/ccip-offchain-upgrade-tests.yml
@@ -256,7 +256,8 @@ jobs:
           # uncomment this later for next release
           # ENV_JOB_IMAGE: ${{ env.ENV_JOB_IMAGE_BASE }}:${{ env.RELEASE_SHA }}
           # for now we run test with a specific test image pertaining to previous release with some added fixes
-          ENV_JOB_IMAGE: ${{ env.ENV_JOB_IMAGE_BASE }}:release/v2.10.0-ccip1.4
+          # this image use 1.2 ramps instead of incompatible 1.5-dev ramps from offchain v2.10.0-ccip1.4-release
+          ENV_JOB_IMAGE: ${{ env.ENV_JOB_IMAGE_BASE }}:release-v2.10.0-ccip1.4
           TEST_SUITE: smoke
           TEST_ARGS: -test.timeout 30m
           TEST_LOG_LEVEL: info

--- a/integration-tests/ccip-tests/load/helper.go
+++ b/integration-tests/ccip-tests/load/helper.go
@@ -102,13 +102,22 @@ func (l *LoadArgs) setSchedule() {
 }
 
 func (l *LoadArgs) SanityCheck() {
+	var allLanes []*actions.CCIPLane
 	for _, lane := range l.TestSetupArgs.Lanes {
-		err := lane.ForwardLane.SendRequests(1, actions.DataOnlyTransfer, big.NewInt(600_000))
-		require.NoError(l.t, err)
-		lane.ForwardLane.ValidateRequests(true)
-		err = lane.ReverseLane.SendRequests(1, actions.DataOnlyTransfer, big.NewInt(600_000))
-		require.NoError(l.t, err)
-		lane.ReverseLane.ValidateRequests(true)
+		allLanes = append(allLanes, lane.ForwardLane)
+		if lane.ReverseLane != nil {
+			allLanes = append(allLanes, lane.ReverseLane)
+		}
+	}
+	for _, lane := range allLanes {
+		ccipLoad := NewCCIPLoad(
+			l.TestCfg.Test, lane,
+			l.TestCfg.TestGroupInput.PhaseTimeout.Duration(),
+			1, 0, nil,
+		)
+		ccipLoad.BeforeAllCall(l.TestCfg.TestGroupInput.MsgType, big.NewInt(*l.TestCfg.TestGroupInput.DestGasLimit))
+		resp := ccipLoad.Call(nil)
+		require.False(l.t, resp.Failed, "request failed in sanity check")
 	}
 }
 

--- a/integration-tests/ccip-tests/load/helper.go
+++ b/integration-tests/ccip-tests/load/helper.go
@@ -115,7 +115,7 @@ func (l *LoadArgs) SanityCheck() {
 			l.TestCfg.TestGroupInput.PhaseTimeout.Duration(),
 			1, 0, nil,
 		)
-		ccipLoad.BeforeAllCall(l.TestCfg.TestGroupInput.MsgType, big.NewInt(*l.TestCfg.TestGroupInput.DestGasLimit))
+		ccipLoad.BeforeAllCall(actions.DataOnlyTransfer, big.NewInt(*l.TestCfg.TestGroupInput.DestGasLimit))
 		resp := ccipLoad.Call(nil)
 		require.False(l.t, resp.Failed, "request failed in sanity check")
 	}


### PR DESCRIPTION
## Motivation
Onchain version in release v2.10.0-ccip1.4 is not compatible with offchain of recent ccip-develop

## Solution
Using custom test image which specifically uses 1.2 ramps as part of upgrade tests