### PR TITLE
CCIP-2371: Add slack thread for posting load test result and fix broken links

### DIFF
--- a/.github/workflows/ccip-load-tests.yml
+++ b/.github/workflows/ccip-load-tests.yml
@@ -1,13 +1,15 @@
 name: CCIP Load Test
-on: push
-    # branches:
-    #   - ccip-develop
-    #   - release*
-  # workflow_dispatch:
-  #   inputs:
-  #     base64_test_input: # base64 encoded toml for test input
-  #       description: 'Base64 encoded toml test input'
-        # required: false
+on: 
+  push:
+    branches:
+      - ccip-develop
+    tags:
+      - '*'
+  workflow_dispatch:
+    inputs:
+      base64_test_input: # base64 encoded toml for test input
+        description: 'Base64 encoded toml test input'
+        required: false
 
 # Only run 1 of this workflow at a time per PR
 concurrency:

--- a/.github/workflows/ccip-load-tests.yml
+++ b/.github/workflows/ccip-load-tests.yml
@@ -1,13 +1,13 @@
 name: CCIP Load Test
-on:
-  push:
-    branches:
-      - ccip-develop
-  workflow_dispatch:
-    inputs:
-      base64_test_input : # base64 encoded toml for test input
-        description: 'Base64 encoded toml test input'
-        required: false
+on: push
+    # branches:
+    #   - ccip-develop
+    #   - release*
+  # workflow_dispatch:
+  #   inputs:
+  #     base64_test_input: # base64 encoded toml for test input
+  #       description: 'Base64 encoded toml test input'
+        # required: false
 
 # Only run 1 of this workflow at a time per PR
 concurrency:
@@ -201,12 +201,90 @@ jobs:
           cache_key_id: ccip-load-${{ env.MOD_CACHE_VERSION }}
           cache_restore_only: "true"
           should_cleanup: "true"
-      ## Notify in slack if the job fails
-      - name: Notify Slack
-        if: failure() && github.event_name != 'workflow_dispatch'
+
+  # Reporting Jobs
+  start-slack-thread:
+    name: Start Slack Thread
+    if: ${{ failure() && needs.*.result != 'skipped' && needs.*.result != 'cancelled' }}
+    environment: integration
+    outputs:
+      thread_ts: ${{ steps.slack.outputs.thread_ts }}
+    permissions:
+      checks: write
+      pull-requests: write
+      id-token: write
+      contents: read
+    runs-on: ubuntu-latest
+    needs: [ccip-load-test]
+    steps:
+      - name: Debug Result
+        run: echo ${{ join(needs.*.result, ',') }}
+      - name: Main Slack Notification
         uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.QA_SLACK_API_KEY }}
+        id: slack
         with:
           channel-id: "#ccip-testing"
-          slack-message: ":x: :mild-panic-intensifies: CCIP load tests failed: \n${{ format('https://github.com/{0}/actions/runs/{1}', github.repository, github.run_id) }}"
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "${{ contains(join(needs.*.result, ','), 'failure') && '#C62828' || '#2E7D32' }}",
+                  "blocks": [
+                    {
+                      "type": "header",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "CCIP load tests results ${{ contains(join(needs.*.result, ','), 'failure') && ':x:' || ':white_check_mark:'}}",
+                        "emoji": true
+                      }
+                    },
+                    {
+                      "type": "divider"
+                    },
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "<${{ github.server_url }}/${{ github.repository }}/${{contains(github.ref_name, 'release') && 'releases/tag' || 'tree'}}/${{ github.ref_name }}|${{ github.ref_name }}> | <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}> | <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Run>"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.QA_SLACK_API_KEY }}
+
+  post-test-results-to-slack:
+    name: Post Test Results for ${{ matrix.network }}
+    if: ${{ always() && needs.*.result != 'skipped' && needs.*.result != 'cancelled' }}
+    environment: integration
+    permissions:
+      checks: write
+      pull-requests: write
+      id-token: write
+      contents: read
+    runs-on: ubuntu-latest
+    needs: start-slack-thread
+    strategy:
+      fail-fast: false
+      matrix:
+        network: [CCIP]
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+      - name: Post Test Results
+        uses: ./.github/actions/notify-slack-jobs-result
+        with:
+          github_token: ${{ github.token }}
+          github_repository: ${{ github.repository }}
+          workflow_run_id: ${{ github.run_id }}
+          github_job_name_regex: ^${{ matrix.network }} (?<cap>.?*)$
+          message_title: ${{ matrix.network }}
+          slack_channel_id: "#ccip-testing"
+          slack_bot_token: ${{ secrets.QA_SLACK_API_KEY }}
+          slack_thread_ts: ${{ needs.start-slack-thread.outputs.thread_ts }}
+
+  # End Reporting Jobs

--- a/.github/workflows/ccip-load-tests.yml
+++ b/.github/workflows/ccip-load-tests.yml
@@ -207,7 +207,7 @@ jobs:
   # Reporting Jobs
   start-slack-thread:
     name: Start Slack Thread
-    if: ${{ failure() && needs.*.result != 'skipped' && needs.*.result != 'cancelled' }}
+    if: ${{ failure() && needs.ccip-load-test.result != 'skipped' && needs.ccip-load-test.result != 'cancelled' }}
     environment: integration
     outputs:
       thread_ts: ${{ steps.slack.outputs.thread_ts }}
@@ -259,7 +259,7 @@ jobs:
 
   post-test-results-to-slack:
     name: Post Test Results for ${{ matrix.network }}
-    if: ${{ always() && needs.*.result != 'skipped' && needs.*.result != 'cancelled' }}
+    if: ${{ failure() && needs.start-slack-thread.result != 'skipped' && needs.start-slack-thread.result != 'cancelled' }}
     environment: integration
     permissions:
       checks: write


### PR DESCRIPTION
## Motivation
When there is a failure in a run, there are multiple notifications fired in previous implementation. It's a better to reduce the noise.

## Solution
Create a slack thread approach to collate the reporting per run.