### PR TITLE
Public HashLeaf Function

### DIFF
--- a/.changeset/good-countries-remain.md
+++ b/.changeset/good-countries-remain.md
@@ -2,4 +2,4 @@
 "ccip": minor
 ---
 
-A factory to provide access to the internal HashLeaf functions.
+#added A factory to provide access to the internal HashLeaf functions.

--- a/.changeset/good-countries-remain.md
+++ b/.changeset/good-countries-remain.md
@@ -1,0 +1,5 @@
+---
+"ccip": minor
+---
+
+A factory to provide access to the internal HashLeaf functions.

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/factory/onramp.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/factory/onramp.go
@@ -80,6 +80,8 @@ func initOrCloseOnRampReader(lggr logger.Logger, versionFinder VersionFinder, so
 			return nil, onRamp.Close()
 		}
 		return onRamp, onRamp.RegisterFilters()
+	// Adding a new version?
+	// Please update the public factory function in leafer.go if the new version updates the leaf hash function.
 	default:
 		return nil, errors.Errorf("unsupported onramp version %v", version.String())
 	}

--- a/core/services/ocr2/plugins/ccip/pkg/leafer/leafer.go
+++ b/core/services/ocr2/plugins/ccip/pkg/leafer/leafer.go
@@ -31,28 +31,28 @@ const (
 )
 
 // MakeLeafHasher is a factory function to construct the onramp implementing the HashLeaf function for a given version.
