### PR TITLE
Add check_env_vars script for required env vars

### DIFF
--- a/crib/devspace.yaml
+++ b/crib/devspace.yaml
@@ -71,6 +71,8 @@ images:
         MACOS_SDK_DIR=$(pwd)/tools/bin/MacOSX12.3.sdk IMAGE=$image ./tools/bin/goreleaser_wrapper release --snapshot --clean --config .goreleaser.devspace.yaml
         docker push $image
 hooks:
+  - command: ./scripts/check_env_vars.sh
+    events: ["before:deploy:app"]
   - wait:
       running: true
       terminatedWithCode: 0

--- a/crib/scripts/check_env_vars.sh
+++ b/crib/scripts/check_env_vars.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# List of required environment variables
+required_vars=(
+  "DEVSPACE_IMAGE"
+  "DEVSPACE_INGRESS_CIDRS"
+  "DEVSPACE_INGRESS_BASE_DOMAIN"
+  "DEVSPACE_INGRESS_CERT_ARN"
+  "DEVSPACE_K8S_POD_WAIT_TIMEOUT"
+  "CHAINLINK_CLUSTER_HELM_CHART_URI"
+  "NS_TTL"
+  "DEVSPACE_CCIP_SCRIPTS_IMAGE"
+  "DEVSPACE_CCIP_SCRIPTS_OIDC_ROLE_ARN"
+  "DEVSPACE_CCIP_SCRIPTS_OUTPUT_BUCKET_NAME"
+  )
+
+missing_vars=0  # Counter for missing variables
+
+# Check each variable
+for var in "${required_vars[@]}"; do
+  if [ -z "${!var}" ]; then  # If variable is unset or empty
+    echo "Error: Environment variable $var is not set."
+    missing_vars=$((missing_vars + 1))
+  fi
+done
+
+# Exit with an error if any variables were missing
+if [ $missing_vars -ne 0 ]; then
+  echo "Total missing environment variables: $missing_vars"
+  echo "To fix it, add missing variables in the \"crib/.env\" file."
+  echo "you can find example of the .env config in the \"crib/.env.example\""
+  exit 1
+else
+  echo "All required environment variables are set."
+fi


### PR DESCRIPTION
## Motivation

Want to check for required env vars used by devspace.

## Solution

Add a script similar to [what's on /chainlink](https://github.com/smartcontractkit/chainlink/blob/develop/crib/scripts/check_env_vars.sh) -- with some additional env vars.