### PR TITLE
[LM-118] add ccip-lm-smoke to eth-smoke-tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -497,6 +497,12 @@ jobs:
       fail-fast: false
       matrix:
         product:
+          - name: ccip-lm-smoke
+            nodes: 1
+            os: ubuntu-latest
+            file: lm
+            dir: ccip-tests/smoke
+            run: -run ^TestLmBasic$
           - name: ccip-smoke
             nodes: 1
             os: ubuntu-latest


### PR DESCRIPTION
## Motivation
LM lacks CI test coverage

## Solution
Add `TestLmBasic` to eth-smoke-tests pipeline