### PR TITLE
initialize ccip ocr3 execute plugin

### DIFF
--- a/.changeset/hip-dingos-shout.md
+++ b/.changeset/hip-dingos-shout.md
@@ -1,0 +1,5 @@
+---
+"ccip": minor
+---
+
+initialize ccip ocr3 execute plugin

--- a/core/services/ocr3/plugins/ccip/execute/factory.go
+++ b/core/services/ocr3/plugins/ccip/execute/factory.go
@@ -1,0 +1,70 @@
+package commit
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+)
+
+// PluginFactoryConstructor implements common OCR3ReportingPluginClient and is used for initializing a plugin factory
+// and a validation service.
+type PluginFactoryConstructor struct{}
+
+func NewPluginFactoryConstructor() *PluginFactoryConstructor {
+	return &PluginFactoryConstructor{}
+}
+func (p PluginFactoryConstructor) NewReportingPluginFactory(
+	ctx context.Context,
+	config types.ReportingPluginServiceConfig,
+	grpcProvider grpc.ClientConnInterface,
+	pipelineRunner types.PipelineRunnerService,
+	telemetry types.TelemetryService,
+	errorLog types.ErrorLog,
+	capRegistry types.CapabilitiesRegistry,
+	keyValueStore types.KeyValueStore,
+) (types.OCR3ReportingPluginFactory, error) {
+	return NewPluginFactory(), nil
+}
+
+func (p PluginFactoryConstructor) NewValidationService(ctx context.Context) (types.ValidationService, error) {
+	panic("implement me")
+}
+
+// PluginFactory implements common ReportingPluginFactory and is used for (re-)initializing commit plugin instances.
+type PluginFactory struct{}
+
+func NewPluginFactory() *PluginFactory {
+	return &PluginFactory{}
+}
+
+func (p PluginFactory) NewReportingPlugin(config ocr3types.ReportingPluginConfig) (ocr3types.ReportingPlugin[[]byte], ocr3types.ReportingPluginInfo, error) {
+	return NewPlugin(), ocr3types.ReportingPluginInfo{}, nil
+}
+
+func (p PluginFactory) Name() string {
+	panic("implement me")
+}
+
+func (p PluginFactory) Start(ctx context.Context) error {
+	panic("implement me")
+}
+
+func (p PluginFactory) Close() error {
+	panic("implement me")
+}
+
+func (p PluginFactory) Ready() error {
+	panic("implement me")
+}
+
+func (p PluginFactory) HealthReport() map[string]error {
+	panic("implement me")
+}
+
+// Interface compatibility checks.
+var _ types.OCR3ReportingPluginClient = &PluginFactoryConstructor{}
+var _ types.OCR3ReportingPluginFactory = &PluginFactory{}

--- a/core/services/ocr3/plugins/ccip/execute/plugin.go
+++ b/core/services/ocr3/plugins/ccip/execute/plugin.go
@@ -1,0 +1,54 @@
+package commit
+
+import (
+	"context"
+
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+)
+
+// Plugin implements the main ocr3 plugin logic.
+type Plugin struct{}
+
+func NewPlugin() *Plugin {
+	return &Plugin{}
+}
+
+func (p *Plugin) Query(ctx context.Context, outctx ocr3types.OutcomeContext) (types.Query, error) {
+	panic("implement me")
+}
+
+func (p *Plugin) Observation(ctx context.Context, outctx ocr3types.OutcomeContext, query types.Query) (types.Observation, error) {
+	panic("implement me")
+}
+
+func (p *Plugin) ValidateObservation(outctx ocr3types.OutcomeContext, query types.Query, ao types.AttributedObservation) error {
+	panic("implement me")
+}
+
+func (p *Plugin) ObservationQuorum(outctx ocr3types.OutcomeContext, query types.Query) (ocr3types.Quorum, error) {
+	panic("implement me")
+}
+
+func (p *Plugin) Outcome(outctx ocr3types.OutcomeContext, query types.Query, aos []types.AttributedObservation) (ocr3types.Outcome, error) {
+	panic("implement me")
+}
+
+func (p *Plugin) Reports(seqNr uint64, outcome ocr3types.Outcome) ([]ocr3types.ReportWithInfo[[]byte], error) {
+	panic("implement me")
+}
+
+func (p *Plugin) ShouldAcceptAttestedReport(ctx context.Context, u uint64, r ocr3types.ReportWithInfo[[]byte]) (bool, error) {
+	panic("implement me")
+}
+
+func (p *Plugin) ShouldTransmitAcceptedReport(ctx context.Context, u uint64, r ocr3types.ReportWithInfo[[]byte]) (bool, error) {
+	panic("implement me")
+}
+
+func (p *Plugin) Close() error {
+	panic("implement me")
+}
+
+// Interface compatibility checks.
+var _ ocr3types.ReportingPlugin[[]byte] = &Plugin{}

--- a/core/services/ocr3/plugins/ccip/internal/model/execute.go
+++ b/core/services/ocr3/plugins/ccip/internal/model/execute.go
@@ -1,0 +1,4 @@
+package model
+
+// ExecutePluginReport is placed here for reference of shared readers structure.
+type ExecutePluginReport struct{}

--- a/core/services/ocr3/plugins/ccip/internal/reader/offramp.go
+++ b/core/services/ocr3/plugins/ccip/internal/reader/offramp.go
@@ -1,0 +1,4 @@
+package reader
+
+// OffRamp is placed here for reference of shared readers structure.
+type OffRamp interface{}


### PR DESCRIPTION
The execute version of https://github.com/smartcontractkit/ccip/pull/715.
Adding an empty implementation for the execute plugin.