### PR TITLE
Median liquidity per chain fault tolerance validation

### DIFF
--- a/.changeset/beige-tables-visit.md
+++ b/.changeset/beige-tables-visit.md
@@ -1,0 +1,5 @@
+---
+"ccip": patch
+---
+
+Validate bft (f+1) for observed liquidity per chain

--- a/core/services/ocr2/plugins/liquiditymanager/rebalcalc/consensus_test.go
+++ b/core/services/ocr2/plugins/liquiditymanager/rebalcalc/consensus_test.go
@@ -64,6 +64,32 @@ func TestMedianLiquidityPerChain(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"below bft",
+			args{[]models.Observation{
+				{
+					LiquidityPerChain: []models.NetworkLiquidity{
+						{Network: 1, Liquidity: ubig.NewI(1)},
+						{Network: 2, Liquidity: ubig.NewI(2)},
+					},
+				},
+				{
+					LiquidityPerChain: []models.NetworkLiquidity{
+						{Network: 3, Liquidity: ubig.NewI(2)},
+						{Network: 3, Liquidity: ubig.NewI(6)},
+					},
+				},
+				{
+					LiquidityPerChain: []models.NetworkLiquidity{
+						{Network: 3, Liquidity: ubig.NewI(4)},
+					},
+				},
+			}, 1},
+			[]models.NetworkLiquidity{
+				{Network: 3, Liquidity: ubig.NewI(4)},
+			},
+			false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Motivation

Currently, we don’t count values of the reported liquidity in each observation to ensure we have at least f+1 values for each chain, which means that we fail the case of empty values (e.g. an oracle that fails to get the values).

## Solution

Count liquidities reported for each chain and ensure the count exceeds the minimum fault tolerance threshold (f+1).