### PR TITLE
sketch chainReader calls and small reader interface updates

### DIFF
--- a/core/services/ocr3/plugins/ccip/commit/plugin_functions.go
+++ b/core/services/ocr3/plugins/ccip/commit/plugin_functions.go
@@ -104,7 +104,7 @@ func observeNewMsgs(
 				"chain", seqNumChain.ChainSel, "minSeqNum", minSeqNum, "maxSeqNum", maxSeqNum)
 
 			newMsgs, err := ccipReader.MsgsBetweenSeqNums(
-				ctx, []model.ChainSelector{seqNumChain.ChainSel}, model.NewSeqNumRange(minSeqNum, maxSeqNum))
+				ctx, seqNumChain.ChainSel, model.NewSeqNumRange(minSeqNum, maxSeqNum))
 			if err != nil {
 				return fmt.Errorf("get messages between seq nums: %w", err)
 			}

--- a/core/services/ocr3/plugins/ccip/commit/plugin_functions_test.go
+++ b/core/services/ocr3/plugins/ccip/commit/plugin_functions_test.go
@@ -207,7 +207,7 @@ func Test_observeNewMsgs(t *testing.T) {
 					mockReader.On(
 						"MsgsBetweenSeqNums",
 						ctx,
-						[]model.ChainSelector{seqNumChain.ChainSel},
+						seqNumChain.ChainSel,
 						model.NewSeqNumRange(seqNumChain.SeqNum+1, seqNumChain.SeqNum+model.SeqNum(1+tc.msgScanBatchSize)),
 					).Return(tc.newMsgs[seqNumChain.ChainSel], nil)
 				}

--- a/core/services/ocr3/plugins/ccip/internal/mocks/ccipreader.go
+++ b/core/services/ocr3/plugins/ccip/internal/mocks/ccipreader.go
@@ -2,7 +2,6 @@ package mocks
 
 import (
 	"context"
-	"time"
 
 	"github.com/smartcontractkit/ccipocr3/internal/model"
 	"github.com/smartcontractkit/ccipocr3/internal/reader"
@@ -19,13 +18,8 @@ func NewCCIPReader() *CCIPReader {
 	}
 }
 
