### PR TITLE
Add ABI caching functionality to `abihelpers` [CCIP-2388]

### DIFF
--- a/.changeset/sixty-spiders-end.md
+++ b/.changeset/sixty-spiders-end.md
@@ -1,0 +1,5 @@
+---
+"ccip": patch
+---
+
+#updated Optimizing ABIEncode and ABIDecode by caching abiStr

--- a/core/services/ocr2/plugins/ccip/abihelpers/abi_helpers.go
+++ b/core/services/ocr2/plugins/ccip/abihelpers/abi_helpers.go
@@ -5,13 +5,12 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
+	"sync"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
 	"github.com/smartcontractkit/libocr/gethwrappers2/ocr2aggregator"
-
-	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/utils"
 )
 
 func MustGetEventID(name string, abi2 abi.ABI) common.Hash {
@@ -67,18 +66,38 @@ type AbiDefinedValid interface {
 	Validate() error
 }
 
+func ABIEncode(abiStr string, values ...interface{}) ([]byte, error) {
+	inAbi, err := getABI(abiStr, ENCODE)
+	if err != nil {
+		return nil, err
+	}
+	res, err := inAbi.Pack("method", values...)
+	if err != nil {
+		return nil, err
+	}
+	return res[4:], nil
+}
+
+func ABIDecode(abiStr string, data []byte) ([]interface{}, error) {
+	inAbi, err := getABI(abiStr, DECODE)
+	if err != nil {
+		return nil, err
+	}
+	return inAbi.Unpack("method", data)
+}
+
 func EncodeAbiStruct[T AbiDefined](decoded T) ([]byte, error) {
-	return utils.ABIEncode(decoded.AbiString(), decoded)
+	return ABIEncode(decoded.AbiString(), decoded)
 }
 
 func EncodeAddress(address common.Address) ([]byte, error) {
-	return utils.ABIEncode(`[{"type":"address"}]`, address)
+	return ABIEncode(`[{"type":"address"}]`, address)
 }
 
 func DecodeAbiStruct[T AbiDefinedValid](encoded []byte) (T, error) {
 	var empty T
 
-	decoded, err := utils.ABIDecode(empty.AbiString(), encoded)
+	decoded, err := ABIDecode(empty.AbiString(), encoded)
 	if err != nil {
 		return empty, err
 	}
@@ -108,4 +127,48 @@ func DecodeOCR2Config(encoded []byte) (*ocr2aggregator.OCR2AggregatorConfigSet, 
 		return unpacked, errors.Wrap(err, "failed to unpack log data")
 	}
 	return unpacked, nil
+}
+
+// create const encode and decode
+const (
+	ENCODE = 1
+	DECODE = 2
+)
+
+// Global cache for ABIs to avoid parsing the same ABI multiple times
+// As the module is already a helper module and not a service, we can keep the cache global
+// It's private to the package and can't be accessed from outside
+var abiCache = make(map[string]*abi.ABI)
+
+// Mutex to access the map in a thread safe way
+var mutex sync.Mutex
+
+// This Function is used to get the ABI from the cache or create a new one and cache it for later use
+// operationType is used to differentiate between encoding and decoding
+// encoding uses a definition with `inputs` and decoding uses a definition with `outputs` (check inDef)
+func getABI(abiStr string, operationType uint8) (*abi.ABI, error) {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	var operationStr string
+	if operationType == ENCODE {
+		operationStr = "inputs"
+	} else if operationType == DECODE {
+		operationStr = "outputs"
+	} else {
+		return nil, fmt.Errorf("invalid operation type")
+	}
+
+	inDef := fmt.Sprintf(`[{ "name" : "method", "type": "function", "%s": %s}]`, operationStr, abiStr)
+
+	if cachedAbi, found := abiCache[inDef]; found {
+		return cachedAbi, nil
+	}
+
+	res, err := abi.JSON(strings.NewReader(inDef))
+	if err != nil {
+		return nil, err
+	}
+	abiCache[inDef] = &res
+	return &res, nil
 }

--- a/core/services/ocr2/plugins/ccip/abihelpers/abi_helpers.go
+++ b/core/services/ocr2/plugins/ccip/abihelpers/abi_helpers.go
@@ -176,13 +176,13 @@ func getABI(abiStr string, operationType uint8) (*abi.ABI, error) {
 	}
 	myAbiCache.mu.RUnlock()
 
-	myAbiCache.mu.Lock()
-	defer myAbiCache.mu.Unlock()
-
 	res, err := abi.JSON(strings.NewReader(inDef))
 	if err != nil {
 		return nil, err
 	}
+
+	myAbiCache.mu.Lock()
+	defer myAbiCache.mu.Unlock()
 	myAbiCache.cache[inDef] = &res
 	return &res, nil
 }

