### PR TITLE
remove DestinationPool from OffRampTokens

### DIFF
--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/offramp_reader_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/offramp_reader_test.go
@@ -366,7 +366,6 @@ func testOffRampReader(t *testing.T, th offRampReaderTH) {
 	require.Empty(t, sourceToDestTokens)
 
 	require.NoError(t, err)
-	require.Empty(t, tokens.DestinationPool)
 }
 
 func TestNewOffRampReader(t *testing.T) {

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_0_0/offramp_reader_unit_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_0_0/offramp_reader_unit_test.go
@@ -99,7 +99,7 @@ func TestOffRampGetDestinationTokensFromSourceTokens(t *testing.T) {
 
 func TestCachedOffRampTokens(t *testing.T) {
 	// Test data.
-	srcTks, dstTks, outputs := generateTokensAndOutputs(3)
+	srcTks, dstTks, _ := generateTokensAndOutputs(3)
 
 	// Mock contract wrapper.
 	mockOffRamp := mock_contracts.NewEVM2EVMOffRampInterface(t)
@@ -110,17 +110,12 @@ func TestCachedOffRampTokens(t *testing.T) {
 	lp := mocks.NewLogPoller(t)
 	lp.On("LatestBlock", mock.Anything).Return(logpoller.LogPollerBlock{BlockNumber: rand.Int63()}, nil)
 
-	ec := evmclimocks.NewClient(t)
-
-	batchCaller := rpclibmocks.NewEvmBatchCaller(t)
-	batchCaller.On("BatchCall", mock.Anything, mock.Anything, mock.Anything).Return(outputs, nil)
-
 	offRamp := OffRamp{
 		offRampV100:    mockOffRamp,
 		lp:             lp,
 		Logger:         logger.TestLogger(t),
-		Client:         ec,
-		evmBatchCaller: batchCaller,
+		Client:         evmclimocks.NewClient(t),
+		evmBatchCaller: rpclibmocks.NewEvmBatchCaller(t),
 		cachedOffRampTokens: cache.NewLogpollerEventsBased[cciptypes.OffRampTokens](
 			lp,
 			offRamp_poolAddedPoolRemovedEvents,
@@ -140,7 +135,6 @@ func TestCachedOffRampTokens(t *testing.T) {
 	require.Equal(t, cciptypes.OffRampTokens{
 		DestinationTokens: ccipcalc.EvmAddrsToGeneric(dstTks...),
 		SourceTokens:      ccipcalc.EvmAddrsToGeneric(srcTks...),
-		DestinationPool:   expectedPools,
 	}, tokens)
 }
 

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_5_0/offramp.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_5_0/offramp.go
@@ -51,9 +51,9 @@ func (o *OffRamp) GetTokens(ctx context.Context) (cciptypes.OffRampTokens, error
 
 func (o *OffRamp) GetSourceAndDestRateLimitTokens(ctx context.Context) (sourceTokens []cciptypes.Address, destTokens []cciptypes.Address, err error) {
 	cachedTokens, err := o.cachedRateLimitTokens.Get(ctx, func(ctx context.Context) (cciptypes.OffRampTokens, error) {
-		tokens, err := o.offRampV150.GetAllRateLimitTokens(&bind.CallOpts{Context: ctx})
-		if err != nil {
-			return cciptypes.OffRampTokens{}, err
+		tokens, err2 := o.offRampV150.GetAllRateLimitTokens(&bind.CallOpts{Context: ctx})
+		if err2 != nil {
+			return cciptypes.OffRampTokens{}, err2
 		}
 
 		if len(tokens.SourceTokens) != len(tokens.DestTokens) {
@@ -61,8 +61,8 @@ func (o *OffRamp) GetSourceAndDestRateLimitTokens(ctx context.Context) (sourceTo
 		}
 
 		return cciptypes.OffRampTokens{
-			DestinationTokens: ccipcalc.EvmAddrsToGeneric(tokens.SourceTokens...),
-			SourceTokens:      ccipcalc.EvmAddrsToGeneric(tokens.DestTokens...),
+			DestinationTokens: ccipcalc.EvmAddrsToGeneric(tokens.DestTokens...),
+			SourceTokens:      ccipcalc.EvmAddrsToGeneric(tokens.SourceTokens...),
 		}, nil
 	})
 	if err != nil {

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_5_0/offramp.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_5_0/offramp.go
@@ -39,14 +39,17 @@ type OffRamp struct {
 
 // GetTokens Returns no data as the offRamps no longer have this information.
 func (o *OffRamp) GetTokens(ctx context.Context) (cciptypes.OffRampTokens, error) {
+	sourceTokens, destTokens, err := o.GetSourceAndDestRateLimitTokens(ctx)
+	if err != nil {
+		return cciptypes.OffRampTokens{}, err
+	}
 	return cciptypes.OffRampTokens{
-		SourceTokens:      []cciptypes.Address{},
-		DestinationTokens: []cciptypes.Address{},
-		DestinationPool:   make(map[cciptypes.Address]cciptypes.Address),
+		SourceTokens:      sourceTokens,
+		DestinationTokens: destTokens,
 	}, nil
 }
 
-func (o *OffRamp) GetSourceToDestTokensMapping(ctx context.Context) (map[cciptypes.Address]cciptypes.Address, error) {
+func (o *OffRamp) GetSourceAndDestRateLimitTokens(ctx context.Context) (sourceTokens []cciptypes.Address, destTokens []cciptypes.Address, err error) {
 	cachedTokens, err := o.cachedRateLimitTokens.Get(ctx, func(ctx context.Context) (cciptypes.OffRampTokens, error) {
 		tokens, err := o.offRampV150.GetAllRateLimitTokens(&bind.CallOpts{Context: ctx})
 		if err != nil {
@@ -63,16 +66,24 @@ func (o *OffRamp) GetSourceToDestTokensMapping(ctx context.Context) (map[cciptyp
 		}, nil
 	})
 	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to get rate limit tokens, if token set is large (~400k) batching may be needed")
+	}
+	return cachedTokens.SourceTokens, cachedTokens.DestinationTokens, nil
+}
+
+func (o *OffRamp) GetSourceToDestTokensMapping(ctx context.Context) (map[cciptypes.Address]cciptypes.Address, error) {
+	sourceTokens, destTokens, err := o.GetSourceAndDestRateLimitTokens(ctx)
+	if err != nil {
 		return nil, errors.Wrap(err, "failed to get rate limit tokens, if token set is large (~400k) batching may be needed")
 	}
 
-	if cachedTokens.SourceTokens == nil || cachedTokens.DestinationTokens == nil {
+	if sourceTokens == nil || destTokens == nil {
 		return nil, errors.New("source or destination tokens are nil")
 	}
 
 	mapping := make(map[cciptypes.Address]cciptypes.Address)
-	for i, sourceToken := range cachedTokens.SourceTokens {
-		mapping[sourceToken] = cachedTokens.DestinationTokens[i]
+	for i, sourceToken := range sourceTokens {
+		mapping[sourceToken] = destTokens[i]
 	}
 	return mapping, nil
 }


### PR DESCRIPTION
We can remove DestinationPool from OffRampTokens, and with that, we're able to fill the struct in the 1.5 offRamp with the rate limited tokens. 

This does not account for bps tokens yet!