-func MakeLeafHasher(ver HasherVersion, cl bind.ContractBackend, sourceChainSelector uint64, destChainSelector uint64, onRampId common.Address) (LeafHasher, error) {
+func MakeLeafHasher(ctx hashlib.Ctx[[32]byte], ver HasherVersion, cl bind.ContractBackend, onRampId common.Address, sourceChainSelector uint64, destChainSelector uint64) (LeafHasher, error) {
 	switch ver {
 	case V1_0_0:
 		or, err := evm_2_evm_onramp_1_0_0.NewEVM2EVMOnRamp(onRampId, cl)
 		if err != nil {
 			return nil, err
 		}
-		h := v1_0_0.NewLeafHasher(sourceChainSelector, destChainSelector, onRampId, hashlib.NewKeccakCtx(), or)
+		h := v1_0_0.NewLeafHasher(sourceChainSelector, destChainSelector, onRampId, ctx, or)
 		return h, nil
 	case V1_2_0:
 		or, err := evm_2_evm_onramp_1_2_0.NewEVM2EVMOnRamp(onRampId, cl)
 		if err != nil {
 			return nil, err
 		}
-		h := v1_2_0.NewLeafHasher(sourceChainSelector, destChainSelector, onRampId, hashlib.NewKeccakCtx(), or)
+		h := v1_2_0.NewLeafHasher(sourceChainSelector, destChainSelector, onRampId, ctx, or)
 		return h, nil
 	case V1_5_0:
 		or, err := evm_2_evm_onramp.NewEVM2EVMOnRamp(onRampId, cl)
 		if err != nil {
 			return nil, err
 		}
-		h := v1_5_0.NewLeafHasher(sourceChainSelector, destChainSelector, onRampId, hashlib.NewKeccakCtx(), or)
+		h := v1_5_0.NewLeafHasher(sourceChainSelector, destChainSelector, onRampId, ctx, or)
 		return h, nil
 	default:
 		return nil, fmt.Errorf("unknown version %q", ver)

--- a/core/services/ocr2/plugins/ccip/pkg/leafer/leafer.go
+++ b/core/services/ocr2/plugins/ccip/pkg/leafer/leafer.go
@@ -31,7 +31,7 @@ const (
 )
 
 // MakeLeafHasher is a factory function to construct the onramp implementing the HashLeaf function for a given version.
-func MakeLeafHasher(ctx hashlib.Ctx[[32]byte], ver HasherVersion, cl bind.ContractBackend, onRampId common.Address, sourceChainSelector uint64, destChainSelector uint64) (LeafHasher, error) {
+func MakeLeafHasher(ver HasherVersion, cl bind.ContractBackend, sourceChainSelector uint64, destChainSelector uint64, onRampId common.Address, ctx hashlib.Ctx[[32]byte]) (LeafHasher, error) {
 	switch ver {
 	case V1_0_0:
 		or, err := evm_2_evm_onramp_1_0_0.NewEVM2EVMOnRamp(onRampId, cl)

--- a/core/services/ocr2/plugins/ccip/pkg/leafer/leafer.go
+++ b/core/services/ocr2/plugins/ccip/pkg/leafer/leafer.go
@@ -21,17 +21,17 @@ type LeafHasher interface {
 	HashLeaf(log types.Log) ([32]byte, error)
 }
 
-// HasherVersion maps to the contract versions.
-type HasherVersion string
+// Version is the contract to use.
+type Version string
 
 const (
-	V1_0_0 HasherVersion = "v1_0_0"
-	V1_2_0 HasherVersion = "v1_2_0"
-	V1_5_0 HasherVersion = "v1_5_0"
+	V1_0_0 Version = "v1_0_0"
+	V1_2_0 Version = "v1_2_0"
+	V1_5_0 Version = "v1_5_0"
 )
 
 // MakeLeafHasher is a factory function to construct the onramp implementing the HashLeaf function for a given version.
-func MakeLeafHasher(ver HasherVersion, cl bind.ContractBackend, sourceChainSelector uint64, destChainSelector uint64, onRampId common.Address, ctx hashlib.Ctx[[32]byte]) (LeafHasher, error) {
+func MakeLeafHasher(ver Version, cl bind.ContractBackend, sourceChainSelector uint64, destChainSelector uint64, onRampId common.Address, ctx hashlib.Ctx[[32]byte]) (LeafHasher, error) {
 	switch ver {
 	case V1_0_0:
 		or, err := evm_2_evm_onramp_1_0_0.NewEVM2EVMOnRamp(onRampId, cl)

--- a/core/services/ocr2/plugins/ccip/pkg/leafer/leafer.go
+++ b/core/services/ocr2/plugins/ccip/pkg/leafer/leafer.go
@@ -1,0 +1,60 @@
+package leafer
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/evm_2_evm_onramp"
+	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/evm_2_evm_onramp_1_0_0"
+	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/evm_2_evm_onramp_1_2_0"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_0_0"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_2_0"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_5_0"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/pkg/hashlib"
+)
+
+// LeafHasher converts a CCIPSendRequested event into something that can be hashed and hashes it.
+type LeafHasher interface {
+	HashLeaf(log types.Log) ([32]byte, error)
+}
+
+// HasherVersion maps to the contract versions.
+type HasherVersion string
+
+const (
+	V1_0_0 HasherVersion = "v1_0_0"
+	V1_2_0 HasherVersion = "v1_2_0"
+	V1_5_0 HasherVersion = "v1_5_0"
+)
+
+// MakeLeafHasher is a factory function to construct the onramp implementing the HashLeaf function for a given version.
+func MakeLeafHasher(ver HasherVersion, cl bind.ContractBackend, sourceChainSelector uint64, destChainSelector uint64, onRampId common.Address) (LeafHasher, error) {
+	switch ver {
+	case V1_0_0:
+		or, err := evm_2_evm_onramp_1_0_0.NewEVM2EVMOnRamp(onRampId, cl)
+		if err != nil {
+			return nil, err
+		}
+		h := v1_0_0.NewLeafHasher(sourceChainSelector, destChainSelector, onRampId, hashlib.NewKeccakCtx(), or)
+		return h, nil
+	case V1_2_0:
+		or, err := evm_2_evm_onramp_1_2_0.NewEVM2EVMOnRamp(onRampId, cl)
+		if err != nil {
+			return nil, err
+		}
+		h := v1_2_0.NewLeafHasher(sourceChainSelector, destChainSelector, onRampId, hashlib.NewKeccakCtx(), or)
+		return h, nil
+	case V1_5_0:
+		or, err := evm_2_evm_onramp.NewEVM2EVMOnRamp(onRampId, cl)
+		if err != nil {
+			return nil, err
+		}
+		h := v1_5_0.NewLeafHasher(sourceChainSelector, destChainSelector, onRampId, hashlib.NewKeccakCtx(), or)
+		return h, nil
+	default:
+		return nil, fmt.Errorf("unknown version %q", ver)
+	}
+}


### PR DESCRIPTION
## Motivation

Reusing the HashLeaf function in a separate repository.

It also allows re-using the HashLeaf function in [the manual-execution app](https://github.com/smartcontractkit/ccip/blob/6ec74ddc55a5ee8d6618aa714101d777f1bddcde/core/scripts/ccip/manual-execution/helpers/execReport.go).

## Solution

A factory function to provide access to the internal HashLeaf functions.