### PR TITLE
enable contract versioning in tests

### DIFF
--- a/integration-tests/ccip-tests/actions/ccip_helpers.go
+++ b/integration-tests/ccip-tests/actions/ccip_helpers.go
@@ -485,11 +485,11 @@ func (ccipModule *CCIPCommon) WatchForPriceUpdates(ctx context.Context) error {
 	var sub event.Subscription
 	gasUpdateEventLatest := make(chan *price_registry.PriceRegistryUsdPerUnitGasUpdated)
 	sub = event.Resubscribe(2*time.Hour, func(_ context.Context) (event.Subscription, error) {
-		sub, err := ccipModule.PriceRegistry.WatchUsdPerUnitGasUpdated(nil, gasUpdateEventLatest, nil)
+		eventSub, err := ccipModule.PriceRegistry.WatchUsdPerUnitGasUpdated(nil, gasUpdateEventLatest, nil)
 		if err != nil {
 			log.Error().Err(err).Msg("error in subscribing to UsdPerUnitGasUpdated event")
 		}
-		return sub, err
+		return eventSub, err
 	})
 	if sub == nil {
 		return fmt.Errorf("no event subscription found")

--- a/integration-tests/ccip-tests/contracts/contract_models.go
+++ b/integration-tests/ccip-tests/contracts/contract_models.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/exp/rand"
 
@@ -17,18 +18,25 @@ import (
 
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/arm_contract"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/commit_store"
+	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/commit_store_1_2_0"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/evm_2_evm_offramp"
+	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/evm_2_evm_offramp_1_2_0"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/evm_2_evm_onramp"
+	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/evm_2_evm_onramp_1_2_0"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/lock_release_token_pool"
+	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/lock_release_token_pool_1_4_0"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/maybe_revert_message_receiver"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/mock_arm_contract"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/mock_usdc_token_transmitter"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/mock_v3_aggregator_contract"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/price_registry"
+	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/price_registry_1_2_0"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/router"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/token_admin_registry"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/token_pool"
+	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/token_pool_1_4_0"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/usdc_token_pool"
+	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/usdc_token_pool_1_4_0"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/link_token_interface"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/shared/generated/burn_mint_erc677"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/shared/generated/erc20"
@@ -40,13 +48,58 @@ var (
 	HundredCoins = new(big.Int).Mul(big.NewInt(1e18), big.NewInt(100))
 )
 
+type ContractVersion string
+
 const (
-	Network = "Network Name"
+	Network                               = "Network Name"
+	V1_2_0                ContractVersion = "1.2.0"
+	V1_4_0                ContractVersion = "1.4.0"
+	LatestPoolVersion     ContractVersion = "1.5.0-dev"
+	Latest                ContractVersion = "latest"
+	PriceRegistryContract                 = "PriceRegistry"
+	OffRampContract                       = "OffRamp"
+	OnRampContract                        = "OnRamp"
+	TokenPoolContract                     = "TokenPool"
+	CommitStoreContract                   = "CommitStore"
+)
+
+var (
+	VersionMap = map[string]ContractVersion{
+		PriceRegistryContract: Latest,
+		OffRampContract:       Latest,
+		OnRampContract:        Latest,
+		CommitStoreContract:   Latest,
+		TokenPoolContract:     Latest,
+	}
+	SupportedContracts = map[string]map[ContractVersion]bool{
+		PriceRegistryContract: {
+			Latest: true,
+			V1_2_0: true,
+		},
+		OffRampContract: {
+			Latest: true,
+			V1_2_0: true,
+		},
+		OnRampContract: {
+			Latest: true,
+			V1_2_0: true,
+		},
+		CommitStoreContract: {
+			Latest: true,
+			V1_2_0: true,
+		},
+		TokenPoolContract: {
+			Latest: true,
+			V1_4_0: true,
+		},
+	}
 )
 
 type RateLimiterConfig struct {
-	Rate     *big.Int
-	Capacity *big.Int
+	IsEnabled bool
+	Rate      *big.Int
+	Capacity  *big.Int
+	Tokens    *big.Int
 }
 
 type ARMConfig struct {
@@ -257,22 +310,225 @@ func (l *LinkToken) Transfer(to string, amount *big.Int) error {
 	return l.client.ProcessTransaction(tx)
 }
 
-// TokenPool represents a TokenPool address
-type TokenPool struct {
-	client          blockchain.EVMClient
+type LatestPool struct {
 	PoolInterface   *token_pool.TokenPool
 	LockReleasePool *lock_release_token_pool.LockReleaseTokenPool
 	USDCPool        *usdc_token_pool.USDCTokenPool
-	EthAddress      common.Address
+}
+
+type V1_4_0Pool struct {
+	PoolInterface   *token_pool_1_4_0.TokenPool
+	LockReleasePool *lock_release_token_pool_1_4_0.LockReleaseTokenPool
+	USDCPool        *usdc_token_pool_1_4_0.USDCTokenPool
+}
+
+type TokenPoolWrapper struct {
+	Latest *LatestPool
+	V1_4_0 *V1_4_0Pool
+}
+
+func (w TokenPoolWrapper) SetRebalancer(opts *bind.TransactOpts, from common.Address) (*types.Transaction, error) {
+	if w.Latest != nil && w.Latest.LockReleasePool != nil {
+		return w.Latest.LockReleasePool.SetRebalancer(opts, from)
+	}
+	if w.V1_4_0 != nil && w.V1_4_0.LockReleasePool != nil {
+		return w.V1_4_0.LockReleasePool.SetRebalancer(opts, from)
+	}
+	return nil, fmt.Errorf("no pool found to set rebalancer")
+}
+
+func (w TokenPoolWrapper) SetUSDCDomains(opts *bind.TransactOpts, updates []usdc_token_pool.USDCTokenPoolDomainUpdate) (*types.Transaction, error) {
+	if w.Latest != nil && w.Latest.USDCPool != nil {
+		return w.Latest.USDCPool.SetDomains(opts, updates)
+	}
+	if w.V1_4_0 != nil && w.V1_4_0.USDCPool != nil {
+		V1_4_0Updates := make([]usdc_token_pool_1_4_0.USDCTokenPoolDomainUpdate, len(updates))
+		for i, update := range updates {
+			V1_4_0Updates[i] = usdc_token_pool_1_4_0.USDCTokenPoolDomainUpdate{
+				AllowedCaller:     update.AllowedCaller,
+				DomainIdentifier:  update.DomainIdentifier,
+				DestChainSelector: update.DestChainSelector,
+				Enabled:           update.Enabled,
+			}
+		}
+		return w.V1_4_0.USDCPool.SetDomains(opts, V1_4_0Updates)
+	}
+	return nil, fmt.Errorf("no pool found to set USDC domains")
+}
+
+func (w TokenPoolWrapper) WithdrawLiquidity(opts *bind.TransactOpts, amount *big.Int) (*types.Transaction, error) {
+	if w.Latest != nil && w.Latest.LockReleasePool != nil {
+		return w.Latest.LockReleasePool.WithdrawLiquidity(opts, amount)
+	}
+	if w.V1_4_0 != nil && w.V1_4_0.LockReleasePool != nil {
+		return w.V1_4_0.LockReleasePool.WithdrawLiquidity(opts, amount)
+	}
+	return nil, fmt.Errorf("no pool found to withdraw liquidity")
+}
+
+func (w TokenPoolWrapper) ProvideLiquidity(opts *bind.TransactOpts, amount *big.Int) (*types.Transaction, error) {
+	if w.Latest != nil && w.Latest.LockReleasePool != nil {
+		return w.Latest.LockReleasePool.ProvideLiquidity(opts, amount)
+	}
+	if w.V1_4_0 != nil && w.V1_4_0.LockReleasePool != nil {
+		return w.V1_4_0.LockReleasePool.ProvideLiquidity(opts, amount)
+	}
+	return nil, fmt.Errorf("no pool found to provide liquidity")
+}
+
+func (w TokenPoolWrapper) SetRemotePool(opts *bind.TransactOpts, selector uint64, pool []byte) (*types.Transaction, error) {
+	if w.Latest != nil && w.Latest.PoolInterface != nil {
+		return w.Latest.PoolInterface.SetRemotePool(opts, selector, pool)
+	}
+	return nil, fmt.Errorf("no pool found to set remote pool")
+}
+
+func (w TokenPoolWrapper) IsSupportedChain(opts *bind.CallOpts, remoteChainSelector uint64) (bool, error) {
+	if w.Latest != nil && w.Latest.PoolInterface != nil {
+		return w.Latest.PoolInterface.IsSupportedChain(opts, remoteChainSelector)
+	}
+	if w.V1_4_0 != nil && w.V1_4_0.PoolInterface != nil {
+		return w.V1_4_0.PoolInterface.IsSupportedChain(opts, remoteChainSelector)
+	}
+	return false, fmt.Errorf("no pool found to check if chain is supported")
+}
+
+func (w TokenPoolWrapper) ApplyChainUpdates(opts *bind.TransactOpts, update []token_pool.TokenPoolChainUpdate) (*types.Transaction, error) {
+	if w.Latest != nil && w.Latest.PoolInterface != nil {
+		return w.Latest.PoolInterface.ApplyChainUpdates(opts, update)
+	}
+	if w.V1_4_0 != nil && w.V1_4_0.PoolInterface != nil {
+		V1_4_0Updates := make([]token_pool_1_4_0.TokenPoolChainUpdate, len(update))
+		for i, u := range update {
+			V1_4_0Updates[i] = token_pool_1_4_0.TokenPoolChainUpdate{
+				RemoteChainSelector: u.RemoteChainSelector,
+				Allowed:             u.Allowed,
+				InboundRateLimiterConfig: token_pool_1_4_0.RateLimiterConfig{
+					IsEnabled: u.InboundRateLimiterConfig.IsEnabled,
+					Capacity:  u.InboundRateLimiterConfig.Capacity,
+					Rate:      u.InboundRateLimiterConfig.Rate,
+				},
+				OutboundRateLimiterConfig: token_pool_1_4_0.RateLimiterConfig{
+					IsEnabled: u.OutboundRateLimiterConfig.IsEnabled,
+					Capacity:  u.OutboundRateLimiterConfig.Capacity,
+					Rate:      u.OutboundRateLimiterConfig.Rate,
+				},
+			}
+		}
+		return w.V1_4_0.PoolInterface.ApplyChainUpdates(opts, V1_4_0Updates)
+	}
+	return nil, fmt.Errorf("no pool found to apply chain updates")
+}
+
+func (w TokenPoolWrapper) SetChainRateLimiterConfig(opts *bind.TransactOpts, selector uint64, out token_pool.RateLimiterConfig, in token_pool.RateLimiterConfig) (*types.Transaction, error) {
+	if w.Latest != nil && w.Latest.PoolInterface != nil {
+		return w.Latest.PoolInterface.SetChainRateLimiterConfig(opts, selector, out, in)
+	}
+	if w.V1_4_0 != nil && w.V1_4_0.PoolInterface != nil {
+		return w.V1_4_0.PoolInterface.SetChainRateLimiterConfig(opts, selector,
+			token_pool_1_4_0.RateLimiterConfig{
+				IsEnabled: out.IsEnabled,
+				Capacity:  out.Capacity,
+				Rate:      out.Rate,
+			}, token_pool_1_4_0.RateLimiterConfig{
+				IsEnabled: in.IsEnabled,
+				Capacity:  in.Capacity,
+				Rate:      in.Rate,
+			})
+	}
+	return nil, fmt.Errorf("no pool found to set chain rate limiter config")
+}
+
+func (w TokenPoolWrapper) GetCurrentOutboundRateLimiterState(opts *bind.CallOpts, selector uint64) (*RateLimiterConfig, error) {
+	if w.Latest != nil && w.Latest.PoolInterface != nil {
+		rl, err := w.Latest.PoolInterface.GetCurrentOutboundRateLimiterState(opts, selector)
+		if err != nil {
+			return nil, err
+		}
+		return &RateLimiterConfig{
+			IsEnabled: rl.IsEnabled,
+			Capacity:  rl.Capacity,
+			Rate:      rl.Rate,
+			Tokens:    rl.Tokens,
+		}, nil
+	}
+	if w.V1_4_0 != nil && w.V1_4_0.PoolInterface != nil {
+		rl, err := w.V1_4_0.PoolInterface.GetCurrentOutboundRateLimiterState(opts, selector)
+		if err != nil {
+			return nil, err
+		}
+		return &RateLimiterConfig{
+			IsEnabled: rl.IsEnabled,
+			Capacity:  rl.Capacity,
+			Rate:      rl.Rate,
+			Tokens:    rl.Tokens,
+		}, nil
+	}
+	return nil, fmt.Errorf("no pool found to get current outbound rate limiter state")
+}
+
+func (w TokenPoolWrapper) GetCurrentInboundRateLimiterState(opts *bind.CallOpts, selector uint64) (*RateLimiterConfig, error) {
+	if w.Latest != nil && w.Latest.PoolInterface != nil {
+		rl, err := w.Latest.PoolInterface.GetCurrentInboundRateLimiterState(opts, selector)
+		if err != nil {
+			return nil, err
+		}
+		return &RateLimiterConfig{
+			IsEnabled: rl.IsEnabled,
+			Capacity:  rl.Capacity,
+			Rate:      rl.Rate,
+			Tokens:    rl.Tokens,
+		}, nil
+	}
+	if w.V1_4_0 != nil && w.V1_4_0.PoolInterface != nil {
+		rl, err := w.V1_4_0.PoolInterface.GetCurrentInboundRateLimiterState(opts, selector)
+		if err != nil {
+			return nil, err
+		}
+		return &RateLimiterConfig{
+			IsEnabled: rl.IsEnabled,
+			Capacity:  rl.Capacity,
+			Rate:      rl.Rate,
+			Tokens:    rl.Tokens,
+		}, nil
+	}
+	return nil, fmt.Errorf("no pool found to get current outbound rate limiter state")
+}
+
+// TokenPool represents a TokenPool address
+type TokenPool struct {
+	client     blockchain.EVMClient
+	Instance   *TokenPoolWrapper
+	EthAddress common.Address
 }
 
 func (pool *TokenPool) Address() string {
 	return pool.EthAddress.Hex()
 }
 
+func (pool *TokenPool) IsUSDC() bool {
+	if pool.Instance.Latest != nil && pool.Instance.Latest.USDCPool != nil {
+		return true
+	}
+	if pool.Instance.V1_4_0 != nil && pool.Instance.V1_4_0.USDCPool != nil {
+		return true
+	}
+	return false
+}
+
+func (pool *TokenPool) IsLockRelease() bool {
+	if pool.Instance.Latest != nil && pool.Instance.Latest.LockReleasePool != nil {
+		return true
+	}
+	if pool.Instance.V1_4_0 != nil && pool.Instance.V1_4_0.LockReleasePool != nil {
+		return true
+	}
+	return false
+}
+
 func (pool *TokenPool) SyncUSDCDomain(destTokenTransmitter *TokenTransmitter, destPoolAddr common.Address, destChainSelector uint64) error {
-	if pool.USDCPool == nil {
-		return fmt.Errorf("USDCPool is nil")
+	if !pool.IsUSDC() {
+		return fmt.Errorf("pool is not a USDC pool, cannot sync domain")
 	}
 
 	var allowedCallerBytes [32]byte
@@ -296,7 +552,7 @@ func (pool *TokenPool) SyncUSDCDomain(destTokenTransmitter *TokenTransmitter, de
 		Str("Allowed Caller", destPoolAddr.Hex()).
 		Str("Dest Chain Selector", fmt.Sprintf("%d", destChainSelector)).
 		Msg("Syncing USDC Domain")
-	tx, err := pool.USDCPool.SetDomains(opts, []usdc_token_pool.USDCTokenPoolDomainUpdate{
+	tx, err := pool.Instance.SetUSDCDomains(opts, []usdc_token_pool.USDCTokenPoolDomainUpdate{
 		{
 			AllowedCaller:     allowedCallerBytes,
 			DomainIdentifier:  domain,
@@ -311,8 +567,8 @@ func (pool *TokenPool) SyncUSDCDomain(destTokenTransmitter *TokenTransmitter, de
 }
 
 func (pool *TokenPool) RemoveLiquidity(amount *big.Int) error {
-	if pool.LockReleasePool == nil {
-		return fmt.Errorf("LockReleasePool is nil")
+	if !pool.IsLockRelease() {
+		return fmt.Errorf("pool is not a lock release pool, cannot remove liquidity")
 	}
 	opts, err := pool.client.TransactionOpts(pool.client.GetDefaultWallet())
 	if err != nil {
@@ -322,7 +578,7 @@ func (pool *TokenPool) RemoveLiquidity(amount *big.Int) error {
 		Str("Token Pool", pool.Address()).
 		Str("Amount", amount.String()).
 		Msg("Initiating removing funds from pool")
-	tx, err := pool.LockReleasePool.WithdrawLiquidity(opts, amount)
+	tx, err := pool.Instance.WithdrawLiquidity(opts, amount)
 	if err != nil {
 		return fmt.Errorf("failed to withdraw liquidity: %w", err)
 	}
@@ -337,8 +593,8 @@ func (pool *TokenPool) RemoveLiquidity(amount *big.Int) error {
 type tokenApproveFn func(string, *big.Int) error
 
 func (pool *TokenPool) AddLiquidity(approveFn tokenApproveFn, tokenAddr string, amount *big.Int) error {
-	if pool.LockReleasePool == nil {
-		return fmt.Errorf("cannot add liquidity to pool")
+	if !pool.IsLockRelease() {
+		return fmt.Errorf("pool is not a lock release pool, cannot add liquidity")
 	}
 	log.Info().
 		Str("Link Token", tokenAddr).
@@ -356,7 +612,7 @@ func (pool *TokenPool) AddLiquidity(approveFn tokenApproveFn, tokenAddr string, 
 	if err != nil {
 		return fmt.Errorf("failed to get transaction opts: %w", err)
 	}
-	_, err = pool.LockReleasePool.SetRebalancer(opts, opts.From)
+	_, err = pool.Instance.SetRebalancer(opts, opts.From)
 	if err != nil {
 		return fmt.Errorf("failed to set rebalancer: %w", err)
 	}
@@ -367,7 +623,7 @@ func (pool *TokenPool) AddLiquidity(approveFn tokenApproveFn, tokenAddr string, 
 	log.Info().
 		Str("Token Pool", pool.Address()).
 		Msg("Initiating adding Tokens in pool")
-	tx, err := pool.LockReleasePool.ProvideLiquidity(opts, amount)
+	tx, err := pool.Instance.ProvideLiquidity(opts, amount)
 	if err != nil {
 		return fmt.Errorf("failed to provide liquidity: %w", err)
 	}
@@ -380,6 +636,10 @@ func (pool *TokenPool) AddLiquidity(approveFn tokenApproveFn, tokenAddr string, 
 }
 
 func (pool *TokenPool) SetRemotePool(remoteChainSelector uint64, remotePool common.Address) error {
+	// if pool is of version 1.4.0, no need to set remote pool
+	if pool.Instance.V1_4_0 != nil {
+		return nil
+	}
 	log.Info().
 		Str("Token Pool", pool.Address()).
 		Str("Dest Pool", remotePool.Hex()).
@@ -393,7 +653,7 @@ func (pool *TokenPool) SetRemotePool(remoteChainSelector uint64, remotePool comm
 	if err != nil {
 		return fmt.Errorf("failed to get transaction opts: %w", err)
 	}
-	tx, err := pool.PoolInterface.SetRemotePool(opts, remoteChainSelector, abiEncodedRemotePool)
+	tx, err := pool.Instance.SetRemotePool(opts, remoteChainSelector, abiEncodedRemotePool)
 
 	if err != nil {
 		return fmt.Errorf("failed to set remote pool %s on token pool: %w", remotePool.Hex(), err)
@@ -412,7 +672,7 @@ func (pool *TokenPool) SetRemoteChainOnPool(remoteChainSelectors []uint64) error
 		Msg("Setting remote chain on pool")
 	var selectorsToUpdate []token_pool.TokenPoolChainUpdate
 	for _, remoteChainSelector := range remoteChainSelectors {
-		isSupported, err := pool.PoolInterface.IsSupportedChain(nil, remoteChainSelector)
+		isSupported, err := pool.Instance.IsSupportedChain(nil, remoteChainSelector)
 		if err != nil {
 			return fmt.Errorf("failed to get if chain is supported: %w", err)
 		}
@@ -449,7 +709,7 @@ func (pool *TokenPool) SetRemoteChainOnPool(remoteChainSelectors []uint64) error
 	if err != nil {
 		return fmt.Errorf("failed to get transaction opts: %w", err)
 	}
-	tx, err := pool.PoolInterface.ApplyChainUpdates(opts, selectorsToUpdate)
+	tx, err := pool.Instance.ApplyChainUpdates(opts, selectorsToUpdate)
 
 	if err != nil {
 		return fmt.Errorf("failed to set chain updates on token pool: %w", err)
@@ -473,7 +733,7 @@ func (pool *TokenPool) SetRemoteChainRateLimits(remoteChainSelector uint64, rl t
 		Str("Remote chain selector", strconv.FormatUint(remoteChainSelector, 10)).
 		Interface("RateLimiterConfig", rl).
 		Msg("Setting Rate Limit on token pool")
-	tx, err := pool.PoolInterface.SetChainRateLimiterConfig(opts, remoteChainSelector, rl, rl)
+	tx, err := pool.Instance.SetChainRateLimiterConfig(opts, remoteChainSelector, rl, rl)
 
 	if err != nil {
 		return fmt.Errorf("error setting rate limit token pool: %w", err)
@@ -510,9 +770,48 @@ func (arm *MockARM) Address() string {
 	return arm.EthAddress.Hex()
 }
 
+type CommitStoreReportAccepted struct {
+	Min        uint64
+	Max        uint64
+	MerkleRoot [32]byte
+	Raw        types.Log
+}
+
+type CommitStoreWrapper struct {
+	Latest *commit_store.CommitStore
+	V1_2_0 *commit_store_1_2_0.CommitStore
+}
+
+func (w CommitStoreWrapper) SetOCR2Config(opts *bind.TransactOpts,
+	signers []common.Address,
+	transmitters []common.Address,
+	f uint8,
+	onchainConfig []byte,
+	offchainConfigVersion uint64,
+	offchainConfig []byte,
+) (*types.Transaction, error) {
+	if w.Latest != nil {
+		return w.Latest.SetOCR2Config(opts, signers, transmitters, f, onchainConfig, offchainConfigVersion, offchainConfig)
+	}
+	if w.V1_2_0 != nil {
+		return w.V1_2_0.SetOCR2Config(opts, signers, transmitters, f, onchainConfig, offchainConfigVersion, offchainConfig)
+	}
+	return nil, fmt.Errorf("no instance found to set OCR2 config")
+}
+
+func (w CommitStoreWrapper) GetExpectedNextSequenceNumber(opts *bind.CallOpts) (uint64, error) {
+	if w.Latest != nil {
+		return w.Latest.GetExpectedNextSequenceNumber(opts)
+	}
+	if w.V1_2_0 != nil {
+		return w.V1_2_0.GetExpectedNextSequenceNumber(opts)
+	}
+	return 0, fmt.Errorf("no instance found to get expected next sequence number")
+}
+
 type CommitStore struct {
 	client     blockchain.EVMClient
-	Instance   *commit_store.CommitStore
+	Instance   *CommitStoreWrapper
 	EthAddress common.Address
 }
 
@@ -585,9 +884,116 @@ func (rDapp *ReceiverDapp) ToggleRevert(revert bool) error {
 	return rDapp.client.ProcessTransaction(tx)
 }
 
+type InternalTimestampedPackedUint224 struct {
+	Value     *big.Int
+	Timestamp uint32
+}
+
+type PriceRegistryUsdPerUnitGasUpdated struct {
+	DestChain uint64
+	Value     *big.Int
+	Timestamp *big.Int
+	Raw       types.Log
+}
+
+type PriceRegistryWrappers struct {
+	Latest *price_registry.PriceRegistry
+	V1_2_0 *price_registry_1_2_0.PriceRegistry
+}
+
+func (p *PriceRegistryWrappers) GetTokenPrice(opts *bind.CallOpts, token common.Address) (*big.Int, error) {
+	if p.Latest != nil {
+		price, err := p.Latest.GetTokenPrice(opts, token)
+		if err != nil {
+			return nil, err
+		}
+		return price.Value, nil
+	}
+	if p.V1_2_0 != nil {
+		p, err := p.V1_2_0.GetTokenPrice(opts, token)
+		if err != nil {
+			return nil, err
+		}
+		return p.Value, nil
+	}
+	return nil, fmt.Errorf("no instance found to get token price")
+}
+
+func (p *PriceRegistryWrappers) AddPriceUpdater(opts *bind.TransactOpts, addr common.Address) (*types.Transaction, error) {
+	if p.Latest != nil {
+		return p.Latest.ApplyPriceUpdatersUpdates(opts, []common.Address{addr}, []common.Address{})
+	}
+	if p.V1_2_0 != nil {
+		return p.V1_2_0.ApplyPriceUpdatersUpdates(opts, []common.Address{addr}, []common.Address{})
+	}
+	return nil, fmt.Errorf("no instance found to add price updater")
+}
+
+func (p *PriceRegistryWrappers) AddFeeToken(opts *bind.TransactOpts, addr common.Address) (*types.Transaction, error) {
+	if p.Latest != nil {
+		return p.Latest.ApplyFeeTokensUpdates(opts, []common.Address{addr}, []common.Address{})
+	}
+	if p.V1_2_0 != nil {
+		return p.V1_2_0.ApplyFeeTokensUpdates(opts, []common.Address{addr}, []common.Address{})
+	}
+	return nil, fmt.Errorf("no instance found to add fee token")
+}
+
+func (p *PriceRegistryWrappers) GetDestinationChainGasPrice(opts *bind.CallOpts, chainselector uint64) (InternalTimestampedPackedUint224, error) {
+	if p.Latest != nil {
+		price, err := p.Latest.GetDestinationChainGasPrice(opts, chainselector)
+		if err != nil {
+			return InternalTimestampedPackedUint224{}, err
+		}
+		return InternalTimestampedPackedUint224{
+			Value:     price.Value,
+			Timestamp: price.Timestamp,
+		}, nil
+	}
+	if p.V1_2_0 != nil {
+		price, err := p.V1_2_0.GetDestinationChainGasPrice(opts, chainselector)
+		if err != nil {
+			return InternalTimestampedPackedUint224{}, err
+		}
+		return InternalTimestampedPackedUint224{
+			Value:     price.Value,
+			Timestamp: price.Timestamp,
+		}, nil
+	}
+	return InternalTimestampedPackedUint224{}, fmt.Errorf("no instance found to add fee token")
+}
+
+func (p *PriceRegistryWrappers) WatchForPriceUpdates(ch interface{}) (event.Subscription, error) {
+	if p.Latest != nil {
+		subChan, ok := ch.(chan *price_registry.PriceRegistryUsdPerUnitGasUpdated)
+		if !ok {
+			return nil, fmt.Errorf("failed to cast to correct channel type in WatchForPriceUpdates, expected chan *price_registry.PriceRegistryUsdPerUnitGasUpdated")
+		}
+		return p.Latest.WatchUsdPerUnitGasUpdated(nil, subChan, nil)
+	}
+	if p.V1_2_0 != nil {
+		subChan, ok := ch.(chan *price_registry_1_2_0.PriceRegistryUsdPerUnitGasUpdated)
+		if !ok {
+			return nil, fmt.Errorf("failed to cast to correct channel type in WatchForPriceUpdates, expected chan *price_registry_1_2_0.PriceRegistryUsdPerUnitGasUpdated")
+		}
+		return p.V1_2_0.WatchUsdPerUnitGasUpdated(nil, subChan, nil)
+	}
+	return nil, fmt.Errorf("no instance found to watch for price updates")
+}
+
+type InternalGasPriceUpdate struct {
+	DestChainSelector uint64
+	UsdPerUnitGas     *big.Int
+}
+
+type InternalTokenPriceUpdate struct {
+	SourceToken common.Address
+	UsdPerToken *big.Int
+}
+
 type PriceRegistry struct {
 	client     blockchain.EVMClient
-	Instance   *price_registry.PriceRegistry
+	Instance   *PriceRegistryWrappers
 	EthAddress common.Address
 }
 
@@ -600,7 +1006,7 @@ func (c *PriceRegistry) AddPriceUpdater(addr common.Address) error {
 	if err != nil {
 		return fmt.Errorf("error getting transaction opts: %w", err)
 	}
-	tx, err := c.Instance.ApplyPriceUpdatersUpdates(opts, []common.Address{addr}, []common.Address{})
+	tx, err := c.Instance.AddPriceUpdater(opts, addr)
 	if err != nil {
 		return fmt.Errorf("error adding price updater: %w", err)
 	}
@@ -616,7 +1022,7 @@ func (c *PriceRegistry) AddFeeToken(addr common.Address) error {
 	if err != nil {
 		return fmt.Errorf("error getting transaction opts: %w", err)
 	}
-	tx, err := c.Instance.ApplyFeeTokensUpdates(opts, []common.Address{addr}, []common.Address{})
+	tx, err := c.Instance.AddFeeToken(opts, addr)
 	if err != nil {
 		return fmt.Errorf("error adding fee token: %w", err)
 	}
@@ -627,18 +1033,65 @@ func (c *PriceRegistry) AddFeeToken(addr common.Address) error {
 	return c.client.ProcessTransaction(tx)
 }
 
-func (c *PriceRegistry) UpdatePrices(priceUpdates price_registry.InternalPriceUpdates) error {
+func (c *PriceRegistry) UpdatePrices(tokenUpdates []InternalTokenPriceUpdate, gasUpdates []InternalGasPriceUpdate) error {
 	opts, err := c.client.TransactionOpts(c.client.GetDefaultWallet())
 	if err != nil {
 		return fmt.Errorf("error getting transaction opts: %w", err)
 	}
-	tx, err := c.Instance.UpdatePrices(opts, priceUpdates)
-	if err != nil {
-		return fmt.Errorf("error updating prices: %w", err)
+	var tx *types.Transaction
+	if c.Instance.Latest != nil {
+		var tokenUpdatesLatest []price_registry.InternalTokenPriceUpdate
+		var gasUpdatesLatest []price_registry.InternalGasPriceUpdate
+		for _, update := range tokenUpdates {
+			tokenUpdatesLatest = append(tokenUpdatesLatest, price_registry.InternalTokenPriceUpdate{
+				SourceToken: update.SourceToken,
+				UsdPerToken: update.UsdPerToken,
+			})
+		}
+		for _, update := range gasUpdates {
+			gasUpdatesLatest = append(gasUpdatesLatest, price_registry.InternalGasPriceUpdate{
+				DestChainSelector: update.DestChainSelector,
+				UsdPerUnitGas:     update.UsdPerUnitGas,
+			})
+		}
+		tx, err = c.Instance.Latest.UpdatePrices(opts, price_registry.InternalPriceUpdates{
+			TokenPriceUpdates: tokenUpdatesLatest,
+			GasPriceUpdates:   gasUpdatesLatest,
+		})
+		if err != nil {
+			return fmt.Errorf("error updating prices: %w", err)
+		}
+	}
+	if c.Instance.V1_2_0 != nil {
+		var tokenUpdates_1_2_0 []price_registry_1_2_0.InternalTokenPriceUpdate
+		var gasUpdates_1_2_0 []price_registry_1_2_0.InternalGasPriceUpdate
+		for _, update := range tokenUpdates {
+			tokenUpdates_1_2_0 = append(tokenUpdates_1_2_0, price_registry_1_2_0.InternalTokenPriceUpdate{
+				SourceToken: update.SourceToken,
+				UsdPerToken: update.UsdPerToken,
+			})
+		}
+		for _, update := range gasUpdates {
+			gasUpdates_1_2_0 = append(gasUpdates_1_2_0, price_registry_1_2_0.InternalGasPriceUpdate{
+				DestChainSelector: update.DestChainSelector,
+				UsdPerUnitGas:     update.UsdPerUnitGas,
+			})
+		}
+		tx, err = c.Instance.V1_2_0.UpdatePrices(opts, price_registry_1_2_0.InternalPriceUpdates{
+			TokenPriceUpdates: tokenUpdates_1_2_0,
+			GasPriceUpdates:   gasUpdates_1_2_0,
+		})
+		if err != nil {
+			return fmt.Errorf("error updating prices: %w", err)
+		}
+	}
+	if tx == nil {
+		return fmt.Errorf("no instance found to update prices")
 	}
 	log.Info().
 		Str(Network, c.client.GetNetworkConfig().Name).
-		Interface("PriceUpdates", priceUpdates).
+		Interface("tokenUpdates", tokenUpdates).
+		Interface("gasUpdates", gasUpdates).
 		Msg("Prices updated")
 	return c.client.ProcessTransaction(tx)
 }
@@ -799,9 +1252,181 @@ func (r *Router) GetFee(destChainSelector uint64, message router.ClientEVM2AnyMe
 	return r.Instance.GetFee(nil, destChainSelector, message)
 }
 
+type SendReqEventData struct {
+	MessageId      [32]byte
+	SequenceNumber uint64
+	Raw            types.Log
+}
+
+type OnRampWrapper struct {
+	Latest *evm_2_evm_onramp.EVM2EVMOnRamp
+	V1_2_0 *evm_2_evm_onramp_1_2_0.EVM2EVMOnRamp
+}
+
+func (w OnRampWrapper) SetNops(opts *bind.TransactOpts, owner common.Address) (*types.Transaction, error) {
+	if w.Latest != nil {
+		return w.Latest.SetNops(opts, []evm_2_evm_onramp.EVM2EVMOnRampNopAndWeight{
+			{
+				Nop:    owner,
+				Weight: 1,
+			},
+		})
+	}
+	if w.V1_2_0 != nil {
+		return w.V1_2_0.SetNops(opts, []evm_2_evm_onramp_1_2_0.EVM2EVMOnRampNopAndWeight{
+			{
+				Nop:    owner,
+				Weight: 1,
+			},
+		})
+	}
+	return nil, fmt.Errorf("no instance found to set nops")
+}
+
+func (w OnRampWrapper) SetTokenTransferFeeConfig(
+	opts *bind.TransactOpts,
+	config []evm_2_evm_onramp.EVM2EVMOnRampTokenTransferFeeConfigArgs,
+	addresses []common.Address,
+) (*types.Transaction, error) {
+	if w.Latest != nil {
+		return w.Latest.SetTokenTransferFeeConfig(opts, config, addresses)
+	}
+	if w.V1_2_0 != nil {
+		var configV12 []evm_2_evm_onramp_1_2_0.EVM2EVMOnRampTokenTransferFeeConfigArgs
+		for _, c := range config {
+			configV12 = append(configV12, evm_2_evm_onramp_1_2_0.EVM2EVMOnRampTokenTransferFeeConfigArgs{
+				Token:             c.Token,
+				MinFeeUSDCents:    c.MinFeeUSDCents,
+				MaxFeeUSDCents:    c.MaxFeeUSDCents,
+				DeciBps:           c.DeciBps,
+				DestGasOverhead:   c.DestGasOverhead,
+				DestBytesOverhead: c.DestBytesOverhead,
+			})
+		}
+		return w.V1_2_0.SetTokenTransferFeeConfig(opts, configV12)
+	}
+	return nil, fmt.Errorf("no instance found to set token transfer fee config")
+}
+
+func (w OnRampWrapper) PayNops(opts *bind.TransactOpts) (*types.Transaction, error) {
+	if w.Latest != nil {
+		return w.Latest.PayNops(opts)
+	}
+	if w.V1_2_0 != nil {
+		return w.V1_2_0.PayNops(opts)
+	}
+	return nil, fmt.Errorf("no instance found to pay nops")
+}
+
+func (w OnRampWrapper) WithdrawNonLinkFees(opts *bind.TransactOpts, native common.Address, owner common.Address) (*types.Transaction, error) {
+	if w.Latest != nil {
+		return w.Latest.WithdrawNonLinkFees(opts, native, owner)
+	}
+	if w.V1_2_0 != nil {
+		return w.V1_2_0.WithdrawNonLinkFees(opts, native, owner)
+	}
+	return nil, fmt.Errorf("no instance found to withdraw non link fees")
+}
+
+func (w OnRampWrapper) SetRateLimiterConfig(opts *bind.TransactOpts, config evm_2_evm_onramp.RateLimiterConfig) (*types.Transaction, error) {
+	if w.Latest != nil {
+		return w.Latest.SetRateLimiterConfig(opts, config)
+	}
+	if w.V1_2_0 != nil {
+		return w.V1_2_0.SetRateLimiterConfig(opts, evm_2_evm_onramp_1_2_0.RateLimiterConfig{
+			IsEnabled: config.IsEnabled,
+			Capacity:  config.Capacity,
+			Rate:      config.Rate,
+		})
+	}
+	return nil, fmt.Errorf("no instance found to set rate limiter config")
+}
+
+func (w OnRampWrapper) ParseCCIPSendRequested(l types.Log) (uint64, error) {
+	if w.Latest != nil {
+		sendReq, err := w.Latest.ParseCCIPSendRequested(l)
+		if err != nil {
+			return 0, err
+		}
+		return sendReq.Message.SequenceNumber, nil
+	}
+	if w.V1_2_0 != nil {
+		sendReq, err := w.V1_2_0.ParseCCIPSendRequested(l)
+		if err != nil {
+			return 0, err
+		}
+		return sendReq.Message.SequenceNumber, nil
+	}
+	return 0, fmt.Errorf("no instance found to parse CCIPSendRequested")
+}
+
+func (w OnRampWrapper) GetDynamicConfig(opts *bind.CallOpts) (uint32, error) {
+	if w.Latest != nil {
+		cfg, err := w.Latest.GetDynamicConfig(opts)
+		if err != nil {
+			return 0, err
+		}
+		return cfg.MaxDataBytes, nil
+	}
+	if w.V1_2_0 != nil {
+		cfg, err := w.V1_2_0.GetDynamicConfig(opts)
+		if err != nil {
+			return 0, err
+		}
+		return cfg.MaxDataBytes, nil
+	}
+	return 0, fmt.Errorf("no instance found to get dynamic config")
+}
+
+func (w OnRampWrapper) ApplyPoolUpdates(opts *bind.TransactOpts, tokens []common.Address, pools []common.Address) (*types.Transaction, error) {
+	if w.Latest != nil {
+		return nil, fmt.Errorf("latest version does not support ApplyPoolUpdates")
+	}
+	if w.V1_2_0 != nil {
+		var poolUpdates []evm_2_evm_onramp_1_2_0.InternalPoolUpdate
+		if len(tokens) != len(pools) {
+			return nil, fmt.Errorf("tokens and pools length mismatch")
+		}
+		for i, token := range tokens {
+			poolUpdates = append(poolUpdates, evm_2_evm_onramp_1_2_0.InternalPoolUpdate{
+				Token: token,
+				Pool:  pools[i],
+			})
+		}
+		return w.V1_2_0.ApplyPoolUpdates(opts, []evm_2_evm_onramp_1_2_0.InternalPoolUpdate{}, poolUpdates)
+	}
+	return nil, fmt.Errorf("no instance found to apply pool updates")
+}
+
+func (w OnRampWrapper) CurrentRateLimiterState(opts *bind.CallOpts) (*RateLimiterConfig, error) {
+	if w.Latest != nil {
+		rlConfig, err := w.Latest.CurrentRateLimiterState(opts)
+		if err != nil {
+			return nil, err
+		}
+		return &RateLimiterConfig{
+			IsEnabled: rlConfig.IsEnabled,
+			Rate:      nil,
+			Capacity:  nil,
+		}, err
+	}
+	if w.V1_2_0 != nil {
+		rlConfig, err := w.V1_2_0.CurrentRateLimiterState(opts)
+		if err != nil {
+			return nil, err
+		}
+		return &RateLimiterConfig{
+			IsEnabled: rlConfig.IsEnabled,
+			Rate:      rlConfig.Rate,
+			Capacity:  rlConfig.Capacity,
+		}, err
+	}
+	return nil, fmt.Errorf("no instance found to get current rate limiter state")
+}
+
 type OnRamp struct {
 	client     blockchain.EVMClient
-	Instance   *evm_2_evm_onramp.EVM2EVMOnRamp
+	Instance   *OnRampWrapper
 	EthAddress common.Address
 }
 
@@ -816,10 +1441,7 @@ func (onRamp *OnRamp) SetNops() error {
 	}
 	owner := common.HexToAddress(onRamp.client.GetDefaultWallet().Address())
 	// set the payee to the default wallet
-	tx, err := onRamp.Instance.SetNops(opts, []evm_2_evm_onramp.EVM2EVMOnRampNopAndWeight{{
-		Nop:    owner,
-		Weight: 1,
-	}})
+	tx, err := onRamp.Instance.SetNops(opts, owner)
 	if err != nil {
 		return fmt.Errorf("failed to set nops: %w", err)
 	}
@@ -887,9 +1509,70 @@ func (onRamp *OnRamp) SetRateLimit(rlConfig evm_2_evm_onramp.RateLimiterConfig) 
 	return onRamp.client.ProcessTransaction(tx)
 }
 
+func (onRamp *OnRamp) ApplyPoolUpdates(tokens []common.Address, pools []common.Address) error {
+	// if the latest version is used, no need to apply pool updates
+	if onRamp.Instance.Latest != nil {
+		return nil
+	}
+	opts, err := onRamp.client.TransactionOpts(onRamp.client.GetDefaultWallet())
+	if err != nil {
+		return fmt.Errorf("failed to get transaction opts: %w", err)
+	}
+	tx, err := onRamp.Instance.ApplyPoolUpdates(opts, tokens, pools)
+	if err != nil {
+		return fmt.Errorf("failed to apply pool updates: %w", err)
+	}
+	log.Info().
+		Interface("tokens", tokens).
+		Interface("pools", pools).
+		Str("onRamp", onRamp.Address()).
+		Str(Network, onRamp.client.GetNetworkConfig().Name).
+		Msg("poolUpdates set in OnRamp")
+	return onRamp.client.ProcessTransaction(tx)
+}
+
+type OffRampWrapper struct {
+	Latest *evm_2_evm_offramp.EVM2EVMOffRamp
+	V1_2_0 *evm_2_evm_offramp_1_2_0.EVM2EVMOffRamp
+}
+
+func (offRamp *OffRampWrapper) CurrentRateLimiterState(opts *bind.CallOpts) (RateLimiterConfig, error) {
+	if offRamp.Latest != nil {
+		rlConfig, err := offRamp.Latest.CurrentRateLimiterState(opts)
+		if err != nil {
+			return RateLimiterConfig{}, err
+		}
+		return RateLimiterConfig{
+			IsEnabled: rlConfig.IsEnabled,
+			Capacity:  rlConfig.Capacity,
+			Rate:      rlConfig.Rate,
+		}, nil
+	}
+	if offRamp.V1_2_0 != nil {
+		rlConfig, err := offRamp.V1_2_0.CurrentRateLimiterState(opts)
+		if err != nil {
+			return RateLimiterConfig{}, err
+		}
+		return RateLimiterConfig{
+			IsEnabled: rlConfig.IsEnabled,
+			Capacity:  rlConfig.Capacity,
+			Rate:      rlConfig.Rate,
+		}, nil
+	}
+	return RateLimiterConfig{}, fmt.Errorf("no instance found to get rate limiter state")
+}
+
+type EVM2EVMOffRampExecutionStateChanged struct {
+	SequenceNumber uint64
+	MessageId      [32]byte
+	State          uint8
+	ReturnData     []byte
+	Raw            types.Log
+}
+
 type OffRamp struct {
 	client     blockchain.EVMClient
-	Instance   *evm_2_evm_offramp.EVM2EVMOffRamp
+	Instance   *OffRampWrapper
 	EthAddress common.Address
 }
 
@@ -917,45 +1600,98 @@ func (offRamp *OffRamp) SetOCR2Config(
 		Interface("transmitterAddresses", transmitters).
 		Str(Network, offRamp.client.GetNetworkConfig().Name).
 		Msg("Configuring OffRamp")
-	tx, err := offRamp.Instance.SetOCR2Config(
-		opts,
-		signers,
-		transmitters,
-		f,
-		onchainConfig,
-		offchainConfigVersion,
-		offchainConfig,
-	)
-
-	if err != nil {
-		return fmt.Errorf("failed to set OCR2 config: %w", err)
+	if offRamp.Instance.Latest != nil {
+		tx, err := offRamp.Instance.Latest.SetOCR2Config(
+			opts,
+			signers,
+			transmitters,
+			f,
+			onchainConfig,
+			offchainConfigVersion,
+			offchainConfig,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to set OCR2 config: %w", err)
+		}
+		return offRamp.client.ProcessTransaction(tx)
 	}
-	return offRamp.client.ProcessTransaction(tx)
+	if offRamp.Instance.V1_2_0 != nil {
+		tx, err := offRamp.Instance.V1_2_0.SetOCR2Config(
+			opts,
+			signers,
+			transmitters,
+			f,
+			onchainConfig,
+			offchainConfigVersion,
+			offchainConfig,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to set OCR2 config: %w", err)
+		}
+		return offRamp.client.ProcessTransaction(tx)
+	}
+	return fmt.Errorf("no instance found to set OCR2 config")
 }
 
 func (offRamp *OffRamp) UpdateRateLimitTokens(sourceTokens, destTokens []common.Address) error {
+	if offRamp.Instance.V1_2_0 != nil {
+		return nil
+	}
 	opts, err := offRamp.client.TransactionOpts(offRamp.client.GetDefaultWallet())
 	if err != nil {
 		return fmt.Errorf("failed to get transaction opts: %w", err)
 	}
-	rateLimitTokens := make([]evm_2_evm_offramp.EVM2EVMOffRampRateLimitToken, len(sourceTokens))
-	for i, sourceToken := range sourceTokens {
-		rateLimitTokens[i] = evm_2_evm_offramp.EVM2EVMOffRampRateLimitToken{
-			SourceToken: sourceToken,
-			DestToken:   destTokens[i],
+	if offRamp.Instance.Latest != nil {
+		rateLimitTokens := make([]evm_2_evm_offramp.EVM2EVMOffRampRateLimitToken, len(sourceTokens))
+		for i, sourceToken := range sourceTokens {
+			rateLimitTokens[i] = evm_2_evm_offramp.EVM2EVMOffRampRateLimitToken{
+				SourceToken: sourceToken,
+				DestToken:   destTokens[i],
+			}
 		}
-	}
 
-	tx, err := offRamp.Instance.UpdateRateLimitTokens(opts, []evm_2_evm_offramp.EVM2EVMOffRampRateLimitToken{}, rateLimitTokens)
-	if err != nil {
-		return fmt.Errorf("failed to apply rate limit tokens updates: %w", err)
+		tx, err := offRamp.Instance.Latest.UpdateRateLimitTokens(opts, []evm_2_evm_offramp.EVM2EVMOffRampRateLimitToken{}, rateLimitTokens)
+		if err != nil {
+			return fmt.Errorf("failed to apply rate limit tokens updates: %w", err)
+		}
+		log.Info().
+			Interface("rateLimitToken adds", rateLimitTokens).
+			Str("offRamp", offRamp.Address()).
+			Str(Network, offRamp.client.GetNetworkConfig().Name).
+			Msg("rateLimitTokens set in OffRamp")
+		return offRamp.client.ProcessTransaction(tx)
 	}
-	log.Info().
-		Interface("rateLimitToken adds", rateLimitTokens).
-		Str("offRamp", offRamp.Address()).
-		Str(Network, offRamp.client.GetNetworkConfig().Name).
-		Msg("rateLimitTokens set in OffRamp")
-	return offRamp.client.ProcessTransaction(tx)
+	return fmt.Errorf("no instance found to update rate limit tokens")
+}
+
+func (offRamp *OffRamp) SyncTokensAndPools(sourceTokens, pools []common.Address) error {
+	if offRamp.Instance.Latest != nil {
+		return nil
+	}
+	opts, err := offRamp.client.TransactionOpts(offRamp.client.GetDefaultWallet())
+	if err != nil {
+		return fmt.Errorf("failed to get transaction opts: %w", err)
+	}
+	if offRamp.Instance.V1_2_0 != nil {
+		var tokenUpdates []evm_2_evm_offramp_1_2_0.InternalPoolUpdate
+		for i, srcToken := range sourceTokens {
+			tokenUpdates = append(tokenUpdates, evm_2_evm_offramp_1_2_0.InternalPoolUpdate{
+				Token: srcToken,
+				Pool:  pools[i],
+			})
+		}
+		tx, err := offRamp.Instance.V1_2_0.ApplyPoolUpdates(opts, []evm_2_evm_offramp_1_2_0.InternalPoolUpdate{}, tokenUpdates)
+		if err != nil {
+			return fmt.Errorf("failed to apply pool updates: %w", err)
+		}
+		log.Info().
+			Interface("tokenUpdates", tokenUpdates).
+			Str("offRamp", offRamp.Address()).
+			Str(Network, offRamp.client.GetNetworkConfig().Name).
+			Msg("tokenUpdates set in OffRamp")
+		return offRamp.client.ProcessTransaction(tx)
+	}
+	return fmt.Errorf("no instance found to sync tokens and pools")
 }
 
 type MockAggregator struct {

--- a/integration-tests/ccip-tests/contracts/contract_models.go
+++ b/integration-tests/ccip-tests/contracts/contract_models.go
@@ -17,6 +17,7 @@ import (
 	"github.com/smartcontractkit/chainlink-testing-framework/blockchain"
 
 	"github.com/smartcontractkit/ccip/integration-tests/wrappers"
+
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/arm_contract"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/commit_store"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/commit_store_1_2_0"

--- a/integration-tests/ccip-tests/contracts/contract_models.go
+++ b/integration-tests/ccip-tests/contracts/contract_models.go
@@ -1406,8 +1406,8 @@ func (w OnRampWrapper) CurrentRateLimiterState(opts *bind.CallOpts) (*RateLimite
 		}
 		return &RateLimiterConfig{
 			IsEnabled: rlConfig.IsEnabled,
-			Rate:      nil,
-			Capacity:  nil,
+			Rate:      rlConfig.Rate,
+			Capacity:  rlConfig.Capacity,
 		}, err
 	}
 	if w.V1_2_0 != nil {

--- a/integration-tests/ccip-tests/contracts/laneconfig/parse_contracts.go
+++ b/integration-tests/ccip-tests/contracts/laneconfig/parse_contracts.go
@@ -34,7 +34,6 @@ type CommonContracts struct {
 	TokenTransmitter   string            `json:"token_transmitter,omitempty"`
 	TokenMessenger     string            `json:"token_messenger,omitempty"`
 	TokenAdminRegistry string            `json:"token_admin_registry,omitempty"`
-	Version            string            `json:"version,omitempty"`
 }
 
 type SourceContracts struct {
@@ -83,9 +82,6 @@ func (l *LaneConfig) Validate() error {
 	}
 	if l.PriceRegistry == "" || !common.IsHexAddress(l.PriceRegistry) {
 		laneConfigError = multierr.Append(laneConfigError, errors.New("must set proper address for price_registry"))
-	}
-	if l.Version != "" && (l.TokenAdminRegistry == "" || !common.IsHexAddress(l.TokenAdminRegistry)) {
-		laneConfigError = multierr.Append(laneConfigError, errors.New("must set proper address for token_admin_registry"))
 	}
 	if l.WrappedNative == "" || !common.IsHexAddress(l.WrappedNative) {
 		laneConfigError = multierr.Append(laneConfigError, errors.New("must set proper address for wrapped_native"))

--- a/integration-tests/ccip-tests/load/ccip_loadgen.go
+++ b/integration-tests/ccip-tests/load/ccip_loadgen.go
@@ -132,9 +132,8 @@ func (c *CCIPE2ELoad) BeforeAllCall() {
 		c.EOAReceiver = c.msg.Receiver
 	}
 	if c.SendMaxDataIntermittentlyInMsgCount > 0 {
-		dCfg, err := sourceCCIP.OnRamp.Instance.GetDynamicConfig(nil)
+		c.MaxDataBytes, err = sourceCCIP.OnRamp.Instance.GetDynamicConfig(nil)
 		require.NoError(c.t, err, "failed to fetch dynamic config")
-		c.MaxDataBytes = dCfg.MaxDataBytes
 	}
 	// if the msg is sent via multicall, transfer the token transfer amount to multicall contract
 	if sourceCCIP.Common.MulticallEnabled &&
@@ -354,9 +353,9 @@ func (c *CCIPE2ELoad) Validate(lggr zerolog.Logger, sendTx *types.Transaction, t
 	}
 
 	for _, msgLog := range msgLogs {
-		seqNum := msgLog.Message.SequenceNumber
+		seqNum := msgLog.SequenceNumber
 		var reqStat *testreporters.RequestStat
-		lggr = lggr.With().Str("msgId ", fmt.Sprintf("0x%x", msgLog.Message.MessageId[:])).Logger()
+		lggr = lggr.With().Str("msgId ", fmt.Sprintf("0x%x", msgLog.MessageId[:])).Logger()
 		for _, stat := range stats {
 			if stat.SeqNum == seqNum {
 				reqStat = stat

--- a/integration-tests/ccip-tests/load/ccip_test.go
+++ b/integration-tests/ccip-tests/load/ccip_test.go
@@ -305,6 +305,7 @@ func TestLoadCCIPStableWithPodChaosDiffCommitAndExec(t *testing.T) {
 // the remote-runner pod gets evicted after the loadgen is resumed.
 // The recommended frequency for this test 2req/min
 func TestLoadCCIPStableRPSAfterARMCurseAndUncurse(t *testing.T) {
+	t.Skipf("need to be enabled as part of CCIP-2277")
 	t.Parallel()
 	lggr := logging.GetTestLogger(t)
 	testArgs := NewLoadArgs(t, lggr)

--- a/integration-tests/ccip-tests/smoke/ccip_test.go
+++ b/integration-tests/ccip-tests/smoke/ccip_test.go
@@ -144,7 +144,7 @@ func TestSmokeCCIPRateLimit(t *testing.T) {
 			require.NoError(t, err)
 			tc.lane.Logger.Info().Interface("rate limit", prevRLOnRamp).Msg("Initial OnRamp rate limiter state")
 
-			prevOnRampRLTokenPool, err := src.Common.BridgeTokenPools[0].PoolInterface.GetCurrentOutboundRateLimiterState(nil, tc.lane.Source.DestinationChainId) // TODO RENS maybe?
+			prevOnRampRLTokenPool, err := src.Common.BridgeTokenPools[0].Instance.GetCurrentOutboundRateLimiterState(nil, tc.lane.Source.DestChainSelector) // TODO RENS maybe?
 			require.NoError(t, err)
 			tc.lane.Logger.Info().
 				Interface("rate limit", prevOnRampRLTokenPool).
@@ -160,7 +160,7 @@ func TestSmokeCCIPRateLimit(t *testing.T) {
 				require.GreaterOrEqual(t, rlOffRamp.Capacity.Cmp(prevRLOnRamp.Capacity), 0, "OffRamp Aggregated capacity should be greater than or equal to OnRamp Aggregated capacity")
 			}
 
-			prevOffRampRLTokenPool, err := tc.lane.Dest.Common.BridgeTokenPools[0].PoolInterface.GetCurrentInboundRateLimiterState(nil, tc.lane.Dest.SourceChainId) // TODO RENS maybe?
+			prevOffRampRLTokenPool, err := tc.lane.Dest.Common.BridgeTokenPools[0].Instance.GetCurrentInboundRateLimiterState(nil, tc.lane.Dest.SourceChainSelector) // TODO RENS maybe?
 			require.NoError(t, err)
 			tc.lane.Logger.Info().
 				Interface("rate limit", prevOffRampRLTokenPool).
@@ -220,11 +220,11 @@ func TestSmokeCCIPRateLimit(t *testing.T) {
 
 			tokenPrice, err := src.Common.PriceRegistry.Instance.GetTokenPrice(nil, src.Common.BridgeTokens[0].ContractAddress)
 			require.NoError(t, err)
-			tc.lane.Logger.Info().Str("tokenPrice.Value", tokenPrice.Value.String()).Msg("Price Registry Token Price")
+			tc.lane.Logger.Info().Str("tokenPrice.Value", tokenPrice.String()).Msg("Price Registry Token Price")
 
 			totalTokensForOnRampCapacity := new(big.Int).Mul(
 				big.NewInt(1e18),
-				new(big.Int).Div(rlOnRamp.Capacity, tokenPrice.Value))
+				new(big.Int).Div(rlOnRamp.Capacity, tokenPrice))
 
 			tc.lane.Source.Common.ChainClient.ParallelTransactions(true)
 
@@ -304,7 +304,7 @@ func TestSmokeCCIPRateLimit(t *testing.T) {
 				TokenPoolRateLimitRate = prevOnRampRLTokenPool.Rate
 			}
 
-			rlOnPool, err := src.Common.BridgeTokenPools[0].PoolInterface.GetCurrentOutboundRateLimiterState(nil, src.DestChainSelector)
+			rlOnPool, err := src.Common.BridgeTokenPools[0].Instance.GetCurrentOutboundRateLimiterState(nil, src.DestChainSelector)
 			require.NoError(t, err)
 			require.True(t, rlOnPool.IsEnabled, "Token Pool rate limiter should be enabled")
 

--- a/integration-tests/ccip-tests/testconfig/ccip.go
+++ b/integration-tests/ccip-tests/testconfig/ccip.go
@@ -16,6 +16,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/config"
 	ctfconfig "github.com/smartcontractkit/chainlink-testing-framework/config"
 
+	ccipcontracts "github.com/smartcontractkit/chainlink/integration-tests/ccip-tests/contracts"
 	"github.com/smartcontractkit/chainlink/integration-tests/contracts"
 )
 
@@ -370,9 +371,10 @@ func (c *CCIPContractConfig) ContractsData() ([]byte, error) {
 }
 
 type CCIP struct {
-	Env         *Common                    `toml:",omitempty"`
-	Deployments *CCIPContractConfig        `toml:",omitempty"`
-	Groups      map[string]*CCIPTestConfig `toml:",omitempty"`
+	Env              *Common                                   `toml:",omitempty"`
+	ContractVersions map[string]*ccipcontracts.ContractVersion `toml:",omitempty"`
+	Deployments      *CCIPContractConfig                       `toml:",omitempty"`
+	Groups           map[string]*CCIPTestConfig                `toml:",omitempty"`
 }
 
 func (c *CCIP) Validate() error {

--- a/integration-tests/ccip-tests/testconfig/override/mainnet-secondary.toml
+++ b/integration-tests/ccip-tests/testconfig/override/mainnet-secondary.toml
@@ -1,4 +1,11 @@
 [CCIP]
+[CCIP.ContractVersions]
+PriceRegistry = '1.2.0'
+OffRamp = '1.2.0'
+OnRamp = '1.2.0'
+TokenPool = '1.4.0'
+CommitStore = '1.2.0'
+
 [CCIP.Deployments]
 Data = """
 {

--- a/integration-tests/ccip-tests/testconfig/override/mainnet.toml
+++ b/integration-tests/ccip-tests/testconfig/override/mainnet.toml
@@ -1,4 +1,11 @@
 [CCIP]
+[CCIP.ContractVersions]
+PriceRegistry = '1.2.0'
+OffRamp = '1.2.0'
+OnRamp = '1.2.0'
+TokenPool = '1.4.0'
+CommitStore = '1.2.0'
+
 [CCIP.Deployments]
 Data = """
 {

--- a/integration-tests/ccip-tests/testconfig/tomls/ccip-default.toml
+++ b/integration-tests/ccip-tests/testconfig/tomls/ccip-default.toml
@@ -1,6 +1,13 @@
 # this file contains the deafult configuration for the test
 # all secrets must be stored in .env file and sourced before running the test
 [CCIP]
+[CCIP.ContractVersions]
+PriceRegistry = 'latest'
+OffRamp = 'latest'
+OnRamp = 'latest'
+CommitStore = 'latest'
+TokenPool = 'latest'
+
 # all variables to set up the test environment
 [CCIP.Env]
 TTL = '5h'

--- a/integration-tests/ccip-tests/testconfig/tomls/node-post-upgrade-compatibility.toml
+++ b/integration-tests/ccip-tests/testconfig/tomls/node-post-upgrade-compatibility.toml
@@ -1,4 +1,11 @@
 [CCIP]
+[CCIP.ContractVersions]
+PriceRegistry = '1.2.0'
+OffRamp = '1.2.0'
+OnRamp = '1.2.0'
+TokenPool = '1.4.0'
+CommitStore = '1.2.0'
+
 [CCIP.Deployments]
 DataFile = 'lane-config/.*.json'
 

--- a/integration-tests/ccip-tests/testconfig/tomls/scalability.toml
+++ b/integration-tests/ccip-tests/testconfig/tomls/scalability.toml
@@ -81,8 +81,8 @@ NoOfCommitNodes = 16
 PhaseTimeout = '50m'
 NodeFunding = 1000.0
 NoOfRoutersPerPair = 2
-#NoOfNetworks = 40
-#MaxNoOfLanes = 200
+NoOfNetworks = 40
+MaxNoOfLanes = 200
 
 [CCIP.Groups.load.OffRampConfig]
 BatchGasLimit = 11000000

--- a/integration-tests/ccip-tests/testconfig/tomls/scalability.toml
+++ b/integration-tests/ccip-tests/testconfig/tomls/scalability.toml
@@ -1,4 +1,12 @@
 [CCIP]
+# we are doing scalability testing against previous release, therefor overriding the contract versions accordingly
+[CCIP.ContractVersions]
+PriceRegistry = '1.2.0'
+OffRamp = '1.2.0'
+OnRamp = '1.2.0'
+TokenPool = '1.4.0'
+CommitStore = '1.2.0'
+
 [CCIP.Env]
 TTL = '15h'
 
@@ -19,7 +27,7 @@ evm_minimum_confirmations = 1
 evm_gas_estimation_buffer = 1000
 evm_supports_eip1559 = true
 evm_default_gas_limit = 7000000
-evm_finality_depth = 1800 # with 1800 blocks of finality, and 1s block time, we have 30 minutes of finality
+evm_finality_depth = 1800 # with 1800 blocks of finality, and 2s block time
 
 [CCIP.Env.Network.EVMNetworks.PRIVATE-CHAIN-2]
 evm_name = 'private-chain-2'
@@ -35,13 +43,13 @@ evm_minimum_confirmations = 1
 evm_gas_estimation_buffer = 1000
 evm_supports_eip1559 = true
 evm_default_gas_limit = 7000000
-evm_finality_depth = 1800 # with 1800 blocks of finality, and 1s block time, we have 30 minutes of finality
+evm_finality_depth = 1800 # with 1800 blocks of finality, and 2s block time
 
-[CCIP.Env.Network.AnvilConfigs.PRIVATE-CHAIN-1]
-block_time = 1
-
-[CCIP.Env.Network.AnvilConfigs.PRIVATE-CHAIN-2]
-block_time = 1
+#[CCIP.Env.Network.AnvilConfigs.PRIVATE-CHAIN-1]
+#block_time = 1
+#
+#[CCIP.Env.Network.AnvilConfigs.PRIVATE-CHAIN-2]
+#block_time = 1
 
 [CCIP.Env.NewCLCluster]
 NoOfNodes = 17
@@ -73,8 +81,8 @@ NoOfCommitNodes = 16
 PhaseTimeout = '50m'
 NodeFunding = 1000.0
 NoOfRoutersPerPair = 2
-NoOfNetworks = 40
-MaxNoOfLanes = 200
+#NoOfNetworks = 40
+#MaxNoOfLanes = 200
 
 [CCIP.Groups.load.OffRampConfig]
 BatchGasLimit = 11000000

--- a/integration-tests/ccip-tests/testsetups/ccip.go
+++ b/integration-tests/ccip-tests/testsetups/ccip.go
@@ -73,6 +73,7 @@ type CCIPTestConfig struct {
 	Test                *testing.T
 	EnvInput            *testconfig.Common
 	TestGroupInput      *testconfig.CCIPTestConfig
+	VersionInput        map[string]*contracts.ContractVersion
 	ContractsInput      *testconfig.CCIPContractConfig
 	AllNetworks         map[string]blockchain.EVMNetwork
 	SelectedNetworks    []blockchain.EVMNetwork
@@ -294,6 +295,31 @@ func (c *CCIPTestConfig) FormNetworkPairCombinations() {
 	}
 }
 
+func (c *CCIPTestConfig) SetContractVersion() error {
+	if c.VersionInput == nil {
+		return nil
+	}
+	for contractName, version := range c.VersionInput {
+		if version != nil {
+			if _, ok := contracts.VersionMap[contractName]; !ok {
+				return fmt.Errorf("contract versioning is not supported for %s, versioning is supported for %v",
+					contractName, contracts.SupportedContracts)
+			}
+			supportedVersions, ok := contracts.SupportedContracts[contractName]
+			if !ok {
+				return fmt.Errorf("contract %s is not supported, versioning is supported for %v",
+					contractName, contracts.SupportedContracts)
+			}
+			if valid, exists := supportedVersions[*version]; !exists || !valid {
+				return fmt.Errorf("contract %s does not support version %s, versioning is supported for %v",
+					contractName, *version, supportedVersions)
+			}
+			contracts.VersionMap[contractName] = *version
+		}
+	}
+	return nil
+}
+
 func (c *CCIPTestConfig) SetOCRParams() error {
 	if c.TestGroupInput.CommitOCRParams != nil {
 		err := mergo.Merge(&contracts.OCR2ParamsForCommit, c.TestGroupInput.CommitOCRParams, mergo.WithOverride)
@@ -353,10 +379,15 @@ func NewCCIPTestConfig(t *testing.T, lggr zerolog.Logger, tType string) *CCIPTes
 		Test:                t,
 		EnvInput:            testCfg.CCIP.Env,
 		ContractsInput:      testCfg.CCIP.Deployments,
+		VersionInput:        testCfg.CCIP.ContractVersions,
 		TestGroupInput:      groupCfg,
 		GethResourceProfile: GethResourceProfile,
 	}
-	err := ccipTestConfig.SetOCRParams()
+	err := ccipTestConfig.SetContractVersion()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ccipTestConfig.SetOCRParams()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Motivation
Use updated test image to test previous ccip images

## Solution
Currently tests use latest gethwrappers for each contracts. It creates version compatibility issues when recent test image is used with previous ccip releases. Previous ccip releases are not compatible with updated ccip contracts.
Introduce contract versioning in test. Default is always latest unless it is overridden by test input toml.