### PR TITLE
Disable ccip scripts with local-dev profile

### DIFF
--- a/crib/devspace.yaml
+++ b/crib/devspace.yaml
@@ -401,3 +401,6 @@ profiles:
       - op: add
         path: deployments.app.helm.valuesFiles
         value: ["../charts/chainlink-cluster/values-profiles/values-dev.yaml"]
+      - op: replace
+        path: deployments.app.helm.values.ccip-scripts.ccipScriptsDeployment.enabled
+        value: false


### PR DESCRIPTION
## Motivation

We don't want ccip-scripts to deploy when using local-dev profile in devspace.

## Solution

Override the value to disable ccip-scripts.