### PR TITLE
feat: chain-selectors version check in CI

### DIFF
--- a/.github/workflows/chain-selectors-check.yml
+++ b/.github/workflows/chain-selectors-check.yml
@@ -1,0 +1,36 @@
+name: Chain Selectors Version Check
+
+on:
+  push:
+    branches:
+      - ccip-develop
+      - release/*
+  pull_request:
+    branches:
+      - release/*
+
+jobs:
+  verify-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+        with:
+          only-modules: true
+          go-version-file: "go.mod"
+
+      - name: Get chain-selectors version
+        id: get-chain-selectors-version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          current_chain_selector_version="$(go list -m -f '{{.Version}}' github.com/smartcontractkit/chain-selectors)"
+          latest_chain_selector_version="$(gh release view -R smartcontractkit/chain-selectors --json tagName --jq '.tagName')"
+
+          if [ "$current_chain_selector_version" != "$latest_chain_selector_version" ]; then
+            echo "::error Chain Selectors version mismatch. Current version: $current_chain_selector_version, Latest version: $latest_chain_selector_version"
+            exit 1
+          fi

--- a/.github/workflows/chain-selectors-check.yml
+++ b/.github/workflows/chain-selectors-check.yml
@@ -5,9 +5,12 @@ on:
     branches:
       - ccip-develop
       - release/*
+    tags:
+      - v*
   pull_request:
     branches:
       - release/*
+
 
 jobs:
   verify-version:
@@ -27,8 +30,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          current_chain_selector_version="$(go list -m -f '{{.Version}}' github.com/smartcontractkit/chain-selectors)"
-          latest_chain_selector_version="$(gh release view -R smartcontractkit/chain-selectors --json tagName --jq '.tagName')"
+          current_chain_selector_version=$(go list -m -f '{{.Version}}' github.com/smartcontractkit/chain-selectors)
+          latest_chain_selector_version=$(gh release view -R smartcontractkit/chain-selectors --json tagName --jq '.tagName')
 
           if [ "$current_chain_selector_version" != "$latest_chain_selector_version" ]; then
             echo "::error Chain Selectors version mismatch. Current version: $current_chain_selector_version, Latest version: $latest_chain_selector_version"


### PR DESCRIPTION
## Motivation

See CCIP-2394.

## Solution

Workflow which compares the `chain-selectors` current version and latest version. If the versions differ, the workflow will fail.

## Testing
- Downgraded chain-selector to v1.0.15 and ran the check: https://github.com/smartcontractkit/ccip/actions/runs/9392408097/job/25866583934?pr=974