### PR TITLE
always return all prices from spec

### DIFF
--- a/core/services/ocr2/plugins/ccip/internal/ccipcommon/shortcuts.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipcommon/shortcuts.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"sort"
 	"strings"
 
 	"golang.org/x/sync/errgroup"
@@ -27,35 +26,6 @@ func GetMessageIDsAsHexString(messages []cciptypes.EVM2EVMMessage) []string {
 type BackfillArgs struct {
 	SourceLP, DestLP                 logpoller.LogPoller
 	SourceStartBlock, DestStartBlock uint64
-}
-
-// GetFilteredSortedLaneTokens returns union of tokens supported on this lane, including fee tokens from the provided price registry
-// and the bridgeable tokens from offRamp. Bridgeable tokens are only included if they are configured on the pricegetter
-// Fee tokens are not filtered as they must always be priced
-func GetFilteredSortedLaneTokens(ctx context.Context, offRamp ccipdata.OffRampReader, priceRegistry cciptypes.PriceRegistryReader, priceGetter cciptypes.PriceGetter) (laneTokens []cciptypes.Address, excludedTokens []cciptypes.Address, err error) {
-	destFeeTokens, destBridgeableTokens, err := GetDestinationTokens(ctx, offRamp, priceRegistry)
-	if err != nil {
-		return nil, nil, fmt.Errorf("get tokens with batch limit: %w", err)
-	}
-
-	destTokensWithPrice, destTokensWithoutPrice, err := priceGetter.FilterConfiguredTokens(ctx, destBridgeableTokens)
-	if err != nil {
-		return nil, nil, fmt.Errorf("filter for priced tokens: %w", err)
-	}
-
-	return flattenedAndSortedTokens(destFeeTokens, destTokensWithPrice), destTokensWithoutPrice, nil
-}
-
-func flattenedAndSortedTokens(slices ...[]cciptypes.Address) (tokens []cciptypes.Address) {
-	// fee token can overlap with bridgeable tokens, we need to dedup them to arrive at lane token set
-	tokens = FlattenUniqueSlice(slices...)
-
-	// return the tokens in deterministic order to aid with testing and debugging
-	sort.Slice(tokens, func(i, j int) bool {
-		return tokens[i] < tokens[j]
-	})
-
-	return tokens
 }
 
 // GetDestinationTokens returns the destination chain fee tokens from the provided price registry

--- a/core/services/ocr2/plugins/ccip/internal/ccipcommon/shortcuts_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipcommon/shortcuts_test.go
@@ -3,21 +3,12 @@ package ccipcommon
 import (
 	"fmt"
 	"math/rand"
-	"sort"
 	"strconv"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccip"
-
-	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/utils"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipcalc"
-	ccipdatamocks "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipdata/mocks"
-	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/pricegetter"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetMessageIDsAsHexString(t *testing.T) {
@@ -65,82 +56,6 @@ func TestFlattenUniqueSlice(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			res := FlattenUniqueSlice(tc.inputSlices...)
 			assert.Equal(t, tc.expectedOutput, res)
-		})
-	}
-}
-
-func TestGetFilteredChainTokens(t *testing.T) {
-	const numTokens = 6
-	var tokens []cciptypes.Address
-	for i := 0; i < numTokens; i++ {
-		tokens = append(tokens, ccipcalc.EvmAddrToGeneric(utils.RandomAddress()))
-	}
-
-	testCases := []struct {
-		name                   string
-		feeTokens              []cciptypes.Address
-		destTokens             []cciptypes.Address
-		expectedChainTokens    []cciptypes.Address
-		expectedFilteredTokens []cciptypes.Address
-	}{
-		{
-			name:                   "empty",
-			feeTokens:              []cciptypes.Address{},
-			destTokens:             []cciptypes.Address{},
-			expectedChainTokens:    []cciptypes.Address{},
-			expectedFilteredTokens: []cciptypes.Address{},
-		},
-		{
-			name:                   "unique tokens",
-			feeTokens:              []cciptypes.Address{tokens[0]},
-			destTokens:             []cciptypes.Address{tokens[1], tokens[2], tokens[3]},
-			expectedChainTokens:    []cciptypes.Address{tokens[0], tokens[1], tokens[2], tokens[3]},
-			expectedFilteredTokens: []cciptypes.Address{tokens[4], tokens[5]},
-		},
-		{
-			name:                   "all tokens",
-			feeTokens:              []cciptypes.Address{tokens[0]},
-			destTokens:             []cciptypes.Address{tokens[1], tokens[2], tokens[3], tokens[4], tokens[5]},
-			expectedChainTokens:    []cciptypes.Address{tokens[0], tokens[1], tokens[2], tokens[3], tokens[4], tokens[5]},
-			expectedFilteredTokens: []cciptypes.Address{},
-		},
-		{
-			name:                   "overlapping tokens",
-			feeTokens:              []cciptypes.Address{tokens[0]},
-			destTokens:             []cciptypes.Address{tokens[1], tokens[2], tokens[5], tokens[3], tokens[0], tokens[2], tokens[3], tokens[4], tokens[5], tokens[5]},
-			expectedChainTokens:    []cciptypes.Address{tokens[0], tokens[1], tokens[2], tokens[3], tokens[4], tokens[5]},
-			expectedFilteredTokens: []cciptypes.Address{},
-		},
-		{
-			name:                   "unconfigured tokens",
-			feeTokens:              []cciptypes.Address{tokens[0]},
-			destTokens:             []cciptypes.Address{tokens[0], tokens[1], tokens[2], tokens[3], tokens[0], tokens[2], tokens[3], tokens[4], tokens[5], tokens[5]},
-			expectedChainTokens:    []cciptypes.Address{tokens[0], tokens[1], tokens[2], tokens[3], tokens[4]},
-			expectedFilteredTokens: []cciptypes.Address{tokens[5]},
-		},
-	}
-
-	ctx := testutils.Context(t)
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-
-			priceRegistry := ccipdatamocks.NewPriceRegistryReader(t)
-			priceRegistry.On("GetFeeTokens", ctx).Return(tc.feeTokens, nil).Once()
-
-			priceGet := pricegetter.NewMockPriceGetter(t)
-			priceGet.On("FilterConfiguredTokens", mock.Anything, mock.Anything).Return(tc.expectedChainTokens, tc.expectedFilteredTokens, nil)
-
-			offRamp := ccipdatamocks.NewOffRampReader(t)
-			offRamp.On("GetTokens", ctx).Return(cciptypes.OffRampTokens{DestinationTokens: tc.destTokens}, nil).Once()
-
-			chainTokens, filteredTokens, err := GetFilteredSortedLaneTokens(ctx, offRamp, priceRegistry, priceGet)
-			assert.NoError(t, err)
-
-			sort.Slice(tc.expectedChainTokens, func(i, j int) bool {
-				return tc.expectedChainTokens[i] < tc.expectedChainTokens[j]
-			})
-			assert.Equal(t, tc.expectedChainTokens, chainTokens)
-			assert.Equal(t, tc.expectedFilteredTokens, filteredTokens)
 		})
 	}
 }

