### PR TITLE
Fix changeset checker for ccip

### DIFF
--- a/.changeset/moody-masks-perform.md
+++ b/.changeset/moody-masks-perform.md
@@ -1,0 +1,5 @@
+---
+"ccip": patch
+---
+
+Fix changeset checker for ccip #bugfix

--- a/.github/scripts/check-changeset-tags.sh
+++ b/.github/scripts/check-changeset-tags.sh
@@ -30,10 +30,10 @@ if [[ ! -f "$CHANGESET_FILE_PATH" ]]; then
 fi
 
 changeset_content=$(sed -n '/^---$/,/^---$/{ /^---$/!p; }' $CHANGESET_FILE_PATH)
-semvar_value=$(echo "$changeset_content" | awk -F": " '/"chainlink"/ {print $2}')
+semvar_value=$(echo "$changeset_content" | awk -F": " '/"ccip"/ {print $2}')
 
 if [[ "$semvar_value" != "major" && "$semvar_value" != "minor" && "$semvar_value" != "patch" ]]; then
-  echo "Invalid changeset semvar value for 'chainlink'. Must be 'major', 'minor', or 'patch'."
+  echo "Invalid changeset semvar value for 'ccip'. Must be 'major', 'minor', or 'patch'."
   exit 1
 fi
 


### PR DESCRIPTION
## Motivation
After merging the chainlink core branch, the changeset generator no longer works with ccip tags

## Solution
Modify `chainlink` tag to `ccip`