-func (r CCIPReader) MsgsAfterTimestamp(ctx context.Context, chains []model.ChainSelector, ts time.Time, limit int) ([]model.CCIPMsg, error) {
-	args := r.Called(ctx, chains, ts, limit)
-	return args.Get(0).([]model.CCIPMsg), args.Error(1)
-}
-
-func (r CCIPReader) MsgsBetweenSeqNums(ctx context.Context, chains []model.ChainSelector, seqNumRange model.SeqNumRange) ([]model.CCIPMsg, error) {
-	args := r.Called(ctx, chains, seqNumRange)
+func (r CCIPReader) MsgsBetweenSeqNums(ctx context.Context, chain model.ChainSelector, seqNumRange model.SeqNumRange) ([]model.CCIPMsg, error) {
+	args := r.Called(ctx, chain, seqNumRange)
 	return args.Get(0).([]model.CCIPMsg), args.Error(1)
 }
 

--- a/core/services/ocr3/plugins/ccip/internal/model/ccip.go
+++ b/core/services/ocr3/plugins/ccip/internal/model/ccip.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"strconv"
 
 	chainselectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
@@ -34,6 +35,10 @@ func NewGasPriceChain(gasPrice *big.Int, chainSel ChainSelector) GasPriceChain {
 }
 
 type SeqNum uint64
+
+func (s SeqNum) String() string {
+	return strconv.FormatUint(uint64(s), 10)
+}
 
 func NewSeqNumRange(start, end SeqNum) SeqNumRange {
 	return SeqNumRange{start, end}

--- a/core/services/ocr3/plugins/ccip/internal/reader/ccip.go
+++ b/core/services/ocr3/plugins/ccip/internal/reader/ccip.go
@@ -5,9 +5,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/smartcontractkit/ccipocr3/internal/model"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/query"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives"
 )
 
 var (
@@ -15,15 +18,10 @@ var (
 )
 
 type CCIP interface {
-	// MsgsAfterTimestamp reads the provided chains.
-	// Finds and returns ccip messages submitted after the target time.
-	// Messages are sorted ascending based on their timestamp and limited up to the provided limit.
-	MsgsAfterTimestamp(ctx context.Context, chains []model.ChainSelector, ts time.Time, limit int) ([]model.CCIPMsg, error)
-
 	// MsgsBetweenSeqNums reads the provided chains.
 	// Finds and returns ccip messages submitted between the provided sequence numbers.
 	// Messages are sorted ascending based on their timestamp and limited up to the provided limit.
-	MsgsBetweenSeqNums(ctx context.Context, chains []model.ChainSelector, seqNumRange model.SeqNumRange) ([]model.CCIPMsg, error)
+	MsgsBetweenSeqNums(ctx context.Context, chain model.ChainSelector, seqNumRange model.SeqNumRange) ([]model.CCIPMsg, error)
 
 	// NextSeqNum reads the destination chain.
 	// Returns the next expected sequence number for each one of the provided chains.
@@ -36,32 +34,93 @@ type CCIP interface {
 	Close(ctx context.Context) error
 }
 
-type ChainReader interface{} // TODO: Imported from chainlink-common
-
 type CCIPChainReader struct {
-	chainReaders map[model.ChainSelector]ChainReader
+	chainReaders map[model.ChainSelector]types.ChainReader
 	destChain    model.ChainSelector
 }
 
-func (r *CCIPChainReader) MsgsAfterTimestamp(ctx context.Context, chains []model.ChainSelector, ts time.Time, limit int) ([]model.CCIPMsg, error) {
-	if err := r.validateReaderExistence(chains...); err != nil {
+func (r *CCIPChainReader) MsgsBetweenSeqNums(ctx context.Context, chain model.ChainSelector, seqNumRange model.SeqNumRange) ([]model.CCIPMsg, error) {
+	if err := r.validateReaderExistence(chain); err != nil {
 		return nil, err
 	}
-	panic("implement me")
-}
 
-func (r *CCIPChainReader) MsgsBetweenSeqNums(ctx context.Context, chains []model.ChainSelector, seqNumRange model.SeqNumRange) ([]model.CCIPMsg, error) {
-	if err := r.validateReaderExistence(chains...); err != nil {
-		return nil, err
+	const (
+		contractName       = "OnRamp"
+		eventName          = "CCIPSendRequested"
+		eventAttributeName = "SequenceNumber"
+	)
+
+	seq, err := r.chainReaders[chain].QueryKey(
+		ctx,
+		contractName,
+		query.KeyFilter{
+			Key: eventName,
+			Expressions: []query.Expression{
+				{
+					Primitive: &primitives.Comparator{
+						Name: eventAttributeName,
+						ValueComparators: []primitives.ValueComparator{
+							{
+								Value:    seqNumRange.Start().String(),
+								Operator: primitives.Gte,
+							},
+							{
+								Value:    seqNumRange.End().String(),
+								Operator: primitives.Lte,
+							},
+						},
+					},
+					BoolExpression: query.BoolExpression{},
+				},
+			},
+		},
+		query.LimitAndSort{
+			SortBy: []query.SortBy{
+				query.NewSortByTimestamp(query.Asc),
+			},
+			Limit: query.Limit{
+				Count: uint64(seqNumRange.End() - seqNumRange.Start() + 1),
+			},
+		},
+		&model.CCIPMsg{},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query onRamp: %w", err)
 	}
-	panic("implement me")
+
+	msgs := make([]model.CCIPMsg, 0)
+	for _, item := range seq {
+		msg, ok := item.Data.(model.CCIPMsg)
+		if !ok {
+			return nil, fmt.Errorf("failed to cast %v to CCIPMsg", item.Data)
+		}
+		msgs = append(msgs, msg)
+	}
+
+	return msgs, nil
 }
 
-func (r *CCIPChainReader) NextSeqNum(ctx context.Context, chains []model.ChainSelector) (seqNum []model.SeqNum, err error) {
+func (r *CCIPChainReader) NextSeqNum(ctx context.Context, chains []model.ChainSelector) ([]model.SeqNum, error) {
 	if err := r.validateReaderExistence(r.destChain); err != nil {
 		return nil, err
 	}
-	panic("implement me")
+
+	const (
+		contractName = "OffRamp"
+		funcName     = "getExpectedNextSequenceNumbers"
+	)
+
+	seqNums := make([]model.SeqNum, 0)
+	err := r.chainReaders[r.destChain].GetLatestValue(
+		ctx,
+		contractName,
+		funcName,
+		map[string]any{
+			"chains": chains,
+		},
+		&seqNums,
+	)
+	return seqNums, err
 }
 
 func (r *CCIPChainReader) GasPrices(ctx context.Context, chains []model.ChainSelector) ([]model.BigInt, error) {


### PR DESCRIPTION
- Remove unused ccip reader function `MsgsAfterTimestamp`.
- Update `MsgsBetweenSeqNums` to accept a single chain.
- Implement ccipReader using actual chainReader. (not 100% accurate queries, will be e2e tested and adjusted later)