--- a/core/services/ocr2/plugins/ccip/abihelpers/abi_helpers_test.go
+++ b/core/services/ocr2/plugins/ccip/abihelpers/abi_helpers_test.go
@@ -1,12 +1,14 @@
 package abihelpers
 
 import (
+	"bytes"
 	"fmt"
 	"math"
 	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -69,4 +71,76 @@ func TestEvmWord(t *testing.T) {
 			assert.Equal(t, tc.exp, h)
 		})
 	}
+}
+
+func TestABIEncodeDecode(t *testing.T) {
+	abiStr := `[{"components": [{"name":"int1","type":"int256"},{"name":"int2","type":"int256"}], "type":"tuple"}]`
+	values := []interface{}{struct {
+		Int1 *big.Int `json:"int1"`
+		Int2 *big.Int `json:"int2"`
+	}{big.NewInt(10), big.NewInt(12)}}
+
+	// First encoding, should call the underlying utils.ABIEncode
+	encoded, err := ABIEncode(abiStr, values...)
+	assert.NoError(t, err)
+	assert.NotNil(t, encoded)
+
+	// Second encoding, should retrieve from cache
+	// we're just testing here that it returns same result
+	encodedAgain, err := ABIEncode(abiStr, values...)
+
+	assert.NoError(t, err)
+	assert.True(t, bytes.Equal(encoded, encodedAgain))
+
+	// Should be able to decode it back to the original values
+	decoded, err := ABIDecode(abiStr, encoded)
+	assert.NoError(t, err)
+	assert.Equal(t, decoded, values)
+}
+
+func BenchmarkComparisonEncode(b *testing.B) {
+	abiStr := `[{"components": [{"name":"int1","type":"int256"},{"name":"int2","type":"int256"}], "type":"tuple"}]`
+	values := []interface{}{struct {
+		Int1 *big.Int `json:"int1"`
+		Int2 *big.Int `json:"int2"`
+	}{big.NewInt(10), big.NewInt(12)}}
+
+	b.Run("WithoutCache", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, _ = utils.ABIEncode(abiStr, values...)
+		}
+	})
+
+	// Warm up the cache
+	_, _ = ABIEncode(abiStr, values...)
+
+	b.Run("WithCache", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, _ = ABIEncode(abiStr, values...)
+		}
+	})
+}
+
+func BenchmarkComparisonDecode(b *testing.B) {
+	abiStr := `[{"components": [{"name":"int1","type":"int256"},{"name":"int2","type":"int256"}], "type":"tuple"}]`
+	values := []interface{}{struct {
+		Int1 *big.Int `json:"int1"`
+		Int2 *big.Int `json:"int2"`
+	}{big.NewInt(10), big.NewInt(12)}}
+	data, _ := utils.ABIEncode(abiStr, values...)
+
+	b.Run("WithoutCache", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, _ = utils.ABIDecode(abiStr, data)
+		}
+	})
+
+	// Warm up the cache
+	_, _ = ABIDecode(abiStr, data)
+
+	b.Run("WithCache", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, _ = ABIDecode(abiStr, data)
+		}
+	})
 }

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_0_0/hasher.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_0_0/hasher.go
@@ -6,9 +6,9 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/types"
-
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/utils"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/evm_2_evm_onramp_1_0_0"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/abihelpers"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/pkg/hashlib"
 )
 
