### PR TITLE
Use Common Test Logger

### DIFF
--- a/integration-tests/ccip-tests/contracts/contract_deployer.go
+++ b/integration-tests/ccip-tests/contracts/contract_deployer.go
@@ -62,6 +62,7 @@ import (
 // CCIPContractsDeployer provides the implementations for deploying CCIP ETH contracts
 type CCIPContractsDeployer struct {
 	evmClient   blockchain.EVMClient
+	logger      zerolog.Logger
 	EthDeployer *contracts.EthereumContractDeployer
 }
 
@@ -69,6 +70,7 @@ type CCIPContractsDeployer struct {
 func NewCCIPContractsDeployer(logger zerolog.Logger, bcClient blockchain.EVMClient) (*CCIPContractsDeployer, error) {
 	return &CCIPContractsDeployer{
 		evmClient:   bcClient,
+		logger:      logger,
 		EthDeployer: contracts.NewEthereumContractDeployer(bcClient, logger),
 	}, nil
 }
@@ -126,7 +128,7 @@ func (e *CCIPContractsDeployer) NewTokenTransmitter(addr common.Address) (*Token
 	if err != nil {
 		return nil, err
 	}
-	log.Info().
+	e.logger.Info().
 		Str("Contract Address", addr.Hex()).
 		Str("Contract Name", "Mock USDC Token Transmitter").
 		Str("From", e.evmClient.GetDefaultWallet().Address()).
@@ -171,6 +173,7 @@ func (e *CCIPContractsDeployer) DeployLinkTokenContract() (*LinkToken, error) {
 	}
 	return &LinkToken{
 		client:     e.evmClient,
+		logger:     e.logger,
 		instance:   instance.(*link_token_interface.LinkToken),
 		EthAddress: *address,
 	}, err
@@ -190,6 +193,7 @@ func (e *CCIPContractsDeployer) DeployBurnMintERC677(ownerMintingAmount *big.Int
 
 	token := &ERC677Token{
 		client:          e.evmClient,
+		logger:          e.logger,
 		ContractAddress: *address,
 		instance:        instance.(*burn_mint_erc677.BurnMintERC677),
 	}
@@ -229,7 +233,7 @@ func (e *CCIPContractsDeployer) NewLinkTokenContract(addr common.Address) (*Link
 	if err != nil {
 		return nil, err
 	}
-	log.Info().
+	e.logger.Info().
 		Str("Contract Address", addr.Hex()).
 		Str("Contract Name", "Link Token").
 		Str("From", e.evmClient.GetDefaultWallet().Address()).
@@ -237,6 +241,7 @@ func (e *CCIPContractsDeployer) NewLinkTokenContract(addr common.Address) (*Link
 		Msg("New contract")
 	return &LinkToken{
 		client:     e.evmClient,
+		logger:     e.logger,
 		instance:   token,
 		EthAddress: addr,
 	}, err
@@ -248,7 +253,7 @@ func (e *CCIPContractsDeployer) NewERC20TokenContract(addr common.Address) (*ERC
 	if err != nil {
 		return nil, err
 	}
-	log.Info().
+	e.logger.Info().
 		Str("Contract Address", addr.Hex()).
 		Str("Contract Name", "ERC20 Token").
 		Str("From", e.evmClient.GetDefaultWallet().Address()).
@@ -256,6 +261,7 @@ func (e *CCIPContractsDeployer) NewERC20TokenContract(addr common.Address) (*ERC
 		Msg("New contract")
 	return &ERC20Token{
 		client:          e.evmClient,
+		logger:          e.logger,
 		instance:        token,
 		ContractAddress: addr,
 	}, err
@@ -266,7 +272,7 @@ func (e *CCIPContractsDeployer) NewLockReleaseTokenPoolContract(addr common.Addr
 	error,
 ) {
 	version := VersionMap[TokenPoolContract]
-	log.Info().Str("version", string(version)).Msg("New LockRelease Token Pool")
+	e.logger.Info().Str("version", string(version)).Msg("New LockRelease Token Pool")
 	switch version {
 	case Latest:
 		pool, err := lock_release_token_pool.NewLockReleaseTokenPool(addr, wrappers.MustNewWrappedContractBackend(e.evmClient, nil))
@@ -274,7 +280,7 @@ func (e *CCIPContractsDeployer) NewLockReleaseTokenPoolContract(addr common.Addr
 		if err != nil {
 			return nil, err
 		}
-		log.Info().
+		e.logger.Info().
 			Str("Contract Address", addr.Hex()).
 			Str("Contract Name", "Native Token Pool").
 			Str("From", e.evmClient.GetDefaultWallet().Address()).
@@ -286,6 +292,7 @@ func (e *CCIPContractsDeployer) NewLockReleaseTokenPoolContract(addr common.Addr
 		}
 		return &TokenPool{
 			client: e.evmClient,
+			logger: e.logger,
 			Instance: &TokenPoolWrapper{
 				Latest: &LatestPool{
 					PoolInterface:   poolInstance,
@@ -299,7 +306,7 @@ func (e *CCIPContractsDeployer) NewLockReleaseTokenPoolContract(addr common.Addr
 		if err != nil {
 			return nil, err
 		}
-		log.Info().
+		e.logger.Info().
 			Str("Contract Address", addr.Hex()).
 			Str("Contract Name", "Native Token Pool").
 			Str("From", e.evmClient.GetDefaultWallet().Address()).
@@ -311,6 +318,7 @@ func (e *CCIPContractsDeployer) NewLockReleaseTokenPoolContract(addr common.Addr
 		}
 		return &TokenPool{
 			client: e.evmClient,
+			logger: e.logger,
 			Instance: &TokenPoolWrapper{
 				V1_4_0: &V1_4_0Pool{
 					PoolInterface:   poolInstance,
@@ -329,7 +337,7 @@ func (e *CCIPContractsDeployer) NewUSDCTokenPoolContract(addr common.Address) (
 	error,
 ) {
 	version := VersionMap[TokenPoolContract]
-	log.Info().Str("version", string(version)).Msg("New USDC Token Pool")
+	e.logger.Info().Str("version", string(version)).Msg("New USDC Token Pool")
 	switch version {
 	case Latest:
 		pool, err := usdc_token_pool.NewUSDCTokenPool(addr, wrappers.MustNewWrappedContractBackend(e.evmClient, nil))
@@ -337,7 +345,7 @@ func (e *CCIPContractsDeployer) NewUSDCTokenPoolContract(addr common.Address) (
 		if err != nil {
 			return nil, err
 		}
-		log.Info().
+		e.logger.Info().
 			Str("Contract Address", addr.Hex()).
 			Str("Contract Name", "USDC Token Pool").
 			Str("From", e.evmClient.GetDefaultWallet().Address()).
@@ -349,6 +357,7 @@ func (e *CCIPContractsDeployer) NewUSDCTokenPoolContract(addr common.Address) (
 		}
 		return &TokenPool{
 			client: e.evmClient,
+			logger: e.logger,
 			Instance: &TokenPoolWrapper{
 				Latest: &LatestPool{
 					PoolInterface: poolInterface,
@@ -363,7 +372,7 @@ func (e *CCIPContractsDeployer) NewUSDCTokenPoolContract(addr common.Address) (
 		if err != nil {
 			return nil, err
 		}
-		log.Info().
+		e.logger.Info().
 			Str("Contract Address", addr.Hex()).
 			Str("Contract Name", "USDC Token Pool").
 			Str("From", e.evmClient.GetDefaultWallet().Address()).
@@ -375,6 +384,7 @@ func (e *CCIPContractsDeployer) NewUSDCTokenPoolContract(addr common.Address) (
 		}
 		return &TokenPool{
 			client: e.evmClient,
+			logger: e.logger,
 			Instance: &TokenPoolWrapper{
 				V1_4_0: &V1_4_0Pool{
 					PoolInterface: poolInterface,
@@ -394,7 +404,7 @@ func (e *CCIPContractsDeployer) DeployUSDCTokenPoolContract(tokenAddr string, to
 	error,
 ) {
 	version := VersionMap[TokenPoolContract]
-	log.Debug().Str("token", tokenAddr).Msg("Deploying usdc token pool")
+	e.logger.Debug().Str("token", tokenAddr).Msg("Deploying usdc token pool")
 	token := common.HexToAddress(tokenAddr)
 	switch version {
 	case Latest:
@@ -447,7 +457,7 @@ func (e *CCIPContractsDeployer) DeployLockReleaseTokenPoolContract(tokenAddr str
 	error,
 ) {
 	version := VersionMap[TokenPoolContract]
-	log.Info().Str("version", string(version)).Msg("Deploying LockRelease Token Pool")
+	e.logger.Info().Str("version", string(version)).Msg("Deploying LockRelease Token Pool")
 	token := common.HexToAddress(tokenAddr)
 	switch version {
 	case Latest:
@@ -462,7 +472,8 @@ func (e *CCIPContractsDeployer) DeployLockReleaseTokenPoolContract(tokenAddr str
 				[]common.Address{},
 				rmnProxy,
 				true,
-				router)
+				router,
+			)
 		})
 
 		if err != nil {
@@ -481,7 +492,8 @@ func (e *CCIPContractsDeployer) DeployLockReleaseTokenPoolContract(tokenAddr str
 				[]common.Address{},
 				rmnProxy,
 				true,
-				router)
+				router,
+			)
 		})
 
 		if err != nil {
@@ -508,7 +520,7 @@ func (e *CCIPContractsDeployer) NewARMContract(addr common.Address) (*ARM, error
 	if err != nil {
 		return nil, err
 	}
-	log.Info().
+	e.logger.Info().
 		Str("Contract Address", addr.Hex()).
 		Str("Contract Name", "Mock ARM Contract").
 		Str("From", e.evmClient.GetDefaultWallet().Address()).
@@ -527,11 +539,11 @@ func (e *CCIPContractsDeployer) NewCommitStore(addr common.Address) (
 	error,
 ) {
 	version := VersionMap[CommitStoreContract]
-	log.Info().Str("version", string(version)).Msg("New CommitStore")
+	e.logger.Info().Str("version", string(version)).Msg("New CommitStore")
 	switch version {
 	case Latest:
 		ins, err := commit_store.NewCommitStore(addr, wrappers.MustNewWrappedContractBackend(e.evmClient, nil))
-		log.Info().
+		e.logger.Info().
 			Str("Contract Address", addr.Hex()).
 			Str("Contract Name", "CommitStore").
 			Str("From", e.evmClient.GetDefaultWallet().Address()).
@@ -539,6 +551,7 @@ func (e *CCIPContractsDeployer) NewCommitStore(addr common.Address) (
 			Msg("New contract")
 		return &CommitStore{
 			client: e.evmClient,
+			logger: e.logger,
 			Instance: &CommitStoreWrapper{
 				Latest: ins,
 			},
@@ -546,7 +559,7 @@ func (e *CCIPContractsDeployer) NewCommitStore(addr common.Address) (
 		}, err
 	case V1_2_0:
 		ins, err := commit_store_1_2_0.NewCommitStore(addr, wrappers.MustNewWrappedContractBackend(e.evmClient, nil))
-		log.Info().
+		e.logger.Info().
 			Str("Contract Address", addr.Hex()).
 			Str("Contract Name", "CommitStore").
 			Str("From", e.evmClient.GetDefaultWallet().Address()).
@@ -554,6 +567,7 @@ func (e *CCIPContractsDeployer) NewCommitStore(addr common.Address) (
 			Msg("New contract")
 		return &CommitStore{
 			client: e.evmClient,
+			logger: e.logger,
 			Instance: &CommitStoreWrapper{
 				V1_2_0: ins,
 			},
@@ -569,7 +583,7 @@ func (e *CCIPContractsDeployer) DeployCommitStore(sourceChainSelector, destChain
 	if !ok {
 		return nil, fmt.Errorf("versioning not supported: %s", version)
 	}
-	log.Info().Str("version", string(version)).Msg("Deploying CommitStore")
+	e.logger.Info().Str("version", string(version)).Msg("Deploying CommitStore")
 	switch version {
 	case Latest:
 		address, _, instance, err := e.evmClient.DeployContract("CommitStore Contract", func(
@@ -592,6 +606,7 @@ func (e *CCIPContractsDeployer) DeployCommitStore(sourceChainSelector, destChain
 		}
 		return &CommitStore{
 			client: e.evmClient,
+			logger: e.logger,
 			Instance: &CommitStoreWrapper{
 				Latest: instance.(*commit_store.CommitStore),
 			},
@@ -618,6 +633,7 @@ func (e *CCIPContractsDeployer) DeployCommitStore(sourceChainSelector, destChain
 		}
 		return &CommitStore{
 			client: e.evmClient,
+			logger: e.logger,
 			Instance: &CommitStoreWrapper{
 				V1_2_0: instance.(*commit_store_1_2_0.CommitStore),
 			},
@@ -643,6 +659,7 @@ func (e *CCIPContractsDeployer) DeployReceiverDapp(revert bool) (
 	}
 	return &ReceiverDapp{
 		client:     e.evmClient,
+		logger:     e.logger,
 		instance:   instance.(*maybe_revert_message_receiver.MaybeRevertMessageReceiver),
 		EthAddress: *address,
 	}, err
@@ -653,7 +670,7 @@ func (e *CCIPContractsDeployer) NewReceiverDapp(addr common.Address) (
 	error,
 ) {
 	ins, err := maybe_revert_message_receiver.NewMaybeRevertMessageReceiver(addr, wrappers.MustNewWrappedContractBackend(e.evmClient, nil))
-	log.Info().
+	e.logger.Info().
 		Str("Contract Address", addr.Hex()).
 		Str("Contract Name", "ReceiverDapp").
 		Str("From", e.evmClient.GetDefaultWallet().Address()).
@@ -661,6 +678,7 @@ func (e *CCIPContractsDeployer) NewReceiverDapp(addr common.Address) (
 		Msg("New contract")
 	return &ReceiverDapp{
 		client:     e.evmClient,
+		logger:     e.logger,
 		instance:   ins,
 		EthAddress: addr,
 	}, err
@@ -681,6 +699,7 @@ func (e *CCIPContractsDeployer) DeployRouter(wrappedNative common.Address, armAd
 	}
 	return &Router{
 		client:     e.evmClient,
+		logger:     e.logger,
 		Instance:   instance.(*router.Router),
 		EthAddress: *address,
 	}, err
@@ -691,7 +710,7 @@ func (e *CCIPContractsDeployer) NewRouter(addr common.Address) (
 	error,
 ) {
 	r, err := router.NewRouter(addr, wrappers.MustNewWrappedContractBackend(e.evmClient, nil))
-	log.Info().
+	e.logger.Info().
 		Str("Contract Address", addr.Hex()).
 		Str("Contract Name", "Router").
 		Str("From", e.evmClient.GetDefaultWallet().Address()).
@@ -702,6 +721,7 @@ func (e *CCIPContractsDeployer) NewRouter(addr common.Address) (
 	}
 	return &Router{
 		client:     e.evmClient,
+		logger:     e.logger,
 		Instance:   r,
 		EthAddress: addr,
 	}, err
@@ -713,7 +733,7 @@ func (e *CCIPContractsDeployer) NewPriceRegistry(addr common.Address) (
 ) {
 	var wrapper *PriceRegistryWrappers
 	version := VersionMap[PriceRegistryContract]
-	log.Info().Str("version", string(version)).Msg("New PriceRegistry")
+	e.logger.Info().Str("version", string(version)).Msg("New PriceRegistry")
 	switch version {
 	case Latest:
 		ins, err := price_registry.NewPriceRegistry(addr, wrappers.MustNewWrappedContractBackend(e.evmClient, nil))
@@ -734,7 +754,7 @@ func (e *CCIPContractsDeployer) NewPriceRegistry(addr common.Address) (
 	default:
 		return nil, fmt.Errorf("version not supported: %s", version)
 	}
-	log.Info().
+	e.logger.Info().
 		Str("Contract Address", addr.Hex()).
 		Str("Contract Name", "PriceRegistry").
 		Str("From", e.evmClient.GetDefaultWallet().Address()).
@@ -742,6 +762,7 @@ func (e *CCIPContractsDeployer) NewPriceRegistry(addr common.Address) (
 		Msg("New contract")
 	return &PriceRegistry{
 		client:     e.evmClient,
+		logger:     e.logger,
 		Instance:   wrapper,
 		EthAddress: addr,
 	}, nil
@@ -753,7 +774,7 @@ func (e *CCIPContractsDeployer) DeployPriceRegistry(tokens []common.Address) (*P
 	var err error
 	var instance interface{}
 	version := VersionMap[PriceRegistryContract]
-	log.Info().Str("version", string(version)).Msg("Deploying PriceRegistry")
+	e.logger.Info().Str("version", string(version)).Msg("Deploying PriceRegistry")
 	switch version {
 	case Latest:
 		address, _, instance, err = e.evmClient.DeployContract("PriceRegistry", func(
@@ -786,6 +807,7 @@ func (e *CCIPContractsDeployer) DeployPriceRegistry(tokens []common.Address) (*P
 	}
 	reg := &PriceRegistry{
 		client:     e.evmClient,
+		logger:     e.logger,
 		EthAddress: *address,
 		Instance:   wrapper,
 	}
@@ -804,6 +826,7 @@ func (e *CCIPContractsDeployer) DeployTokenAdminRegistry() (*TokenAdminRegistry,
 	}
 	return &TokenAdminRegistry{
 		client:     e.evmClient,
+		logger:     e.logger,
 		Instance:   instance.(*token_admin_registry.TokenAdminRegistry),
 		EthAddress: *address,
 	}, err
@@ -814,7 +837,7 @@ func (e *CCIPContractsDeployer) NewTokenAdminRegistry(addr common.Address) (
 	error,
 ) {
 	ins, err := token_admin_registry.NewTokenAdminRegistry(addr, wrappers.MustNewWrappedContractBackend(e.evmClient, nil))
-	log.Info().
+	e.logger.Info().
 		Str("Contract Address", addr.Hex()).
 		Str("Contract Name", "TokenAdminRegistry").
 		Str("From", e.evmClient.GetDefaultWallet().Address()).
@@ -822,6 +845,7 @@ func (e *CCIPContractsDeployer) NewTokenAdminRegistry(addr common.Address) (
 		Msg("New contract")
 	return &TokenAdminRegistry{
 		client:     e.evmClient,
+		logger:     e.logger,
 		Instance:   ins,
 		EthAddress: addr,
 	}, err
@@ -832,8 +856,8 @@ func (e *CCIPContractsDeployer) NewOnRamp(addr common.Address) (
 	error,
 ) {
 	version := VersionMap[OnRampContract]
-	log.Info().Str("version", string(version)).Msg("New OnRamp")
-	log.Info().
+	e.logger.Info().Str("version", string(version)).Msg("New OnRamp")
+	e.logger.Info().
 		Str("Contract Address", addr.Hex()).
 		Str("Contract Name", "OnRamp").
 		Str("From", e.evmClient.GetDefaultWallet().Address()).
@@ -847,6 +871,7 @@ func (e *CCIPContractsDeployer) NewOnRamp(addr common.Address) (
 		}
 		return &OnRamp{
 			client:     e.evmClient,
+			logger:     e.logger,
 			Instance:   &OnRampWrapper{V1_2_0: ins},
 			EthAddress: addr,
 		}, err
@@ -857,6 +882,7 @@ func (e *CCIPContractsDeployer) NewOnRamp(addr common.Address) (
 		}
 		return &OnRamp{
 			client:     e.evmClient,
+			logger:     e.logger,
 			Instance:   &OnRampWrapper{Latest: ins},
 			EthAddress: addr,
 		}, nil
@@ -878,7 +904,7 @@ func (e *CCIPContractsDeployer) DeployOnRamp(
 	linkTokenAddress common.Address,
 ) (*OnRamp, error) {
 	version := VersionMap[OnRampContract]
-	log.Info().Str("version", string(version)).Msg("Deploying OnRamp")
+	e.logger.Info().Str("version", string(version)).Msg("Deploying OnRamp")
 	switch version {
 	case V1_2_0:
 		feeTokenConfigV1_2_0 := make([]evm_2_evm_onramp_1_2_0.EVM2EVMOnRampFeeTokenConfigArgs, len(feeTokenConfig))
@@ -945,6 +971,7 @@ func (e *CCIPContractsDeployer) DeployOnRamp(
 		}
 		return &OnRamp{
 			client: e.evmClient,
+			logger: e.logger,
 			Instance: &OnRampWrapper{
 				V1_2_0: instance.(*evm_2_evm_onramp_1_2_0.EVM2EVMOnRamp),
 			},
@@ -997,6 +1024,7 @@ func (e *CCIPContractsDeployer) DeployOnRamp(
 		}
 		return &OnRamp{
 			client: e.evmClient,
+			logger: e.logger,
 			Instance: &OnRampWrapper{
 				Latest: instance.(*evm_2_evm_onramp.EVM2EVMOnRamp),
 			},
@@ -1012,14 +1040,14 @@ func (e *CCIPContractsDeployer) NewOffRamp(addr common.Address) (
 	error,
 ) {
 	version := VersionMap[OffRampContract]
-	log.Info().Str("version", string(version)).Msg("New OffRamp")
+	e.logger.Info().Str("version", string(version)).Msg("New OffRamp")
 	switch version {
 	case V1_2_0:
 		ins, err := evm_2_evm_offramp_1_2_0.NewEVM2EVMOffRamp(addr, wrappers.MustNewWrappedContractBackend(e.evmClient, nil))
 		if err != nil {
 			return nil, err
 		}
-		log.Info().
+		e.logger.Info().
 			Str("Contract Address", addr.Hex()).
 			Str("Contract Name", "OffRamp").
 			Str("From", e.evmClient.GetDefaultWallet().Address()).
@@ -1027,6 +1055,7 @@ func (e *CCIPContractsDeployer) NewOffRamp(addr common.Address) (
 			Msg("New contract")
 		return &OffRamp{
 			client:     e.evmClient,
+			logger:     e.logger,
 			Instance:   &OffRampWrapper{V1_2_0: ins},
 			EthAddress: addr,
 		}, err
@@ -1035,7 +1064,7 @@ func (e *CCIPContractsDeployer) NewOffRamp(addr common.Address) (
 		if err != nil {
 			return nil, err
 		}
-		log.Info().
+		e.logger.Info().
 			Str("Contract Address", addr.Hex()).
 			Str("Contract Name", "OffRamp").
 			Str("From", e.evmClient.GetDefaultWallet().Address()).
@@ -1043,6 +1072,7 @@ func (e *CCIPContractsDeployer) NewOffRamp(addr common.Address) (
 			Msg("New contract")
 		return &OffRamp{
 			client:     e.evmClient,
+			logger:     e.logger,
 			Instance:   &OffRampWrapper{Latest: ins},
 			EthAddress: addr,
 		}, err
@@ -1059,7 +1089,7 @@ func (e *CCIPContractsDeployer) DeployOffRamp(
 	rmnProxy common.Address,
 ) (*OffRamp, error) {
 	version := VersionMap[OffRampContract]
-	log.Info().Str("version", string(version)).Msg("Deploying OffRamp")
+	e.logger.Info().Str("version", string(version)).Msg("Deploying OffRamp")
 	switch version {
 	case V1_2_0:
 		address, _, instance, err := e.evmClient.DeployContract("OffRamp Contract", func(
@@ -1091,6 +1121,7 @@ func (e *CCIPContractsDeployer) DeployOffRamp(
 		}
 		return &OffRamp{
 			client: e.evmClient,
+			logger: e.logger,
 			Instance: &OffRampWrapper{
 				V1_2_0: instance.(*evm_2_evm_offramp_1_2_0.EVM2EVMOffRamp),
 			},
@@ -1124,6 +1155,7 @@ func (e *CCIPContractsDeployer) DeployOffRamp(
 		}
 		return &OffRamp{
 			client: e.evmClient,
+			logger: e.logger,
 			Instance: &OffRampWrapper{
 				Latest: instance.(*evm_2_evm_offramp.EVM2EVMOffRamp),
 			},
@@ -1157,7 +1189,7 @@ func (e *CCIPContractsDeployer) DeployMockAggregator(decimals uint8, initialAns 
 	if err != nil {
 		return nil, fmt.Errorf("deploying mock aggregator: %w", err)
 	}
-	log.Info().
+	e.logger.Info().
 		Str("Contract Address", address.Hex()).
 		Str("Contract Name", "MockAggregator").
 		Str("From", e.evmClient.GetDefaultWallet().Address()).
@@ -1165,6 +1197,7 @@ func (e *CCIPContractsDeployer) DeployMockAggregator(decimals uint8, initialAns 
 		Msg("New contract")
 	return &MockAggregator{
 		client:          e.evmClient,
+		logger:          e.logger,
 		Instance:        instance.(*mock_v3_aggregator_contract.MockV3Aggregator),
 		ContractAddress: *address,
 	}, nil
@@ -1177,6 +1210,7 @@ func (e *CCIPContractsDeployer) NewMockAggregator(addr common.Address) (*MockAgg
 	}
 	return &MockAggregator{
 		client:          e.evmClient,
+		logger:          e.logger,
 		Instance:        ins,
 		ContractAddress: addr,
 	}, nil
@@ -1191,7 +1225,7 @@ func (e *CCIPContractsDeployer) TypeAndVersion(addr common.Address) (string, err
 	if err != nil {
 		return "", fmt.Errorf("error calling typeAndVersion on addr: %s %w", addr.Hex(), err)
 	}
-	log.Info().
+	e.logger.Info().
 		Str("TypeAndVersion", tvStr).
 		Str("Contract Address", addr.Hex()).
 		Msg("TypeAndVersion")

--- a/integration-tests/ccip-tests/contracts/lm_contracts.go
+++ b/integration-tests/ccip-tests/contracts/lm_contracts.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/rs/zerolog/log"
+	"github.com/rs/zerolog"
 	"github.com/smartcontractkit/ccip/integration-tests/wrappers"
 
 	"github.com/smartcontractkit/chainlink-testing-framework/blockchain"
@@ -50,6 +50,7 @@ func (e *CCIPContractsDeployer) DeployArmProxy(arm common.Address) (*ArmProxy, e
 
 type LiquidityManager struct {
 	client     blockchain.EVMClient
+	logger     zerolog.Logger
 	Instance   *liquiditymanager.LiquidityManager
 	EthAddress *common.Address
 }
@@ -78,6 +79,7 @@ func (e *CCIPContractsDeployer) DeployLiquidityManager(
 	}
 	return &LiquidityManager{
 		client:     e.evmClient,
+		logger:     e.logger,
 		Instance:   instance.(*liquiditymanager.LiquidityManager),
 		EthAddress: address,
 	}, err
@@ -86,7 +88,7 @@ func (e *CCIPContractsDeployer) DeployLiquidityManager(
 func (v *LiquidityManager) SetCrossChainRebalancer(
 	crossChainRebalancerArgs liquiditymanager.ILiquidityManagerCrossChainRebalancerArgs,
 ) error {
-	log.Info().
+	v.logger.Info().
 		Str("Liquidity Manager", v.EthAddress.String()).
 		Msg("Setting crosschain rebalancer on liquidity manager")
 	opts, err := v.client.TransactionOpts(v.client.GetDefaultWallet())
@@ -98,7 +100,7 @@ func (v *LiquidityManager) SetCrossChainRebalancer(
 		return fmt.Errorf("failed to set cross chain rebalancer: %w", err)
 
 	}
-	log.Info().
+	v.logger.Info().
 		Str("Liquidity Manager", v.EthAddress.String()).
 		Interface("Rebalance Argsr", crossChainRebalancerArgs).
 		Msg("Crosschain Rebalancer set on liquidity manager")
@@ -113,8 +115,7 @@ func (v *LiquidityManager) SetOCR3Config(
 	offchainConfigVersion uint64,
 	offchainConfig []byte,
 ) error {
-
-	log.Info().
+	v.logger.Info().
 		Str("Liquidity Manager", v.EthAddress.String()).
 		Msg("Setting ocr3 config on liquidity manager")
 	opts, err := v.client.TransactionOpts(v.client.GetDefaultWallet())
@@ -133,7 +134,7 @@ func (v *LiquidityManager) SetOCR3Config(
 		return fmt.Errorf("failed to set cross chain rebalancer: %w", err)
 
 	}
-	log.Info().
+	v.logger.Info().
 		Str("Liquidity Manager", v.EthAddress.String()).
 		Msg("Set OCR3Config on LM")
 	return v.client.ProcessTransaction(tx)


### PR DESCRIPTION
## Motivation

Logging in CCIP tests is a little all over the place. Ideally we should utilize the primary test logger whenever possible for cleaner results from tooling.

## Solution

Pass the test logger to CCIP contracts that lacked it before.