### PR TITLE
Support token prices in commit plugin

### DIFF
--- a/core/services/ocr3/plugins/ccip/commit/factory.go
+++ b/core/services/ocr3/plugins/ccip/commit/factory.go
@@ -41,8 +41,17 @@ func NewPluginFactory() *PluginFactory {
 	return &PluginFactory{}
 }
 
-func (p PluginFactory) NewReportingPlugin(config ocr3types.ReportingPluginConfig) (ocr3types.ReportingPlugin[[]byte], ocr3types.ReportingPluginInfo, error) {
-	return NewPlugin(context.Background(), config.OracleID, model.CommitPluginConfig{}, nil, nil, nil), ocr3types.ReportingPluginInfo{}, nil
+func (p PluginFactory) NewReportingPlugin(config ocr3types.ReportingPluginConfig,
+) (ocr3types.ReportingPlugin[[]byte], ocr3types.ReportingPluginInfo, error) {
+	return NewPlugin(
+		context.Background(),
+		config.OracleID,
+		model.CommitPluginConfig{},
+		nil,
+		nil,
+		nil,
+		nil,
+	), ocr3types.ReportingPluginInfo{}, nil
 }
 
 func (p PluginFactory) Name() string {

--- a/core/services/ocr3/plugins/ccip/commit/plugin.go
+++ b/core/services/ocr3/plugins/ccip/commit/plugin.go
@@ -21,11 +21,12 @@ import (
 // Plugin implements the main ocr3 ccip commit plugin logic.
 // To learn more about the plugin lifecycle, see the ocr3types.ReportingPlugin interface.
 type Plugin struct {
-	nodeID      commontypes.OracleID
-	cfg         model.CommitPluginConfig
-	ccipReader  reader.CCIP
-	reportCodec codec.Commit
-	lggr        logger.Logger
+	nodeID            commontypes.OracleID
+	cfg               model.CommitPluginConfig
+	ccipReader        reader.CCIP
+	tokenPricesReader reader.TokenPrices
+	reportCodec       codec.Commit
+	lggr              logger.Logger
 
 	// readableChains is the set of chains that the plugin can read from.
 	readableChains mapset.Set[model.ChainSelector]
@@ -40,6 +41,7 @@ func NewPlugin(
 	nodeID commontypes.OracleID,
 	cfg model.CommitPluginConfig,
 	ccipReader reader.CCIP,
+	tokenPricesReader reader.TokenPrices,
 	reportCodec codec.Commit,
 	lggr logger.Logger,
 ) *Plugin {
@@ -49,11 +51,12 @@ func NewPlugin(
 	}
 
 	return &Plugin{
-		nodeID:      nodeID,
-		cfg:         cfg,
-		ccipReader:  ccipReader,
-		reportCodec: reportCodec,
-		lggr:        lggr,
+		nodeID:            nodeID,
+		cfg:               cfg,
+		ccipReader:        ccipReader,
+		tokenPricesReader: tokenPricesReader,
+		reportCodec:       reportCodec,
+		lggr:              lggr,
 
 		readableChains:    mapset.NewSet(cfg.Reads...),
 		knownSourceChains: knownSourceChains,
@@ -86,7 +89,8 @@ func (p *Plugin) Query(_ context.Context, _ ocr3types.OutcomeContext) (types.Que
 //
 // Token Prices:
 //
-//	TODO
+//	We discover the token prices only for the tokens that are used to pay for ccip fees.
+//	The fee tokens are configured in the plugin config.
 func (p *Plugin) Observation(ctx context.Context, outctx ocr3types.OutcomeContext, _ types.Query) (types.Observation, error) {
 	maxSeqNumsPerChain, err := observeMaxSeqNums(
 		ctx,
@@ -113,7 +117,19 @@ func (p *Plugin) Observation(ctx context.Context, outctx ocr3types.OutcomeContex
 		return types.Observation{}, fmt.Errorf("observe new messages: %w", err)
 	}
 
-	// TODO: The code below is related to token and gas prices and should be cleaned up in relevant PRs...
+	var tokenPrices []model.TokenPrice
+	if p.cfg.TokenPricesObserver {
+		tokenPrices, err = observeTokenPrices(
+			ctx,
+			p.tokenPricesReader,
+			p.cfg.FeeTokens,
+		)
+		if err != nil {
+			return types.Observation{}, fmt.Errorf("observe token prices: %w", err)
+		}
+	}
+
+	// TODO: The code below is related to gas prices and should be cleaned up in relevant PRs...
 	knownSourceChainsSlice := p.knownSourceChains.ToSlice()
 	sort.Slice(knownSourceChainsSlice, func(i, j int) bool { return knownSourceChainsSlice[i] < knownSourceChainsSlice[j] })
 
@@ -130,10 +146,10 @@ func (p *Plugin) Observation(ctx context.Context, outctx ocr3types.OutcomeContex
 		gasPrices = append(gasPrices, model.NewGasPriceChain(gasPricesVals[i], ch))
 	}
 
-	// Find the token prices.
-	tokenPrices := make([]model.TokenPrice, 0) // TODO: token prices ...
-
-	p.lggr.Infow("submitting observation", "observedNewMsgs", len(newMsgs), "gasPrices", len(gasPrices), "tokenPrices", len(tokenPrices))
+	p.lggr.Infow("submitting observation",
+		"observedNewMsgs", len(newMsgs),
+		"gasPrices", len(gasPrices),
+		"tokenPrices", len(tokenPrices))
 	return model.NewCommitPluginObservation(newMsgs, gasPrices, tokenPrices, maxSeqNumsPerChain).Encode()
 }
 
@@ -151,8 +167,8 @@ func (p *Plugin) ValidateObservation(_ ocr3types.OutcomeContext, _ types.Query, 
 		return fmt.Errorf("validate observer %d reading eligibility: %w", ao.Observer, err)
 	}
 
-	if err := validateObservedGasAndTokenPrices(obs.GasPrices, obs.TokenPrices); err != nil {
-		return fmt.Errorf("validate gas and token prices: %w", err)
+	if err := validateObservedTokenPrices(obs.TokenPrices); err != nil {
+		return fmt.Errorf("validate token prices: %w", err)
 	}
 
 	return nil
@@ -195,7 +211,12 @@ func (p *Plugin) Outcome(_ ocr3types.OutcomeContext, _ types.Query, aos []types.
 	}
 	p.lggr.Debugw("new messages consensus", "merkleRoots", merkleRoots)
 
-	return model.NewCommitPluginOutcome(maxSeqNumsConsensus, merkleRoots).Encode()
+	tokenPrices, err := tokenPricesConsensus(decodedObservations, p.cfg.FChain[p.cfg.DestChain])
+	if err != nil {
+		return ocr3types.Outcome{}, fmt.Errorf("token prices consensus: %w", err)
+	}
+
+	return model.NewCommitPluginOutcome(maxSeqNumsConsensus, merkleRoots, tokenPrices).Encode()
 }
 
 func (p *Plugin) Reports(seqNr uint64, outcome ocr3types.Outcome) ([]ocr3types.ReportWithInfo[[]byte], error) {

--- a/core/services/ocr3/plugins/ccip/commit/plugin_functions_test.go
+++ b/core/services/ocr3/plugins/ccip/commit/plugin_functions_test.go
@@ -2,6 +2,7 @@ package commit
 
 import (
 	"context"
+	"math/big"
 	"reflect"
 	"slices"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	"github.com/smartcontractkit/ccipocr3/internal/mocks"
 	"github.com/smartcontractkit/ccipocr3/internal/model"
 	"github.com/smartcontractkit/libocr/commontypes"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -227,6 +229,34 @@ func Test_observeNewMsgs(t *testing.T) {
 	}
 }
 
+func Test_observeTokenPrices(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("happy path", func(t *testing.T) {
+		priceReader := mocks.NewTokenPricesReader()
+		tokens := []types.Account{"0x1", "0x2", "0x3"}
+		mockPrices := []*big.Int{big.NewInt(10), big.NewInt(20), big.NewInt(30)}
+		priceReader.On("GetTokenPricesUSD", ctx, tokens).Return(mockPrices, nil)
+		prices, err := observeTokenPrices(ctx, priceReader, tokens)
+		assert.NoError(t, err)
+		assert.Equal(t, []model.TokenPrice{
+			model.NewTokenPrice("0x1", big.NewInt(10)),
+			model.NewTokenPrice("0x2", big.NewInt(20)),
+			model.NewTokenPrice("0x3", big.NewInt(30)),
+		}, prices)
+	})
+
+	t.Run("price reader internal issue", func(t *testing.T) {
+		priceReader := mocks.NewTokenPricesReader()
+		tokens := []types.Account{"0x1", "0x2", "0x3"}
+		mockPrices := []*big.Int{big.NewInt(10), big.NewInt(20)} // returned two prices for three tokens
+		priceReader.On("GetTokenPricesUSD", ctx, tokens).Return(mockPrices, nil)
+		_, err := observeTokenPrices(ctx, priceReader, tokens)
+		assert.Error(t, err)
+	})
+
+}
+
 func Test_validateObservedSequenceNumbers(t *testing.T) {
 	testCases := []struct {
 		name       string
@@ -399,7 +429,61 @@ func Test_validateObserverReadingEligibility(t *testing.T) {
 	}
 }
 
-func Test_validateObservedGasAndTokenPrices(t *testing.T) {}
+func Test_validateObservedTokenPrices(t *testing.T) {
+	testCases := []struct {
+		name        string
+		tokenPrices []model.TokenPrice
+		expErr      bool
+	}{
+		{
+			name:        "empty is valid",
+			tokenPrices: []model.TokenPrice{},
+			expErr:      false,
+		},
+		{
+			name: "all valid",
+			tokenPrices: []model.TokenPrice{
+				model.NewTokenPrice("0x1", big.NewInt(1)),
+				model.NewTokenPrice("0x2", big.NewInt(1)),
+				model.NewTokenPrice("0x3", big.NewInt(1)),
+				model.NewTokenPrice("0xa", big.NewInt(1)),
+			},
+			expErr: false,
+		},
+		{
+			name: "dup price",
+			tokenPrices: []model.TokenPrice{
+				model.NewTokenPrice("0x1", big.NewInt(1)),
+				model.NewTokenPrice("0x2", big.NewInt(1)),
+				model.NewTokenPrice("0x1", big.NewInt(1)), // dup
+				model.NewTokenPrice("0xa", big.NewInt(1)),
+			},
+			expErr: true,
+		},
+		{
+			name: "nil price",
+			tokenPrices: []model.TokenPrice{
+				model.NewTokenPrice("0x1", big.NewInt(1)),
+				model.NewTokenPrice("0x2", big.NewInt(1)),
+				model.NewTokenPrice("0x3", nil), // nil price
+				model.NewTokenPrice("0xa", big.NewInt(1)),
+			},
+			expErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateObservedTokenPrices(tc.tokenPrices)
+			if tc.expErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+
+	}
+}
 
 func Test_newMsgsConsensus(t *testing.T) {
 	testCases := []struct {
@@ -765,6 +849,7 @@ func Test_maxSeqNumsConsensus(t *testing.T) {
 				},
 				nil,
 				nil,
+				nil,
 				lggr,
 			)
 
@@ -775,6 +860,116 @@ func Test_maxSeqNumsConsensus(t *testing.T) {
 			}
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expSeqNums, seqNums)
+		})
+	}
+}
+
+func Test_tokenPricesConsensus(t *testing.T) {
+	testCases := []struct {
+		name         string
+		observations []model.CommitPluginObservation
+		fChain       int
+		expPrices    []model.TokenPrice
+		expErr       bool
+	}{
+		{
+			name:         "empty",
+			observations: make([]model.CommitPluginObservation, 0),
+			fChain:       2,
+			expPrices:    make([]model.TokenPrice, 0),
+			expErr:       false,
+		},
+		{
+			name: "happy flow",
+			observations: []model.CommitPluginObservation{
+				{
+					TokenPrices: []model.TokenPrice{
+						model.NewTokenPrice("0x1", big.NewInt(10)),
+						model.NewTokenPrice("0x2", big.NewInt(20)),
+					},
+				},
+				{
+					TokenPrices: []model.TokenPrice{
+						model.NewTokenPrice("0x1", big.NewInt(11)),
+						model.NewTokenPrice("0x2", big.NewInt(21)),
+					},
+				},
+				{
+					TokenPrices: []model.TokenPrice{
+						model.NewTokenPrice("0x1", big.NewInt(11)),
+						model.NewTokenPrice("0x2", big.NewInt(21)),
+					},
+				},
+				{
+					TokenPrices: []model.TokenPrice{
+						model.NewTokenPrice("0x1", big.NewInt(10)),
+						model.NewTokenPrice("0x2", big.NewInt(21)),
+					},
+				},
+				{
+					TokenPrices: []model.TokenPrice{
+						model.NewTokenPrice("0x1", big.NewInt(11)),
+						model.NewTokenPrice("0x2", big.NewInt(20)),
+					},
+				},
+			},
+			fChain: 2,
+			expPrices: []model.TokenPrice{
+				model.NewTokenPrice("0x1", big.NewInt(11)),
+				model.NewTokenPrice("0x2", big.NewInt(21)),
+			},
+			expErr: false,
+		},
+		{
+			name: "not enough observations for some token",
+			observations: []model.CommitPluginObservation{
+				{
+					TokenPrices: []model.TokenPrice{
+						model.NewTokenPrice("0x2", big.NewInt(20)),
+					},
+				},
+				{
+					TokenPrices: []model.TokenPrice{
+						model.NewTokenPrice("0x1", big.NewInt(11)),
+						model.NewTokenPrice("0x2", big.NewInt(21)),
+					},
+				},
+				{
+					TokenPrices: []model.TokenPrice{
+						model.NewTokenPrice("0x1", big.NewInt(11)),
+						model.NewTokenPrice("0x2", big.NewInt(21)),
+					},
+				},
+				{
+					TokenPrices: []model.TokenPrice{
+						model.NewTokenPrice("0x1", big.NewInt(10)),
+						model.NewTokenPrice("0x2", big.NewInt(21)),
+					},
+				},
+				{
+					TokenPrices: []model.TokenPrice{
+						model.NewTokenPrice("0x1", big.NewInt(10)),
+						model.NewTokenPrice("0x2", big.NewInt(20)),
+					},
+				},
+			},
+			fChain: 2,
+			expPrices: []model.TokenPrice{
+				model.NewTokenPrice("0x2", big.NewInt(21)),
+			},
+			expErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			prices, err := tokenPricesConsensus(tc.observations, tc.fChain)
+			if tc.expErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expPrices, prices)
 		})
 	}
 }

--- a/core/services/ocr3/plugins/ccip/internal/libs/slicelib/bigint.go
+++ b/core/services/ocr3/plugins/ccip/internal/libs/slicelib/bigint.go
@@ -1,0 +1,24 @@
+package slicelib
+
+import (
+	"sort"
+
+	"github.com/smartcontractkit/ccipocr3/internal/model"
+)
+
+// BigIntSortedMiddle returns the middle number after sorting the provided numbers. nil is returned if the provided slice is empty.
+// If length of the provided slice is even, the right-hand-side value of the middle 2 numbers is returned.
+// The objective of this function is to always pick within the range of values reported by honest nodes when we have 2f+1 values.
+func BigIntSortedMiddle(vals []model.BigInt) model.BigInt {
+	if len(vals) == 0 {
+		return model.BigInt{}
+	}
+
+	valsCopy := make([]model.BigInt, len(vals))
+	copy(valsCopy[:], vals[:])
+
+	sort.Slice(valsCopy, func(i, j int) bool {
+		return (valsCopy[i].Int).Cmp(valsCopy[j].Int) < 0
+	})
+	return valsCopy[len(valsCopy)/2]
+}

--- a/core/services/ocr3/plugins/ccip/internal/libs/slicelib/bigint_test.go
+++ b/core/services/ocr3/plugins/ccip/internal/libs/slicelib/bigint_test.go
@@ -1,0 +1,55 @@
+package slicelib
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/smartcontractkit/ccipocr3/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBigIntSortedMiddle(t *testing.T) {
+	tests := []struct {
+		name string
+		vals []model.BigInt
+		want model.BigInt
+	}{
+		{
+			name: "base case",
+			vals: []model.BigInt{
+				{big.NewInt(1)},
+				{big.NewInt(2)},
+				{big.NewInt(4)},
+				{big.NewInt(5)},
+			},
+			want: model.BigInt{Int: big.NewInt(4)},
+		},
+		{
+			name: "not sorted",
+			vals: []model.BigInt{
+				{big.NewInt(100)},
+				{big.NewInt(50)},
+				{big.NewInt(30)},
+				{big.NewInt(110)},
+			},
+			want: model.BigInt{Int: big.NewInt(100)},
+		},
+		{
+			name: "empty slice",
+			vals: []model.BigInt{},
+			want: model.BigInt{},
+		},
+		{
+			name: "one item",
+			vals: []model.BigInt{
+				{big.NewInt(123)},
+			},
+			want: model.BigInt{Int: big.NewInt(123)},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, BigIntSortedMiddle(tt.vals), "BigIntSortedMiddle(%v)", tt.vals)
+		})
+	}
+}

--- a/core/services/ocr3/plugins/ccip/internal/mocks/pricesreader.go
+++ b/core/services/ocr3/plugins/ccip/internal/mocks/pricesreader.go
@@ -1,0 +1,28 @@
+package mocks
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/smartcontractkit/ccipocr3/internal/reader"
+	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+	"github.com/stretchr/testify/mock"
+)
+
+type TokenPricesReader struct {
+	*mock.Mock
+}
+
+func NewTokenPricesReader() *TokenPricesReader {
+	return &TokenPricesReader{
+		Mock: &mock.Mock{},
+	}
+}
+
+func (t TokenPricesReader) GetTokenPricesUSD(ctx context.Context, tokens []ocrtypes.Account) ([]*big.Int, error) {
+	args := t.Called(ctx, tokens)
+	return args.Get(0).([]*big.Int), args.Error(1)
+}
+
+// Interface compatibility check.
+var _ reader.TokenPrices = (*TokenPricesReader)(nil)

--- a/core/services/ocr3/plugins/ccip/internal/model/ccip.go
+++ b/core/services/ocr3/plugins/ccip/internal/model/ccip.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math/big"
@@ -12,13 +11,13 @@ import (
 
 type TokenPrice struct {
 	TokenID types.Account `json:"tokenID"`
-	Price   *big.Int
+	Price   BigInt        `json:"price"`
 }
 
 func NewTokenPrice(tokenID types.Account, price *big.Int) TokenPrice {
 	return TokenPrice{
 		TokenID: tokenID,
-		Price:   price,
+		Price:   BigInt{price},
 	}
 }
 
@@ -87,27 +86,4 @@ type CCIPMsgBaseDetails struct {
 	ID          Bytes32       `json:"id"`
 	SourceChain ChainSelector `json:"sourceChain,string"`
 	SeqNum      SeqNum        `json:"seqNum,string"`
-}
-
-type Bytes32 [32]byte
-
-func (m Bytes32) String() string {
-	return "0x" + hex.EncodeToString(m[:])
-}
-
-func (m Bytes32) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf(`"%s"`, m.String())), nil
-}
-
-func (m *Bytes32) UnmarshalJSON(data []byte) error {
-	v := string(data)
-	if len(v) < 4 {
-		return fmt.Errorf("invalid MerkleRoot: %s", v)
-	}
-	b, err := hex.DecodeString(v[1 : len(v)-1][2:])
-	if err != nil {
-		return err
-	}
-	copy(m[:], b)
-	return nil
 }

--- a/core/services/ocr3/plugins/ccip/internal/model/ccip_test.go
+++ b/core/services/ocr3/plugins/ccip/internal/model/ccip_test.go
@@ -77,7 +77,7 @@ func TestNewTokenPrice(t *testing.T) {
 	t.Run("base", func(t *testing.T) {
 		tp := NewTokenPrice("link", big.NewInt(1000))
 		assert.Equal(t, "link", string(tp.TokenID))
-		assert.Equal(t, uint64(1000), tp.Price.Uint64())
+		assert.Equal(t, uint64(1000), tp.Price.Int.Uint64())
 	})
 }
 

--- a/core/services/ocr3/plugins/ccip/internal/model/commit.go
+++ b/core/services/ocr3/plugins/ccip/internal/model/commit.go
@@ -42,12 +42,18 @@ func DecodeCommitPluginObservation(b []byte) (CommitPluginObservation, error) {
 type CommitPluginOutcome struct {
 	MaxSeqNums  []SeqNumChain     `json:"maxSeqNums"`
 	MerkleRoots []MerkleRootChain `json:"merkleRoots"`
+	TokenPrices []TokenPrice      `json:"tokenPrices"`
 }
 
-func NewCommitPluginOutcome(seqNums []SeqNumChain, merkleRoots []MerkleRootChain) CommitPluginOutcome {
+func NewCommitPluginOutcome(
+	seqNums []SeqNumChain,
+	merkleRoots []MerkleRootChain,
+	tokenPrices []TokenPrice,
+) CommitPluginOutcome {
 	return CommitPluginOutcome{
 		MaxSeqNums:  seqNums,
 		MerkleRoots: merkleRoots,
+		TokenPrices: tokenPrices,
 	}
 }
 

--- a/core/services/ocr3/plugins/ccip/internal/model/commit_test.go
+++ b/core/services/ocr3/plugins/ccip/internal/model/commit_test.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"math"
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,11 +38,15 @@ func TestCommitPluginOutcome_EncodeAndDecode(t *testing.T) {
 			NewMerkleRootChain(ChainSelector(1), NewSeqNumRange(21, 22), [32]byte{1}),
 			NewMerkleRootChain(ChainSelector(2), NewSeqNumRange(25, 35), [32]byte{2}),
 		},
+		[]TokenPrice{
+			NewTokenPrice("0x123", big.NewInt(1234)),
+			NewTokenPrice("0x125", big.NewInt(0).Mul(big.NewInt(999999999999), big.NewInt(999999999999))),
+		},
 	)
 
 	b, err := o.Encode()
 	assert.NoError(t, err)
-	assert.Equal(t, string(b), `{"maxSeqNums":[{"chainSel":1,"seqNum":20},{"chainSel":2,"seqNum":25}],"merkleRoots":[{"chain":1,"seqNumsRange":[21,22],"merkleRoot":"0x0100000000000000000000000000000000000000000000000000000000000000"},{"chain":2,"seqNumsRange":[25,35],"merkleRoot":"0x0200000000000000000000000000000000000000000000000000000000000000"}]}`)
+	assert.Equal(t, `{"maxSeqNums":[{"chainSel":1,"seqNum":20},{"chainSel":2,"seqNum":25}],"merkleRoots":[{"chain":1,"seqNumsRange":[21,22],"merkleRoot":"0x0100000000000000000000000000000000000000000000000000000000000000"},{"chain":2,"seqNumsRange":[25,35],"merkleRoot":"0x0200000000000000000000000000000000000000000000000000000000000000"}],"tokenPrices":[{"tokenID":"0x123","price":"1234"},{"tokenID":"0x125","price":"999999999998000000000001"}]}`, string(b))
 
 	o2, err := DecodeCommitPluginOutcome(b)
 	assert.NoError(t, err)

--- a/core/services/ocr3/plugins/ccip/internal/model/config.go
+++ b/core/services/ocr3/plugins/ccip/internal/model/config.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/smartcontractkit/libocr/commontypes"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 )
 
 type CommitPluginConfig struct {
@@ -23,7 +24,12 @@ type CommitPluginConfig struct {
 	// ObserverInfo is a map of oracle IDs to ObserverInfo.
 	ObserverInfo map[commontypes.OracleID]ObserverInfo
 
-	// TBD:
+	// FeeTokens is a list of tokens that can be used to pay for ccip fees.
+	FeeTokens []types.Account
+
+	// TokenPricesObserver indicates that the node can observe token prices.
+	TokenPricesObserver bool
+
 	NewMsgScanDuration  time.Duration
 	NewMsgScanLimit     int
 	NewMsgScanBatchSize int

--- a/core/services/ocr3/plugins/ccip/internal/model/types.go
+++ b/core/services/ocr3/plugins/ccip/internal/model/types.go
@@ -1,0 +1,61 @@
+package model
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math/big"
+)
+
+type Bytes32 [32]byte
+
+func (m Bytes32) String() string {
+	return "0x" + hex.EncodeToString(m[:])
+}
+
+func (m Bytes32) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%s"`, m.String())), nil
+}
+
+func (m *Bytes32) UnmarshalJSON(data []byte) error {
+	v := string(data)
+	if len(v) < 4 {
+		return fmt.Errorf("invalid MerkleRoot: %s", v)
+	}
+	b, err := hex.DecodeString(v[1 : len(v)-1][2:])
+	if err != nil {
+		return err
+	}
+	copy(m[:], b)
+	return nil
+}
+
+type BigInt struct {
+	*big.Int
+}
+
+func (b BigInt) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%s"`, b.String())), nil
+}
+
+func (b *BigInt) UnmarshalJSON(p []byte) error {
+	if string(p) == "null" {
+		return nil
+	}
+
+	if len(p) < 2 {
+		return fmt.Errorf("invalid BigInt: %s", p)
+	}
+	p = p[1 : len(p)-1]
+
+	z := big.NewInt(0)
+	_, ok := z.SetString(string(p), 10)
+	if !ok {
+		return fmt.Errorf("not a valid big integer: %s", p)
+	}
+	b.Int = z
+	return nil
+}
+
+func (b BigInt) IsEmpty() bool {
+	return b.Int == nil
+}

--- a/core/services/ocr3/plugins/ccip/internal/reader/prices.go
+++ b/core/services/ocr3/plugins/ccip/internal/reader/prices.go
@@ -1,0 +1,14 @@
+package reader
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+)
+
+type TokenPrices interface {
+	// GetTokenPricesUSD returns the prices of the provided tokens in USD.
+	// The order of the returned prices corresponds to the order of the provided tokens.
+	GetTokenPricesUSD(ctx context.Context, tokens []types.Account) ([]*big.Int, error)
+}


### PR DESCRIPTION
Supporting token prices in commit plugin.

- Config: Prices only for fee tokens, provided in plugin config.
- Observation: Using token prices reader interface
- Validations: Non dups / etc...
- Consensus: Median