@@ -42,14 +42,14 @@ func (t *LeafHasher) HashLeaf(log types.Log) ([32]byte, error) {
 	if err != nil {
 		return [32]byte{}, err
 	}
-	encodedTokens, err := utils.ABIEncode(
+	encodedTokens, err := abihelpers.ABIEncode(
 		`[
 {"components": [{"name":"token","type":"address"},{"name":"amount","type":"uint256"}], "type":"tuple[]"}]`, message.Message.TokenAmounts)
 	if err != nil {
 		return [32]byte{}, err
 	}
 
-	packedValues, err := utils.ABIEncode(
+	packedValues, err := abihelpers.ABIEncode(
 		`[
 {"name": "leafDomainSeparator","type":"bytes1"},
 {"name": "metadataHash", "type":"bytes32"},

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_2_0/hasher.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_2_0/hasher.go
@@ -4,9 +4,8 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-
-	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/utils"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/evm_2_evm_onramp_1_2_0"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/abihelpers"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_0_0"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/pkg/hashlib"
 )
@@ -35,7 +34,7 @@ func (t *LeafHasher) HashLeaf(log types.Log) ([32]byte, error) {
 		return [32]byte{}, err
 	}
 	message := msg.Message
-	encodedTokens, err := utils.ABIEncode(
+	encodedTokens, err := abihelpers.ABIEncode(
 		`[
 {"components": [{"name":"token","type":"address"},{"name":"amount","type":"uint256"}], "type":"tuple[]"}]`, message.TokenAmounts)
 	if err != nil {
@@ -52,7 +51,7 @@ func (t *LeafHasher) HashLeaf(log types.Log) ([32]byte, error) {
 		return [32]byte{}, err
 	}
 
-	packedFixedSizeValues, err := utils.ABIEncode(
+	packedFixedSizeValues, err := abihelpers.ABIEncode(
 		`[
 {"name": "sender", "type":"address"},
 {"name": "receiver", "type":"address"},
@@ -77,7 +76,7 @@ func (t *LeafHasher) HashLeaf(log types.Log) ([32]byte, error) {
 	}
 	fixedSizeValuesHash := t.ctx.Hash(packedFixedSizeValues)
 
-	packedValues, err := utils.ABIEncode(
+	packedValues, err := abihelpers.ABIEncode(
 		`[
 {"name": "leafDomainSeparator","type":"bytes1"},
 {"name": "metadataHash", "type":"bytes32"},

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_5_0/hasher.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_5_0/hasher.go
@@ -4,9 +4,8 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-
-	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/utils"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/evm_2_evm_onramp"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/abihelpers"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_0_0"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/pkg/hashlib"
 )
@@ -35,7 +34,7 @@ func (t *LeafHasher) HashLeaf(log types.Log) ([32]byte, error) {
 		return [32]byte{}, err
 	}
 	message := msg.Message
-	encodedTokens, err := utils.ABIEncode(
+	encodedTokens, err := abihelpers.ABIEncode(
 		`[
 {"components": [{"name":"token","type":"address"},{"name":"amount","type":"uint256"}], "type":"tuple[]"}]`, message.TokenAmounts)
 	if err != nil {
@@ -52,7 +51,7 @@ func (t *LeafHasher) HashLeaf(log types.Log) ([32]byte, error) {
 		return [32]byte{}, err
 	}
 
-	packedFixedSizeValues, err := utils.ABIEncode(
+	packedFixedSizeValues, err := abihelpers.ABIEncode(
 		`[
 {"name": "sender", "type":"address"},
 {"name": "receiver", "type":"address"},
@@ -77,7 +76,7 @@ func (t *LeafHasher) HashLeaf(log types.Log) ([32]byte, error) {
 	}
 	fixedSizeValuesHash := t.ctx.Hash(packedFixedSizeValues)
 
-	packedValues, err := utils.ABIEncode(
+	packedValues, err := abihelpers.ABIEncode(
 		`[
 {"name": "leafDomainSeparator","type":"bytes1"},
 {"name": "metadataHash", "type":"bytes32"},


### PR DESCRIPTION
## Motivation

ABIEncode/ABIDecode functions are used in multiple places in CCIP. Unfortunately, these functions keep serializing provided abi with every call to them and most (all?) of the usage in CCIP has always const abi that never change over time.


## Solution

* Add a string to *abi.ABI map which is only accessible inside abi_helpers
* Cache all abiStr ( distinguish between encode, decode for same abiStr)
* Add new public facing functions for `ABIEncode` and `ABIDecode` and use them instead `utils.ABIEncode` and `utils.ABIDecode`

Benchmark results:
```
BenchmarkComparisonEncode/WithoutCache-14                 125930              8219 ns/op
BenchmarkComparisonEncode/WithoutCache-14                 145154              8355 ns/op
BenchmarkComparisonEncode/WithoutCache-14                 141247              8437 ns/op
BenchmarkComparisonEncode/WithoutCache-14                 141610              8371 ns/op
BenchmarkComparisonEncode/WithCache-14                   1219718               969.8 ns/op
BenchmarkComparisonEncode/WithCache-14                   1233378               979.3 ns/op
BenchmarkComparisonEncode/WithCache-14                   1220919               988.2 ns/op
BenchmarkComparisonEncode/WithCache-14                   1000000              1063 ns/op
BenchmarkComparisonDecode/WithoutCache-14                 149152              8080 ns/op
BenchmarkComparisonDecode/WithoutCache-14                 148034              7842 ns/op
BenchmarkComparisonDecode/WithoutCache-14                 149011              7815 ns/op
BenchmarkComparisonDecode/WithoutCache-14                 145190              8369 ns/op
BenchmarkComparisonDecode/WithCache-14                   2385868               501.6 ns/op
BenchmarkComparisonDecode/WithCache-14                   2335604               517.9 ns/op
BenchmarkComparisonDecode/WithCache-14                   2327654               495.4 ns/op
BenchmarkComparisonDecode/WithCache-14                   2376956               493.6 ns/op
```
