### PR TITLE
CCIP-2313: Adding slack notification for failure notification in load and chaos test

### DIFF
--- a/.github/workflows/ccip-chaos-tests.yml
+++ b/.github/workflows/ccip-chaos-tests.yml
@@ -153,7 +153,15 @@ jobs:
           aws_registries: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
           cache_key_id: ccip-load-${{ env.MOD_CACHE_VERSION }}
           cache_restore_only: "true"
-
+      ## Notify in slack if the job fails
+      - name: Notify Slack
+        if: failure() && github.event_name != 'workflow_dispatch'
+        uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.QA_SLACK_API_KEY }}
+        with:
+          channel-id: "#ccip-testing"
+          slack-message: ":x: :mild-panic-intensifies: CCIP chaos tests failed: ${{ job.html_url }}\n${{ format('https://github.com/smartcontractkit/chainlink/actions/runs/{0}', github.run_id) }}"
       ## Run Cleanup if the job succeeds
       - name: cleanup
         if: always()
@@ -226,7 +234,15 @@ jobs:
           aws_registries: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
           cache_key_id: ccip-load-${{ env.MOD_CACHE_VERSION }}
           cache_restore_only: "true"
-
+      ## Notify in slack if the job fails
+      - name: Notify Slack
+        if: failure() && github.event_name != 'workflow_dispatch'
+        uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.QA_SLACK_API_KEY }}
+        with:
+          channel-id: "#ccip-testing"
+          slack-message: ":x: :mild-panic-intensifies: CCIP chaos with load tests failed: ${{ job.html_url }}\n${{ format('https://github.com/smartcontractkit/chainlink/actions/runs/{0}', github.run_id) }}"
       ## Run Cleanup if the job succeeds
       - name: cleanup
         if: always()

--- a/.github/workflows/ccip-load-tests.yml
+++ b/.github/workflows/ccip-load-tests.yml
@@ -201,3 +201,12 @@ jobs:
           cache_key_id: ccip-load-${{ env.MOD_CACHE_VERSION }}
           cache_restore_only: "true"
           should_cleanup: "true"
+      ## Notify in slack if the job fails
+      - name: Notify Slack
+        if: failure() && github.event_name != 'workflow_dispatch'
+        uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.QA_SLACK_API_KEY }}
+        with:
+          channel-id: "#ccip-testing"
+          slack-message: ":x: :mild-panic-intensifies: CCIP load tests failed: ${{ job.html_url }}\n${{ format('https://github.com/smartcontractkit/chainlink/actions/runs/{0}', github.run_id) }}"


### PR DESCRIPTION
## Motivation
The recent failure in chaos test is not notified properly as there is no slack notification setup available for CCIP load and chaos test.

## Solution
Add the slack notification to #ccip-testing channel as requested in this ticket [CCIP-2313](https://smartcontract-it.atlassian.net/browse/CCIP-2313) for load, chaos and chaos with load test.

Test Soak Notifications app is added to the #ccip-testing private channel as well. (Thanks Anirudh!)

[CCIP-2313]: https://smartcontract-it.atlassian.net/browse/CCIP-2313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