### PR TITLE
ocr3 - add msg hasher dependency

### DIFF
--- a/core/services/ocr3/plugins/ccip/commit/factory.go
+++ b/core/services/ocr3/plugins/ccip/commit/factory.go
@@ -52,6 +52,7 @@ func (p PluginFactory) NewReportingPlugin(config ocr3types.ReportingPluginConfig
 		nil,
 		nil,
 		nil,
+		nil,
 	), ocr3types.ReportingPluginInfo{}, nil
 }
 

--- a/core/services/ocr3/plugins/ccip/commit/plugin.go
+++ b/core/services/ocr3/plugins/ccip/commit/plugin.go
@@ -26,6 +26,7 @@ type Plugin struct {
 	ccipReader        reader.CCIP
 	tokenPricesReader reader.TokenPrices
 	reportCodec       codec.Commit
+	msgHasher         codec.MessageHasher
 	lggr              logger.Logger
 
 	// readableChains is the set of chains that the plugin can read from.
@@ -43,6 +44,7 @@ func NewPlugin(
 	ccipReader reader.CCIP,
 	tokenPricesReader reader.TokenPrices,
 	reportCodec codec.Commit,
+	msgHasher codec.MessageHasher,
 	lggr logger.Logger,
 ) *Plugin {
 	knownSourceChains := mapset.NewSet[model.ChainSelector](cfg.Reads...)
@@ -56,6 +58,7 @@ func NewPlugin(
 		ccipReader:        ccipReader,
 		tokenPricesReader: tokenPricesReader,
 		reportCodec:       reportCodec,
+		msgHasher:         msgHasher,
 		lggr:              lggr,
 
 		readableChains:    mapset.NewSet(cfg.Reads...),
@@ -109,6 +112,7 @@ func (p *Plugin) Observation(ctx context.Context, outctx ocr3types.OutcomeContex
 		ctx,
 		p.lggr,
 		p.ccipReader,
+		p.msgHasher,
 		p.readableChains,
 		maxSeqNumsPerChain,
 		p.cfg.NewMsgScanBatchSize,

--- a/core/services/ocr3/plugins/ccip/commit/plugin_functions_test.go
+++ b/core/services/ocr3/plugins/ccip/commit/plugin_functions_test.go
@@ -199,6 +199,7 @@ func Test_observeNewMsgs(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			mockReader := mocks.NewCCIPReader()
+			msgHasher := mocks.NewNopMessageHasher()
 			lggr := logger.Test(t)
 
 			for _, seqNumChain := range tc.maxSeqNumsPerChain {
@@ -216,6 +217,7 @@ func Test_observeNewMsgs(t *testing.T) {
 				ctx,
 				lggr,
 				mockReader,
+				msgHasher,
 				mapset.NewSet(tc.readChains...),
 				tc.maxSeqNumsPerChain,
 				tc.msgScanBatchSize,
@@ -249,6 +251,7 @@ func Benchmark_observeNewMsgs(b *testing.B) {
 		ctx := context.Background()
 		lggr, _ := logger.New()
 		ccipReader := mocks.NewCCIPReader()
+		msgHasher := mocks.NewNopMessageHasher()
 
 		expNewMsgs := make([]model.CCIPMsg, 0, newMsgsPerChain*numChains)
 		for _, seqNumChain := range maxSeqNumsPerChain {
@@ -281,6 +284,7 @@ func Benchmark_observeNewMsgs(b *testing.B) {
 			ctx,
 			lggr,
 			ccipReader,
+			msgHasher,
 			mapset.NewSet(readChains...),
 			maxSeqNumsPerChain,
 			newMsgsPerChain,

--- a/core/services/ocr3/plugins/ccip/internal/codec/codec.go
+++ b/core/services/ocr3/plugins/ccip/internal/codec/codec.go
@@ -15,3 +15,7 @@ type Execute interface {
 	Encode(context.Context, model.ExecutePluginReport) ([]byte, error)
 	Decode(context.Context, []byte) (model.ExecutePluginReport, error)
 }
+
+type MessageHasher interface {
+	Hash(msg model.CCIPMsg) (model.Bytes32, error)
+}

--- a/core/services/ocr3/plugins/ccip/internal/mocks/messagehasher.go
+++ b/core/services/ocr3/plugins/ccip/internal/mocks/messagehasher.go
@@ -1,0 +1,15 @@
+package mocks
+
+import (
+	"github.com/smartcontractkit/ccipocr3/internal/model"
+)
+
+type NopMessageHasher struct{}
+
+func NewNopMessageHasher() *NopMessageHasher {
+	return &NopMessageHasher{}
+}
+
+func (m *NopMessageHasher) Hash(msg model.CCIPMsg) (model.Bytes32, error) {
+	return msg.ID, nil
+}

--- a/core/services/ocr3/plugins/ccip/internal/model/ccip.go
+++ b/core/services/ocr3/plugins/ccip/internal/model/ccip.go
@@ -75,17 +75,6 @@ type CCIPMsg struct {
 	CCIPMsgBaseDetails
 }
 
-func (c CCIPMsg) IsValid() error {
-	if c.ID != c.Hash() {
-		return fmt.Errorf("message id does not match the computed hash")
-	}
-	return nil
-}
-
-func (c CCIPMsg) Hash() Bytes32 {
-	return c.ID // todo: hash msg fields similar to what the contract does
-}
-
 func (c CCIPMsg) String() string {
 	js, _ := json.Marshal(c)
 	return fmt.Sprintf("%s", js)


### PR DESCRIPTION
We want a message hasher dependency. For different versions and different chain families we'll have different msg hashes.