### PR TITLE
add ci-kubeconform gha

### DIFF
--- a/.github/workflows/ccip-client-compatibility-tests.yml
+++ b/.github/workflows/ccip-client-compatibility-tests.yml
@@ -58,7 +58,7 @@ jobs:
 
   build-chainlink:
     if: needs.changes.outputs.src == 'true' || github.event_name == 'workflow_dispatch'
-    needs: [ changes ]
+    needs: [changes]
     environment: integration
     permissions:
       id-token: write
@@ -92,7 +92,7 @@ jobs:
 
   build-tests:
     if: needs.changes.outputs.src == 'true' || github.event_name == 'workflow_dispatch'
-    needs: [ changes ]
+    needs: [changes]
     environment: integration
     permissions:
       id-token: write
@@ -127,7 +127,7 @@ jobs:
 
   get-latest-available-images:
     if: needs.changes.outputs.src == 'true' || github.event_name == 'workflow_dispatch'
-    needs: [ changes ]
+    needs: [changes]
     environment: integration
     runs-on: ubuntu-latest
     permissions:
@@ -151,7 +151,7 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
         with:
-          mask-password: 'true'
+          mask-password: "true"
         env:
           AWS_REGION: ${{ secrets.QA_AWS_REGION }}
       - name: Get latest docker images from ECR
@@ -178,7 +178,7 @@ jobs:
       pull-requests: write
       id-token: write
       contents: read
-    needs: [ build-chainlink, changes, get-latest-available-images ]
+    needs: [build-chainlink, changes, get-latest-available-images]
     if: needs.changes.outputs.src == 'true' || github.event_name == 'workflow_dispatch'
     env:
       SELECTED_NETWORKS: SIMULATED_1,SIMULATED_2
@@ -304,7 +304,7 @@ jobs:
       id-token: write
       contents: read
     runs-on: ubuntu-latest
-    needs: [ evm-compatibility-matrix, changes ]
+    needs: [evm-compatibility-matrix, changes]
     steps:
       - name: Debug Result
         run: echo ${{ join(needs.*.result, ',') }}
@@ -361,7 +361,7 @@ jobs:
       id-token: write
       contents: read
     runs-on: ubuntu-latest
-    needs: [ start-slack-thread ]
+    needs: [changes, start-slack-thread]
     steps:
       - name: Checkout the repo
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2

--- a/.github/workflows/ccip-client-compatibility-tests.yml
+++ b/.github/workflows/ccip-client-compatibility-tests.yml
@@ -353,7 +353,7 @@ jobs:
 
   post-test-results-to-slack:
     name: Post Test Results for ${{matrix.client}}
-    if: ${{ always() && needs.*.result != 'skipped' && needs.*.result != 'cancelled' }}
+    if: ${{ always() && needs.changes.outputs.src == 'true' && needs.*.result != 'skipped' && needs.*.result != 'cancelled' }}
     environment: integration
     permissions:
       checks: write

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -9,24 +9,29 @@ on:
 jobs:
   ci-lint-helm-charts:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-      actions: read
     steps:
-      - name: Add repositories
-        run: |
-          helm repo add mockserver https://www.mock-server.com
-          helm repo add opentelemetry-collector https://open-telemetry.github.io/opentelemetry-helm-charts
-          helm repo add tempo https://grafana.github.io/helm-charts
-          helm repo add grafana https://grafana.github.io/helm-charts
       - name: ci-lint-helm-charts
-        uses: smartcontractkit/.github/actions/ci-lint-charts@6b08487b176ef7cad086526d0b54ddff6691c044 # ci-lint-charts@0.1.2
+        uses: smartcontractkit/.github/actions/ci-lint-charts@7fa39741b11e66ed59f8aad786d4b9356c389f3f # ci-lint-charts@0.2.0
         with:
           # chart testing inputs
           chart-testing-extra-args: "--lint-conf=lintconf.yaml"
+          charts-dir: charts/chainlink-cluster
           # grafana inputs
           metrics-job-name: ci-lint-helm-charts
+          gc-basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
+          gc-host: ${{ secrets.GRAFANA_INTERNAL_HOST }}
+          gc-org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
+
+  ci-kubeconform:
+    runs-on: ubuntu-latest
+    steps:
+      - name: ci-kubeconform
+        uses: smartcontractkit/.github/actions/ci-kubeconform@7fa39741b11e66ed59f8aad786d4b9356c389f3f # ci-kubeconform@0.1.0
+        with:
+          # kubeform inputs
+          charts-dir: charts/chainlink-cluster
+          # grafana inputs
+          metrics-job-name: ci-kubeconform
           gc-basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
           gc-host: ${{ secrets.GRAFANA_INTERNAL_HOST }}
           gc-org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ci-kubeconform
-        uses: smartcontractkit/.github/actions/ci-kubeconform@7fa39741b11e66ed59f8aad786d4b9356c389f3f # ci-kubeconform@0.1.0
+        uses: smartcontractkit/.github/actions/ci-kubeconform@1ae8a9a984814c4daf50aa96f03be2cba0ef3fec # ci-kubeconform@0.2.0
         with:
           # kubeform inputs
           charts-dir: charts/chainlink-cluster


### PR DESCRIPTION
This adds a new CI check called `ci-kubeconform` to validate k8s manifests as well as refactor the `ci-lint-helm-charts` workflow to have the `add helm repos` inside the .github action instead.
