### PR TITLE
Sync liquidity graph once on startup

### DIFF
--- a/.changeset/neat-birds-smash.md
+++ b/.changeset/neat-birds-smash.md
@@ -1,0 +1,5 @@
+---
+"ccip": patch
+---
+
+Sync liquidity graph only once on startup and cache the liquidity graphs in the plugin, upon Observation call discoverer to update balances.

--- a/core/services/ocr2/plugins/liquiditymanager/discoverer/discoverer.go
+++ b/core/services/ocr2/plugins/liquiditymanager/discoverer/discoverer.go
@@ -23,7 +23,10 @@ type Factory interface {
 
 //go:generate mockery --quiet --name Discoverer --output ./mocks --filename discoverer_mock.go --case=underscore
 type Discoverer interface {
+	// Discover fetches the entire graph
 	Discover(ctx context.Context) (graph.Graph, error)
+	// DiscoverBalances fetch only the balances rather building the entire graph
+	DiscoverBalances(context.Context, graph.Graph) error
 }
 
 type evmDep struct {

--- a/core/services/ocr2/plugins/liquiditymanager/discoverer/mocks/discoverer_mock.go
+++ b/core/services/ocr2/plugins/liquiditymanager/discoverer/mocks/discoverer_mock.go
@@ -45,6 +45,24 @@ func (_m *Discoverer) Discover(ctx context.Context) (graph.Graph, error) {
 	return r0, r1
 }
 
+// DiscoverBalances provides a mock function with given fields: _a0, _a1
+func (_m *Discoverer) DiscoverBalances(_a0 context.Context, _a1 graph.Graph) error {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DiscoverBalances")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, graph.Graph) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // NewDiscoverer creates a new instance of Discoverer. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewDiscoverer(t interface {

--- a/core/services/ocr2/plugins/liquiditymanager/factory.go
+++ b/core/services/ocr2/plugins/liquiditymanager/factory.go
@@ -69,13 +69,18 @@ func (p PluginFactory) NewReportingPlugin(config ocr3types.ReportingPluginConfig
 		closePluginTimeout = time.Duration(p.config.ClosePluginTimeoutSec) * time.Second
 	}
 
+	discoverer, err := p.discovererFactory.NewDiscoverer(p.config.LiquidityManagerNetwork, p.config.LiquidityManagerAddress)
+	if err != nil {
+		return nil, ocr3types.ReportingPluginInfo{}, fmt.Errorf("init discoverer: %w", err)
+	}
+
 	return NewPlugin(
 			config.F,
 			closePluginTimeout,
 			p.config.LiquidityManagerNetwork,
 			p.config.LiquidityManagerAddress,
 			p.lmFactory,
-			p.discovererFactory,
+			discoverer,
 			p.bridgeFactory,
 			liquidityRebalancer,
 			liquiditymanager.NewEvmReportCodec(),

--- a/core/services/ocr2/plugins/liquiditymanager/plugin.go
+++ b/core/services/ocr2/plugins/liquiditymanager/plugin.go
@@ -483,7 +483,7 @@ func (p *Plugin) syncGraph(ctx context.Context) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	if p.liquidityGraph == nil {
+	if p.liquidityGraph.IsEmpty() {
 		if err := p.syncGraphEdges(ctx); err != nil {
 			return fmt.Errorf("sync graph edges: %w", err)
 		}

--- a/core/services/ocr2/plugins/liquiditymanager/plugin.go
+++ b/core/services/ocr2/plugins/liquiditymanager/plugin.go
@@ -27,14 +27,12 @@ import (
 
 type Plugin struct {
 	f                       int
-	rootNetwork             models.NetworkSelector
-	rootAddress             models.Address
 	closePluginTimeout      time.Duration
 	liquidityManagerFactory evmliquiditymanager.Factory
-	discovererFactory       discoverer.Factory
+	discoverer              discoverer.Discoverer
 	bridgeFactory           bridge.Factory
 	mu                      sync.RWMutex
-	rebalancerGraph         graph.Graph
+	liquidityGraph          graph.Graph
 	liquidityRebalancer     liquidityrebalancer.Rebalancer
 	inflight                inflight.Container
 	lggr                    logger.Logger
@@ -47,7 +45,7 @@ func NewPlugin(
 	rootNetwork models.NetworkSelector,
 	rootAddress models.Address,
 	liquidityManagerFactory evmliquiditymanager.Factory,
-	discovererFactory discoverer.Factory,
+	discoverer discoverer.Discoverer,
 	bridgeFactory bridge.Factory,
 	liquidityRebalancer liquidityrebalancer.Rebalancer,
 	reportCodec evmliquiditymanager.OnchainReportCodec,
@@ -55,13 +53,11 @@ func NewPlugin(
 ) *Plugin {
 	return &Plugin{
 		f:                       f,
-		rootNetwork:             rootNetwork,
-		rootAddress:             rootAddress,
 		closePluginTimeout:      closePluginTimeout,
 		liquidityManagerFactory: liquidityManagerFactory,
-		discovererFactory:       discovererFactory,
 		bridgeFactory:           bridgeFactory,
-		rebalancerGraph:         graph.NewGraph(),
+		discoverer:              discoverer,
+		liquidityGraph:          graph.NewGraph(),
 		liquidityRebalancer:     liquidityRebalancer,
 		inflight:                inflight.New(),
 		reportCodec:             reportCodec,
@@ -84,8 +80,8 @@ func (p *Plugin) Observation(ctx context.Context, outcomeCtx ocr3types.OutcomeCo
 	}
 
 	networkLiquidities := make([]models.NetworkLiquidity, 0)
-	for _, net := range p.rebalancerGraph.GetNetworks() {
-		liq, err := p.rebalancerGraph.GetLiquidity(net)
+	for _, net := range p.liquidityGraph.GetNetworks() {
+		liq, err := p.liquidityGraph.GetLiquidity(net)
 		if err != nil {
 			return ocrtypes.Observation{}, err
 		}
@@ -100,7 +96,7 @@ func (p *Plugin) Observation(ctx context.Context, outcomeCtx ocr3types.OutcomeCo
 	numExpired := p.inflight.Expire(pendingTransfers)
 	inflightTransfers := p.inflight.GetAll()
 
-	edges, err := p.rebalancerGraph.GetEdges()
+	edges, err := p.liquidityGraph.GetEdges()
 	if err != nil {
 		return ocrtypes.Observation{}, fmt.Errorf("get edges: %w", err)
 	}
@@ -111,8 +107,8 @@ func (p *Plugin) Observation(ctx context.Context, outcomeCtx ocr3types.OutcomeCo
 	}
 
 	configDigests := make([]models.ConfigDigestWithMeta, 0)
-	for _, net := range p.rebalancerGraph.GetNetworks() {
-		data, err := p.rebalancerGraph.GetData(net)
+	for _, net := range p.liquidityGraph.GetNetworks() {
+		data, err := p.liquidityGraph.GetData(net)
 		if err != nil {
 			return nil, fmt.Errorf("get rb %d data: %w", net, err)
 		}
@@ -285,7 +281,7 @@ func (p *Plugin) Reports(seqNr uint64, outcome ocr3types.Outcome) ([]ocr3types.R
 	var reports []ocr3types.ReportWithInfo[models.Report]
 	for networkID, transfers := range incomingAndOutgoing {
 		// todo: we shouldn't use plugin state
-		rebalancerAddress, err := p.rebalancerGraph.GetRebalancerAddress(networkID)
+		rebalancerAddress, err := p.liquidityGraph.GetRebalancerAddress(networkID)
 		if err != nil {
 			return nil, fmt.Errorf("liquidity manager for %v does not exist", networkID)
 		}
@@ -444,10 +440,10 @@ func (p *Plugin) Close() error {
 	defer cf()
 
 	var errs []error
-	for _, networkID := range p.rebalancerGraph.GetNetworks() {
+	for _, networkID := range p.liquidityGraph.GetNetworks() {
 		p.lggr.Infow("closing liquidityManager network", "network", networkID)
 
-		liquidityManagerAddress, err := p.rebalancerGraph.GetRebalancerAddress(networkID)
+		liquidityManagerAddress, err := p.liquidityGraph.GetRebalancerAddress(networkID)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("get liquidityManager address for %d: %w", networkID, err))
 			continue
@@ -470,28 +466,34 @@ func (p *Plugin) Close() error {
 	return multierr.Combine(errs...)
 }
 
+func (p *Plugin) syncGraphEdges(ctx context.Context) error {
+	p.lggr.Infow("syncing graph edges")
+	// todo: discoverer factory is not required we can pass a discoverer instance to the plugin
+	p.lggr.Infow("discovering liquidity managers")
+	g, err := p.discoverer.Discover(ctx)
+	if err != nil {
+		return fmt.Errorf("discovering rebalancers: %w", err)
+	}
+	p.lggr.Infow("finished syncing graph edges", "graph", g.String())
+	p.liquidityGraph = g
+	return nil
+}
+
 func (p *Plugin) syncGraph(ctx context.Context) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	p.lggr.Infow("syncing graph edges")
-
-	// todo: discoverer factory is not required we can pass a discoverer instance to the plugin
-	p.lggr.Infow("discovering rebalancers")
-	discoverer, err := p.discovererFactory.NewDiscoverer(p.rootNetwork, p.rootAddress)
-	if err != nil {
-		return fmt.Errorf("init discoverer: %w", err)
+	if p.liquidityGraph == nil {
+		if err := p.syncGraphEdges(ctx); err != nil {
+			return fmt.Errorf("sync graph edges: %w", err)
+		}
+	} else {
+		p.lggr.Infow("syncing graph liquidities")
+		if err := p.discoverer.DiscoverBalances(ctx, p.liquidityGraph); err != nil {
+			return fmt.Errorf("discovering balances: %w", err)
+		}
+		p.lggr.Infow("finished syncing graph liquidities")
 	}
-
-	// todo: discoverer should immediately return without making any rpc calls if there wasn't any change
-	g, err := discoverer.Discover(ctx)
-	if err != nil {
-		return fmt.Errorf("discovering rebalancers: %w", err)
-	}
-
-	p.rebalancerGraph = g
-
-	p.lggr.Infow("finished syncing graph edges", "graph", g.String())
 
 	return nil
 }
@@ -500,7 +502,7 @@ func (p *Plugin) loadPendingTransfers(ctx context.Context, lggr logger.Logger) (
 	p.lggr.Infow("loading pending transfers")
 
 	pendingTransfers := make([]models.PendingTransfer, 0)
-	edges, err := p.rebalancerGraph.GetEdges()
+	edges, err := p.liquidityGraph.GetEdges()
 	if err != nil {
 		return nil, fmt.Errorf("get edges: %w", err)
 	}
@@ -515,11 +517,11 @@ func (p *Plugin) loadPendingTransfers(ctx context.Context, lggr logger.Logger) (
 			continue
 		}
 
-		localToken, err := p.rebalancerGraph.GetTokenAddress(edge.Source)
+		localToken, err := p.liquidityGraph.GetTokenAddress(edge.Source)
 		if err != nil {
 			return nil, fmt.Errorf("get local token address for %v: %w", edge.Source, err)
 		}
-		remoteToken, err := p.rebalancerGraph.GetTokenAddress(edge.Dest)
+		remoteToken, err := p.liquidityGraph.GetTokenAddress(edge.Dest)
 		if err != nil {
 			return nil, fmt.Errorf("get remote token address for %v: %w", edge.Dest, err)
 		}
@@ -655,22 +657,22 @@ func (p *Plugin) resolveProposedTransfers(ctx context.Context, lggr logger.Logge
 			return nil, fmt.Errorf("init bridge: %w", err)
 		}
 
-		fromNetRebalancer, err := p.rebalancerGraph.GetRebalancerAddress(proposedTransfer.From)
+		fromNetRebalancer, err := p.liquidityGraph.GetRebalancerAddress(proposedTransfer.From)
 		if err != nil {
 			return nil, fmt.Errorf("get liquidityManager address for %v: %w", proposedTransfer.From, err)
 		}
 
-		fromNetToken, err := p.rebalancerGraph.GetTokenAddress(proposedTransfer.From)
+		fromNetToken, err := p.liquidityGraph.GetTokenAddress(proposedTransfer.From)
 		if err != nil {
 			return nil, fmt.Errorf("get token address for %v: %w", proposedTransfer.From, err)
 		}
 
-		toNetRebalancer, err := p.rebalancerGraph.GetRebalancerAddress(proposedTransfer.To)
+		toNetRebalancer, err := p.liquidityGraph.GetRebalancerAddress(proposedTransfer.To)
 		if err != nil {
 			return nil, fmt.Errorf("get liquidityManager address for %v: %w", proposedTransfer.To, err)
 		}
 
-		toNetToken, err := p.rebalancerGraph.GetTokenAddress(proposedTransfer.To)
+		toNetToken, err := p.liquidityGraph.GetTokenAddress(proposedTransfer.To)
 		if err != nil {
 			return nil, fmt.Errorf("get token address for %v: %w", proposedTransfer.To, err)
 		}

--- a/core/services/ocr2/plugins/liquiditymanager/plugin_test.go
+++ b/core/services/ocr2/plugins/liquiditymanager/plugin_test.go
@@ -277,11 +277,13 @@ func TestPlugin_Observation(t *testing.T) {
 			mockDiscoverer := discoverermocks.NewDiscoverer(t)
 			p.discovererFactory.
 				On("NewDiscoverer", mock.Anything, mock.Anything).
-				Return(mockDiscoverer, nil)
+				Return(mockDiscoverer, nil).Maybe()
 			g, err := tc.observedGraph(t)
 			mockDiscoverer.
 				On("Discover", ctx).
 				Return(g, err)
+			mockDiscoverer.On("DiscoverBalances", ctx, g).Return(nil).Maybe()
+			p.plugin.discoverer = mockDiscoverer
 
 			// loadPendingTransfers && resolveProposedTransfers
 			for sourceDest, bridgeFn := range tc.bridges {
@@ -1606,7 +1608,7 @@ func newPluginWithMocks(
 	lmFactory := mocks.NewFactory(t)
 	discovererFactory := discoverermocks.NewFactory(t)
 	discovererMock := discoverermocks.NewDiscoverer(t)
-	discovererFactory.On("NewDiscoverer", mock.Anything, mock.Anything).Return(discovererMock, nil)
+	discovererFactory.On("NewDiscoverer", mock.Anything, mock.Anything).Return(discovererMock, nil).Maybe()
 	bridgeFactory := bridgemocks.NewFactory(t)
 	rebalancerAlg := liquidityrebalancer.NewPingPong()
 	return &pluginWithMocks{


### PR DESCRIPTION
## Motivation

The liquidity graph doesn’t need to be synced on every single plugin run.

## Solution

Sync only on startup and cache the liquidity graphs in the plugin, upon `Observation` call discoverer to update balances.

Includes the following changes:

- call syncGraph only once upon startup
- cache graphs in the plugin
- add function to fetch only the balances rather building the entire graph: 
`DiscoverBalances(context.Context, graph.Graph)`