### PR TITLE
fix failing db compatibility test

### DIFF
--- a/integration-tests/ccip-tests/testconfig/tomls/db-compatibility.toml
+++ b/integration-tests/ccip-tests/testconfig/tomls/db-compatibility.toml
@@ -27,3 +27,8 @@ DBTag = '14.8'
 Name = 'node5'
 DBImage = 'postgres'
 DBTag = '15.6'
+
+[[CCIP.Env.NewCLCluster.Nodes]]
+Name = 'node6'
+DBImage = 'postgres'
+DBTag = '15.6'


### PR DESCRIPTION
## Motivation

[ETH Smoke Tests ccip-smoke-db-compatibility](https://github.com/smartcontractkit/ccip/actions/runs/8908125787/job/24463336085?pr=756#logs) is failing

## Solution

Fix the TOML config for db-compatibility test.
This was removed in https://github.com/smartcontractkit/ccip/commit/aa3b21961e280cb29d9e9e0baa5c670f1a6452fa