### PR TITLE
Add devspace cmd for getting test input from s3

### DIFF
--- a/crib/.gitignore
+++ b/crib/.gitignore
@@ -1,3 +1,4 @@
 values-profiles/*
 !values-profiles/values-dev.yaml.example
 !values-profiles/README.md
+override.toml

--- a/crib/devspace.yaml
+++ b/crib/devspace.yaml
@@ -57,6 +57,8 @@ commands:
     go run dashboard/cmd/deploy.go
   dashboard_test: |-
     cd dashboard/tests && npx playwright test || cd -
+  get_test_input: |-
+    aws s3 cp s3://${DEVSPACE_CCIP_SCRIPTS_OUTPUT_BUCKET_NAME}/${DEVSPACE_NAMESPACE}-testInput.toml override.toml
 
 images:
   app:
@@ -97,6 +99,7 @@ deployments:
     updateImageTags: false
     namespace: ${DEVSPACE_NAMESPACE}
     helm:
+      upgradeArgs: [ "--timeout", "10m" ]
       releaseName: "app"
       chart:
         name: ${CCIP_HELM_CHART_URI}


### PR DESCRIPTION
## Motivation
* Fix timeout issue
* improve DevX in onchain testing flow

## Solution
* Add devspace cmd for getting test input from s3
* And add helm upgrade timeout as a fix to timeout issue