--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/evm.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/evm.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/pkg/errors"
 
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccip"
 
@@ -81,25 +82,8 @@ func NewDynamicPriceGetter(cfg config.DynamicPriceGetterConfig, evmClients map[u
 }
 
 // FilterConfiguredTokens implements the PriceGetter interface.
-// It filters a list of token addresses for only those that have a price resolution rule configured on the PriceGetterConfig
-func (d *DynamicPriceGetter) FilterConfiguredTokens(ctx context.Context, tokens []cciptypes.Address) (configured []cciptypes.Address, unconfigured []cciptypes.Address, err error) {
-	configured = []cciptypes.Address{}
-	unconfigured = []cciptypes.Address{}
-	for _, tk := range tokens {
-		evmAddr, err := ccipcalc.GenericAddrToEvm(tk)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		if _, isAgg := d.cfg.AggregatorPrices[evmAddr]; isAgg {
-			configured = append(configured, tk)
-		} else if _, isStatic := d.cfg.StaticPrices[evmAddr]; isStatic {
-			configured = append(configured, tk)
-		} else {
-			unconfigured = append(unconfigured, tk)
-		}
-	}
-	return configured, unconfigured, nil
+func (d *DynamicPriceGetter) FilterConfiguredTokens(context.Context, []cciptypes.Address) ([]cciptypes.Address, []cciptypes.Address, error) {
+	return nil, nil, errors.Errorf("FilterConfiguredTokens has been removed")
 }
 
 // TokenPricesUSD implements the PriceGetter interface.

--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/evm_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/evm_test.go
@@ -69,12 +69,11 @@ func TestDynamicPriceGetter(t *testing.T) {
 			}
 			require.NoError(t, err)
 			ctx := testutils.Context(t)
-			// Check configured token
-			unconfiguredTk := cciptypes.Address(utils.RandomAddress().String())
-			cfgTokens, uncfgTokens, err := pg.FilterConfiguredTokens(ctx, []cciptypes.Address{unconfiguredTk})
-			require.NoError(t, err)
-			assert.Equal(t, []cciptypes.Address{}, cfgTokens)
-			assert.Equal(t, []cciptypes.Address{unconfiguredTk}, uncfgTokens)
+
+			// FilterConfiguredTokens has been removed and should error.
+			_, _, err = pg.FilterConfiguredTokens(ctx, []cciptypes.Address{})
+			require.Error(t, err)
+
 			// Build list of tokens to query.
 			tokens := make([]cciptypes.Address, 0, len(test.param.tokens))
 			for _, tk := range test.param.tokens {

--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/pipeline.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/pipeline.go
@@ -3,10 +3,8 @@ package pricegetter
 import (
 	"context"
 	"math/big"
-	"strings"
 	"time"
 
-	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 
@@ -21,49 +19,39 @@ import (
 var _ PriceGetter = &PipelineGetter{}
 
 type PipelineGetter struct {
-	source        string
-	runner        pipeline.Runner
-	jobID         int32
-	externalJobID uuid.UUID
-	name          string
-	lggr          logger.Logger
+	rawPipelineDefinition string
+	runner                pipeline.Runner
+	jobID                 int32
+	externalJobID         uuid.UUID
+	name                  string
+	lggr                  logger.Logger
 }
 
-func NewPipelineGetter(source string, runner pipeline.Runner, jobID int32, externalJobID uuid.UUID, name string, lggr logger.Logger) (*PipelineGetter, error) {
-	_, err := pipeline.Parse(source)
+func NewPipelineGetter(rawPipelineDefinition string, runner pipeline.Runner, jobID int32, externalJobID uuid.UUID, name string, lggr logger.Logger) (*PipelineGetter, error) {
+	_, err := pipeline.Parse(rawPipelineDefinition)
 	if err != nil {
 		return nil, err
 	}
 
 	return &PipelineGetter{
-		source:        source,
-		runner:        runner,
-		jobID:         jobID,
-		externalJobID: externalJobID,
-		name:          name,
-		lggr:          lggr,
+		rawPipelineDefinition: rawPipelineDefinition,
+		runner:                runner,
+		jobID:                 jobID,
+		externalJobID:         externalJobID,
+		name:                  name,
+		lggr:                  lggr,
 	}, nil
 }
 
-// FilterForConfiguredTokens implements the PriceGetter interface.
-// It filters a list of token addresses for only those that have a pipeline job configured on the TokenPricesUSDPipeline
-func (d *PipelineGetter) FilterConfiguredTokens(ctx context.Context, tokens []cciptypes.Address) (configured []cciptypes.Address, unconfigured []cciptypes.Address, err error) {
-	lcSource := strings.ToLower(d.source)
-	for _, tk := range tokens {
-		lcToken := strings.ToLower(string(tk))
-		if strings.Contains(lcSource, lcToken) {
-			configured = append(configured, tk)
-		} else {
-			unconfigured = append(unconfigured, tk)
-		}
-	}
-	return configured, unconfigured, nil
+// FilterConfiguredTokens implements the PriceGetter interface.
+func (d *PipelineGetter) FilterConfiguredTokens(context.Context, []cciptypes.Address) ([]cciptypes.Address, []cciptypes.Address, error) {
+	return nil, nil, errors.Errorf("FilterConfiguredTokens has been removed")
 }
 
 func (d *PipelineGetter) TokenPricesUSD(ctx context.Context, tokens []cciptypes.Address) (map[cciptypes.Address]*big.Int, error) {
 	_, trrs, err := d.runner.ExecuteRun(ctx, pipeline.Spec{
 		ID:           d.jobID,
-		DotDagSource: d.source,
+		DotDagSource: d.rawPipelineDefinition,
 		CreatedAt:    time.Now(),
 		JobID:        d.jobID,
 		JobName:      d.name,
@@ -84,7 +72,6 @@ func (d *PipelineGetter) TokenPricesUSD(ctx context.Context, tokens []cciptypes.
 		return nil, errors.Errorf("expected map output of price pipeline, got %T", finalResult.Values[0])
 	}
 
-	providedTokensSet := mapset.NewSet(tokens...)
 	tokenPrices := make(map[cciptypes.Address]*big.Int)
 	for tokenAddressStr, rawPrice := range prices {
 		tokenAddressStr := ccipcalc.HexToAddress(tokenAddressStr)
@@ -92,10 +79,7 @@ func (d *PipelineGetter) TokenPricesUSD(ctx context.Context, tokens []cciptypes.
 		if err != nil {
 			return nil, err
 		}
-
-		if providedTokensSet.Contains(tokenAddressStr) {
-			tokenPrices[tokenAddressStr] = castedPrice
-		}
+		tokenPrices[tokenAddressStr] = castedPrice
 	}
 
 	// The mapping of token address to source of token price has to live offchain.

--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/pipeline_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/pipeline_test.go
@@ -57,11 +57,9 @@ func TestDataSource(t *testing.T) {
 
 	priceGetter := newTestPipelineGetter(t, source)
 
-	// USDC & LINK are configured
-	confTokens, _, err := priceGetter.FilterConfiguredTokens(context.Background(), []cciptypes.Address{linkTokenAddress, usdcTokenAddress})
-	require.NoError(t, err)
-	assert.Equal(t, linkTokenAddress, confTokens[0])
-	assert.Equal(t, usdcTokenAddress, confTokens[1])
+	// FilterConfiguredTokens has been removed and should error.
+	_, _, err := priceGetter.FilterConfiguredTokens(context.Background(), []cciptypes.Address{linkTokenAddress, usdcTokenAddress})
+	require.Error(t, err)
 
 	// Ask for all prices present in spec.
 	prices, err := priceGetter.TokenPricesUSD(context.Background(), []cciptypes.Address{
@@ -80,11 +78,12 @@ func TestDataSource(t *testing.T) {
 	})
 	require.Error(t, err)
 
-	// Ask only one price
+	// Ask only one price, expect to get all prices back
 	prices, err = priceGetter.TokenPricesUSD(context.Background(), []cciptypes.Address{linkTokenAddress})
 	require.NoError(t, err)
 	assert.Equal(t, prices, map[cciptypes.Address]*big.Int{
 		linkTokenAddress: big.NewInt(0).Mul(big.NewInt(200), big.NewInt(1000000000000000000)),
+		usdcTokenAddress: big.NewInt(0).Mul(big.NewInt(1000), big.NewInt(1000000000000000000)),
 	})
 
 }


### PR DESCRIPTION
## Motivation
With the introduction of rotating leader lanes, the jobspec becomes the source of truth of what tokens to report prices for

## Solution
Always report all prices configured in the jobspec, regardless of what lane tokens are configured.