### PR TITLE
Fix crib dev-profile reference

### DIFF
--- a/crib/devspace.yaml
+++ b/crib/devspace.yaml
@@ -459,7 +459,7 @@ profiles:
         path: deployments.app.helm.values.chainlink-cluster.chainlink.global.overridesToml
       - op: add
         path: deployments.app.helm.valuesFiles
-        value: ["../charts/chainlink-cluster/values-profiles/values-dev.yaml"]
+        value: ["./values-profiles/values-dev.yaml"]
       - op: replace
         path: deployments.app.helm.values.ccipScriptsDeployment.enabled
         value: false


### PR DESCRIPTION
## Motivation
`../charts/` directory was deleted when we moved out charts to internal repo. Now dev-profile is located under crib directory

## Solution
Update devspace config to match the current location of dev profile