### PR TITLE
Fix multi-line string in template for CRIB config map

### DIFF
--- a/charts/chainlink-cluster/templates/chainlink-cm.yaml
+++ b/charts/chainlink-cluster/templates/chainlink-cm.yaml
@@ -60,7 +60,7 @@ data:
     [WebServer.TLS]
     HTTPSPort = 0
     {{- end }}
-  overrides.toml: |-
+  overrides.toml: |
   {{- if (hasKey $cfg "overridesToml") }}
   {{- $cfg.overridesToml | nindent 4 }}
   {{- else if and (hasKey $.Values.chainlink.global "overridesToml") $.Values.chainlink.global.overridesToml }}


### PR DESCRIPTION
## Motivation

Fix an error with toml config being in a format where the node could not read.


## Solution

Using `|` as the multi-line yaml operator seemed to fix the issue.