### PR TITLE
Let USDC look for the exact nonce instead of relying on ordering

### DIFF
--- a/contracts/src/v0.8/ccip/onRamp/EVM2EVMMultiOnRamp.sol
+++ b/contracts/src/v0.8/ccip/onRamp/EVM2EVMMultiOnRamp.sol
@@ -334,8 +334,6 @@ contract EVM2EVMMultiOnRamp is IEVM2AnyMultiOnRamp, ILinkAvailable, AggregateRat
     newMessage.messageId = Internal._hash(newMessage, destChainConfig.metadataHash);
 
     // Emit message request
-    // This must happen after any pool events as some tokens (e.g. USDC) emit events that we expect to precede this
-    // event in the offchain code.
     emit CCIPSendRequested(destChainSelector, newMessage);
     return newMessage.messageId;
   }

--- a/contracts/src/v0.8/ccip/onRamp/EVM2EVMOnRamp.sol
+++ b/contracts/src/v0.8/ccip/onRamp/EVM2EVMOnRamp.sol
@@ -376,8 +376,6 @@ contract EVM2EVMOnRamp is IEVM2AnyOnRamp, ILinkAvailable, AggregateRateLimiter, 
     newMessage.messageId = Internal._hash(newMessage, i_metadataHash);
 
     // Emit message request
-    // This must happen after any pool events as some tokens (e.g. USDC) emit events that we expect to precede this
-    // event in the offchain code.
     emit CCIPSendRequested(newMessage);
     return newMessage.messageId;
   }

--- a/contracts/src/v0.8/ccip/pools/TokenPool.sol
+++ b/contracts/src/v0.8/ccip/pools/TokenPool.sol
@@ -206,6 +206,7 @@ abstract contract TokenPool is IPool, OwnerIsCreator {
   }
 
   /// @notice Sets the remote pool address for a given chain selector.
+  /// @dev The chain should first be enabled through applyChainUpdates
   /// @param remoteChainSelector The remote chain selector for which the remote pool address is being set.
   /// @param remotePoolAddress The address of the remote pool.
   function setRemotePool(uint64 remoteChainSelector, bytes calldata remotePoolAddress) external onlyOwner {
@@ -237,6 +238,10 @@ abstract contract TokenPool is IPool, OwnerIsCreator {
   /// @notice Sets the permissions for a list of chains selectors. Actual senders for these chains
   /// need to be allowed on the Router to interact with this pool.
   /// @dev Only callable by the owner
+  /// @dev This function is used to enable or disable chains, to update rate limits or the remote pool
+  /// use the specific functions for those. There is no specific function to update the remote token,
+  /// this is because the remote token is not expected to ever change. If it does, the chain can be removed
+  /// using this function, and then added back with the updated token.
   /// @param chains A list of chains and their new permission status & rate limits. Rate limits
   /// are only used when the chain is being added through `allowed` being true.
   function applyChainUpdates(ChainUpdate[] calldata chains) external virtual onlyOwner {

--- a/contracts/src/v0.8/ccip/pools/USDC/ITokenMessenger.sol
+++ b/contracts/src/v0.8/ccip/pools/USDC/ITokenMessenger.sol
@@ -59,7 +59,7 @@ interface ITokenMessenger {
   function messageBodyVersion() external view returns (uint32);
 
   /// Returns local Message Transmitter responsible for sending and receiving messages
-  /// to/from remote domainsmessage transmitter for this token messenger.
+  /// to/from remote domains message transmitter for this token messenger.
   /// @dev immutable
   function localMessageTransmitter() external view returns (address);
 }

--- a/core/services/ocr2/plugins/ccip/ccipexec/initializers.go
+++ b/core/services/ocr2/plugins/ccip/ccipexec/initializers.go
@@ -18,7 +18,6 @@ import (
 	libocr2 "github.com/smartcontractkit/libocr/offchainreporting2plus"
 
 	commonlogger "github.com/smartcontractkit/chainlink-common/pkg/logger"
-
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccip"
 
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/cache"

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/mocks/usdc_reader_mock.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/mocks/usdc_reader_mock.go
@@ -14,7 +14,7 @@ type USDCReader struct {
 }
 
 // GetUSDCMessageWithNonce provides a mock function with given fields: ctx, nonce
-func (_m *USDCReader) GetUSDCMessageWithNonce(ctx context.Context, nonce [32]byte) ([]byte, error) {
+func (_m *USDCReader) GetUSDCMessageWithNonce(ctx context.Context, nonce uint64) ([]byte, error) {
 	ret := _m.Called(ctx, nonce)
 
 	if len(ret) == 0 {
@@ -23,10 +23,10 @@ func (_m *USDCReader) GetUSDCMessageWithNonce(ctx context.Context, nonce [32]byt
 
 	var r0 []byte
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, [32]byte) ([]byte, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, uint64) ([]byte, error)); ok {
 		return rf(ctx, nonce)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, [32]byte) []byte); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, uint64) []byte); ok {
 		r0 = rf(ctx, nonce)
 	} else {
 		if ret.Get(0) != nil {
@@ -34,7 +34,7 @@ func (_m *USDCReader) GetUSDCMessageWithNonce(ctx context.Context, nonce [32]byt
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, [32]byte) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, uint64) error); ok {
 		r1 = rf(ctx, nonce)
 	} else {
 		r1 = ret.Error(1)

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/mocks/usdc_reader_mock.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/mocks/usdc_reader_mock.go
@@ -13,29 +13,29 @@ type USDCReader struct {
 	mock.Mock
 }
 
-// GetUSDCMessagePriorToLogIndexInTx provides a mock function with given fields: ctx, logIndex, usdcTokenIndexOffset, txHash
-func (_m *USDCReader) GetUSDCMessagePriorToLogIndexInTx(ctx context.Context, logIndex int64, usdcTokenIndexOffset int, txHash string) ([]byte, error) {
-	ret := _m.Called(ctx, logIndex, usdcTokenIndexOffset, txHash)
+// GetUSDCMessageWithNonce provides a mock function with given fields: ctx, nonce
+func (_m *USDCReader) GetUSDCMessageWithNonce(ctx context.Context, nonce [32]byte) ([]byte, error) {
+	ret := _m.Called(ctx, nonce)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetUSDCMessagePriorToLogIndexInTx")
+		panic("no return value specified for GetUSDCMessageWithNonce")
 	}
 
 	var r0 []byte
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, int64, int, string) ([]byte, error)); ok {
-		return rf(ctx, logIndex, usdcTokenIndexOffset, txHash)
+	if rf, ok := ret.Get(0).(func(context.Context, [32]byte) ([]byte, error)); ok {
+		return rf(ctx, nonce)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, int64, int, string) []byte); ok {
-		r0 = rf(ctx, logIndex, usdcTokenIndexOffset, txHash)
+	if rf, ok := ret.Get(0).(func(context.Context, [32]byte) []byte); ok {
+		r0 = rf(ctx, nonce)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]byte)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, int64, int, string) error); ok {
-		r1 = rf(ctx, logIndex, usdcTokenIndexOffset, txHash)
+	if rf, ok := ret.Get(1).(func(context.Context, [32]byte) error); ok {
+		r1 = rf(ctx, nonce)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/usdc_reader.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/usdc_reader.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/utils"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/abihelpers"
@@ -16,18 +16,14 @@ import (
 
 const (
 	MESSAGE_SENT_FILTER_NAME = "USDC message sent"
+	USDC_MESSAGE_NONCE_INDEX = 2
 )
 
 var _ USDCReader = &USDCReaderImpl{}
 
 //go:generate mockery --quiet --name USDCReader --filename usdc_reader_mock.go --case=underscore
 type USDCReader interface {
-	// GetUSDCMessagePriorToLogIndexInTx returns the specified USDC message data.
-	// e.g. if msg contains 3 tokens: [usdc1, wETH, usdc2] ignoring non-usdc tokens
-	// if usdcTokenIndexOffset is 0 we select usdc2
-	// if usdcTokenIndexOffset is 1 we select usdc1
-	// The message logs are found using the provided transaction hash.
-	GetUSDCMessagePriorToLogIndexInTx(ctx context.Context, logIndex int64, usdcTokenIndexOffset int, txHash string) ([]byte, error)
+	GetUSDCMessageWithNonce(ctx context.Context, nonce [32]byte) ([]byte, error)
 }
 
 type USDCReaderImpl struct {
@@ -70,39 +66,29 @@ func parseUSDCMessageSent(logData []byte) ([]byte, error) {
 	return decodeAbiStruct, nil
 }
 
-func (u *USDCReaderImpl) GetUSDCMessagePriorToLogIndexInTx(ctx context.Context, logIndex int64, usdcTokenIndexOffset int, txHash string) ([]byte, error) {
-	// fetch all the usdc logs for the provided tx hash
-	logs, err := u.lp.IndexedLogsByTxHash(
+func (u *USDCReaderImpl) GetUSDCMessageWithNonce(ctx context.Context, nonce [32]byte) ([]byte, error) {
+	logs, err := u.lp.IndexedLogsTopicRange(
 		ctx,
 		u.usdcMessageSent,
 		u.transmitterAddress,
-		common.HexToHash(txHash),
+		USDC_MESSAGE_NONCE_INDEX,
+		nonce,
+		nonce,
+		types.Finalized,
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	// collect the logs with log index less than the provided log index
-	allUsdcTokensData := make([][]byte, 0)
-	for _, current := range logs {
-		if current.LogIndex < logIndex {
-			u.lggr.Infow("Found USDC message", "logIndex", current.LogIndex, "txHash", current.TxHash.Hex(), "data", hexutil.Encode(current.Data))
-			allUsdcTokensData = append(allUsdcTokensData, current.Data)
-		}
+	if len(logs) == 0 {
+		return nil, errors.New("no USDC message found")
 	}
 
-	usdcTokenIndex := (len(allUsdcTokensData) - 1) - usdcTokenIndexOffset
-
-	if usdcTokenIndex < 0 || usdcTokenIndex >= len(allUsdcTokensData) {
-		u.lggr.Errorw("usdc message not found",
-			"logIndex", logIndex,
-			"allUsdcTokenData", len(allUsdcTokensData),
-			"txHash", txHash,
-			"usdcTokenIndex", usdcTokenIndex,
-		)
-		return nil, errors.Errorf("usdc token index %d is not valid", usdcTokenIndex)
+	if len(logs) > 1 {
+		return nil, errors.New("more than one USDC message found, nonces should be unique")
 	}
-	return parseUSDCMessageSent(allUsdcTokensData[usdcTokenIndex])
+
+	return parseUSDCMessageSent(logs[0].Data)
 }
 
 func NewUSDCReader(lggr logger.Logger, jobID string, transmitter common.Address, lp logpoller.LogPoller, registerFilters bool) (*USDCReaderImpl, error) {

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/usdc_reader_internal_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/usdc_reader_internal_test.go
@@ -1,8 +1,6 @@
 package ccipdata
 
 import (
-	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -11,86 +9,15 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/client"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
-	lpmocks "github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/utils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
-
-func TestLogPollerClient_GetUSDCMessagePriorToLogIndexInTx(t *testing.T) {
-	addr := utils.RandomAddress()
-	txHash := common.BytesToHash(addr[:])
-	ccipLogIndex := int64(100)
-
-	expectedData := "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000f80000000000000001000000020000000000048d71000000000000000000000000eb08f243e5d3fcff26a9e38ae5520a669f4019d000000000000000000000000023a04d5935ed8bc8e3eb78db3541f0abfb001c6e0000000000000000000000006cb3ed9b441eb674b58495c8b3324b59faff5243000000000000000000000000000000005425890298aed601595a70ab815c96711a31bc65000000000000000000000000ab4f961939bfe6a93567cc57c59eed7084ce2131000000000000000000000000000000000000000000000000000000000000271000000000000000000000000035e08285cfed1ef159236728f843286c55fc08610000000000000000"
-	expectedPostParse := "0x0000000000000001000000020000000000048d71000000000000000000000000eb08f243e5d3fcff26a9e38ae5520a669f4019d000000000000000000000000023a04d5935ed8bc8e3eb78db3541f0abfb001c6e0000000000000000000000006cb3ed9b441eb674b58495c8b3324b59faff5243000000000000000000000000000000005425890298aed601595a70ab815c96711a31bc65000000000000000000000000ab4f961939bfe6a93567cc57c59eed7084ce2131000000000000000000000000000000000000000000000000000000000000271000000000000000000000000035e08285cfed1ef159236728f843286c55fc0861"
-	lggr := logger.TestLogger(t)
-
-	t.Run("multiple found - selected last", func(t *testing.T) {
-		lp := lpmocks.NewLogPoller(t)
-		u, _ := NewUSDCReader(lggr, "job_123", utils.RandomAddress(), lp, false)
-
-		lp.On("IndexedLogsByTxHash",
-			mock.Anything,
-			u.usdcMessageSent,
-			u.transmitterAddress,
-			txHash,
-		).Return([]logpoller.Log{
-			{LogIndex: ccipLogIndex - 2, Data: []byte("-2")},
-			{LogIndex: ccipLogIndex - 1, Data: hexutil.MustDecode(expectedData)},
-			{LogIndex: ccipLogIndex, Data: []byte("0")},
-			{LogIndex: ccipLogIndex + 1, Data: []byte("1")},
-		}, nil)
-		usdcMessageData, err := u.GetUSDCMessagePriorToLogIndexInTx(context.Background(), ccipLogIndex, 0, txHash.String())
-		assert.NoError(t, err)
-		assert.Equal(t, expectedPostParse, hexutil.Encode(usdcMessageData))
-		lp.AssertExpectations(t)
-	})
-
-	t.Run("multiple found - selected first", func(t *testing.T) {
-		lp := lpmocks.NewLogPoller(t)
-		u, _ := NewUSDCReader(lggr, "job_123", utils.RandomAddress(), lp, false)
-
-		lp.On("IndexedLogsByTxHash",
-			mock.Anything,
-			u.usdcMessageSent,
-			u.transmitterAddress,
-			txHash,
-		).Return([]logpoller.Log{
-			{LogIndex: ccipLogIndex - 2, Data: hexutil.MustDecode(expectedData)},
-			{LogIndex: ccipLogIndex - 1, Data: []byte("-2")},
-			{LogIndex: ccipLogIndex, Data: []byte("0")},
-			{LogIndex: ccipLogIndex + 1, Data: []byte("1")},
-		}, nil)
-		usdcMessageData, err := u.GetUSDCMessagePriorToLogIndexInTx(context.Background(), ccipLogIndex, 1, txHash.String())
-		assert.NoError(t, err)
-		assert.Equal(t, expectedPostParse, hexutil.Encode(usdcMessageData))
-		lp.AssertExpectations(t)
-	})
-
-	t.Run("none found", func(t *testing.T) {
-		lp := lpmocks.NewLogPoller(t)
-		u, _ := NewUSDCReader(lggr, "job_123", utils.RandomAddress(), lp, false)
-		lp.On("IndexedLogsByTxHash",
-			mock.Anything,
-			u.usdcMessageSent,
-			u.transmitterAddress,
-			txHash,
-		).Return([]logpoller.Log{}, nil)
-
-		usdcMessageData, err := u.GetUSDCMessagePriorToLogIndexInTx(context.Background(), ccipLogIndex, 0, txHash.String())
-		assert.Errorf(t, err, fmt.Sprintf("no USDC message found prior to log index %d in tx %s", ccipLogIndex, txHash.Hex()))
-		assert.Nil(t, usdcMessageData)
-
-		lp.AssertExpectations(t)
-	})
-}
 
 func TestParse(t *testing.T) {
 	expectedBody, err := hexutil.Decode("0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000f80000000000000001000000020000000000048d71000000000000000000000000eb08f243e5d3fcff26a9e38ae5520a669f4019d000000000000000000000000023a04d5935ed8bc8e3eb78db3541f0abfb001c6e0000000000000000000000006cb3ed9b441eb674b58495c8b3324b59faff5243000000000000000000000000000000005425890298aed601595a70ab815c96711a31bc65000000000000000000000000ab4f961939bfe6a93567cc57c59eed7084ce2131000000000000000000000000000000000000000000000000000000000000271000000000000000000000000035e08285cfed1ef159236728f843286c55fc08610000000000000000")

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/usdc_reader_internal_test.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/usdc_reader_internal_test.go
@@ -1,6 +1,8 @@
 package ccipdata
 
 import (
+	"encoding/hex"
+	"strconv"
 	"testing"
 	"time"
 
@@ -67,5 +69,28 @@ func TestFilters(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, lp.HasFilter(f1))
 		assert.False(t, lp.HasFilter(f2))
+	})
+}
+
+func TestEncoding(t *testing.T) {
+	t.Run("encode expectedSlot", func(t *testing.T) {
+		sourceDomainHex := "e0f516f1"
+		destDomainHex := "f516f1ee"
+		nonceHex := "f56f101748232938"
+		version := "00000000"
+		sender := "000000000000000000000000"
+
+		sourceDomain, err := strconv.ParseUint(sourceDomainHex, 16, 32)
+		require.NoError(t, err)
+		destDomain, err := strconv.ParseUint(destDomainHex, 16, 32)
+		require.NoError(t, err)
+		nonce, err := strconv.ParseUint(nonceHex, 16, 64)
+		require.NoError(t, err)
+
+		expected := version + sourceDomainHex + destDomainHex + nonceHex + sender
+
+		actualSlot := GetExpectedNonceSlotData(uint32(sourceDomain), uint32(destDomain), nonce)
+
+		assert.Equal(t, expected, hex.EncodeToString(actualSlot[:]))
 	})
 }

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_0_0/onramp.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_0_0/onramp.go
@@ -2,7 +2,6 @@ package v1_0_0
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -191,10 +190,6 @@ func (o *OnRamp) IsSourceCursed(ctx context.Context) (bool, error) {
 		return false, fmt.Errorf("checking if source Arm is cursed: %w", err)
 	}
 	return cursed, nil
-}
-
-func (o *OnRamp) GetUSDCMessagePriorToLogIndexInTx(ctx context.Context, logIndex, offsetFromFinal int64, txHash common.Hash) ([]byte, error) {
-	return nil, errors.New("USDC not supported in < 1.2.0")
 }
 
 func (o *OnRamp) Close() error {

--- a/core/services/ocr2/plugins/ccip/tokendata/observability/usdc_client_test.go
+++ b/core/services/ocr2/plugins/ccip/tokendata/observability/usdc_client_test.go
@@ -83,7 +83,8 @@ func testMonitoring(t *testing.T, name string, server *httptest.Server, requests
 	// Mock USDC reader.
 	usdcReader := mocks.NewUSDCReader(t)
 	msgBody := []byte{0xb0, 0xd1}
-	usdcReader.On("GetUSDCMessagePriorToLogIndexInTx", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(msgBody, nil)
+	nonce := utils.RandomBytes32()
+	usdcReader.On("GetUSDCMessageWithNonce", mock.Anything, nonce).Return(msgBody, nil)
 
 	// Service with monitored http client.
 	usdcTokenAddr := utils.RandomAddress()
@@ -101,6 +102,7 @@ func testMonitoring(t *testing.T, name string, server *httptest.Server, requests
 						Amount: big.NewInt(rand.Int63()),
 					},
 				},
+				SourceTokenData: [][]byte{nonce[:]},
 			},
 		}, 0)
 	}

--- a/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc.go
+++ b/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc.go
@@ -2,6 +2,7 @@ package usdc
 
 import (
 	"context"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -231,13 +232,15 @@ func (s *TokenDataReader) getUSDCMessageBody(
 	if tokenIndex >= len(msg.EVM2EVMMessage.SourceTokenData) || tokenIndex < 0 {
 		return []byte{}, fmt.Errorf("invalid token index %d for msg with %d source token data", tokenIndex, len(msg.EVM2EVMMessage.SourceTokenData))
 	}
-	nonce := msg.EVM2EVMMessage.SourceTokenData[tokenIndex]
+	nonceBytes := msg.EVM2EVMMessage.SourceTokenData[tokenIndex]
 
-	if len(nonce) != 32 {
-		return []byte{}, fmt.Errorf("invalid nonce length %d", len(nonce))
+	if len(nonceBytes) != 32 {
+		return []byte{}, fmt.Errorf("invalid nonce length %d", len(nonceBytes))
 	}
 
-	parsedMsgBody, err := s.usdcReader.GetUSDCMessageWithNonce(ctx, [32]byte(nonce))
+	nonce := binary.BigEndian.Uint64(nonceBytes)
+
+	parsedMsgBody, err := s.usdcReader.GetUSDCMessageWithNonce(ctx, nonce)
 	if err != nil {
 		return []byte{}, err
 	}

--- a/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc_test.go
+++ b/core/services/ocr2/plugins/ccip/tokendata/usdc/usdc_test.go
@@ -20,13 +20,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccip"
-
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/utils"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipcalc"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipdata"
 	ccipdatamocks "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipdata/mocks"
+	ccipmocks "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipdata/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/tokendata"
 )
 
@@ -227,7 +227,9 @@ func getMockUSDCEndpoint(t *testing.T, response attestationResponse) *httptest.S
 func TestGetUSDCMessageBody(t *testing.T) {
 	expectedBody := []byte("0x0000000000000001000000020000000000048d71000000000000000000000000eb08f243e5d3fcff26a9e38ae5520a669f4019d000000000000000000000000023a04d5935ed8bc8e3eb78db3541f0abfb001c6e0000000000000000000000006cb3ed9b441eb674b58495c8b3324b59faff5243000000000000000000000000000000005425890298aed601595a70ab815c96711a31bc65000000000000000000000000ab4f961939bfe6a93567cc57c59eed7084ce2131000000000000000000000000000000000000000000000000000000000000271000000000000000000000000035e08285cfed1ef159236728f843286c55fc0861")
 	usdcReader := ccipdatamocks.USDCReader{}
-	usdcReader.On("GetUSDCMessagePriorToLogIndexInTx", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(expectedBody, nil)
+	nonce := utils.RandomBytes32()
+
+	usdcReader.On("GetUSDCMessageWithNonce", mock.Anything, nonce).Return(expectedBody, nil)
 
 	usdcTokenAddr := utils.RandomAddress()
 	lggr := logger.TestLogger(t)
@@ -242,64 +244,13 @@ func TestGetUSDCMessageBody(t *testing.T) {
 					Amount: big.NewInt(rand.Int63()),
 				},
 			},
+			SourceTokenData: [][]byte{nonce[:]},
 		},
 	}, 0)
 	require.NoError(t, err)
 	require.Equal(t, body, expectedBody)
 
-	usdcReader.AssertNumberOfCalls(t, "GetUSDCMessagePriorToLogIndexInTx", 1)
-}
-
-func TestTokenDataReader_getUsdcTokenEndOffset(t *testing.T) {
-	usdcToken := utils.RandomAddress()
-	nonUsdcToken := utils.RandomAddress()
-
-	multipleTokens := []common.Address{
-		usdcToken, // 2
-		nonUsdcToken,
-		nonUsdcToken,
-		usdcToken, // 1
-		usdcToken, // 0
-		nonUsdcToken,
-	}
-
-	testCases := []struct {
-		name       string
-		tokens     []common.Address
-		tokenIndex int
-		expOffset  int
-		expErr     bool
-	}{
-		{name: "one non usdc token", tokens: []common.Address{nonUsdcToken}, tokenIndex: 0, expOffset: 0, expErr: true},
-		{name: "one usdc token", tokens: []common.Address{usdcToken}, tokenIndex: 0, expOffset: 0, expErr: false},
-		{name: "one usdc token wrong index", tokens: []common.Address{usdcToken}, tokenIndex: 1, expOffset: 0, expErr: true},
-		{name: "multiple tokens 1", tokens: multipleTokens, tokenIndex: 0, expOffset: 2},
-		{name: "multiple tokens - non usdc selected", tokens: multipleTokens, tokenIndex: 2, expErr: true},
-		{name: "multiple tokens 2", tokens: multipleTokens, tokenIndex: 3, expOffset: 1},
-		{name: "multiple tokens 3", tokens: multipleTokens, tokenIndex: 4, expOffset: 0},
-		{name: "multiple tokens not found", tokens: multipleTokens, tokenIndex: 5, expErr: true},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			r := &TokenDataReader{usdcTokenAddress: usdcToken}
-			tokenAmounts := make([]cciptypes.TokenAmount, len(tc.tokens))
-			for i := range tokenAmounts {
-				tokenAmounts[i] = cciptypes.TokenAmount{
-					Token:  ccipcalc.EvmAddrToGeneric(tc.tokens[i]),
-					Amount: big.NewInt(rand.Int63()),
-				}
-			}
-			msg := cciptypes.EVM2EVMOnRampCCIPSendRequestedWithMeta{EVM2EVMMessage: cciptypes.EVM2EVMMessage{TokenAmounts: tokenAmounts}}
-			offset, err := r.getUsdcTokenEndOffset(msg, tc.tokenIndex)
-			if tc.expErr {
-				assert.Error(t, err)
-				return
-			}
-			assert.NoError(t, err)
-			assert.Equal(t, tc.expOffset, offset)
-		})
-	}
+	usdcReader.AssertNumberOfCalls(t, "GetUSDCMessageWithNonce", 1)
 }
 
 func TestUSDCReader_rateLimiting(t *testing.T) {
@@ -362,9 +313,10 @@ func TestUSDCReader_rateLimiting(t *testing.T) {
 			attestationURI, err := url.ParseRequestURI(ts.URL)
 			require.NoError(t, err)
 
+			nonce := utils.RandomBytes32()
 			lggr := logger.TestLogger(t)
-			lp := mocks.NewLogPoller(t)
-			usdcReader, _ := ccipdata.NewUSDCReader(lggr, "job_123", mockMsgTransmitter, lp, false)
+			usdcReader := ccipmocks.NewUSDCReader(t)
+			usdcReader.On("GetUSDCMessageWithNonce", mock.Anything, nonce).Return([]byte{}, nil)
 			usdcService := NewUSDCTokenDataReader(lggr, usdcReader, attestationURI, 0, utils.RandomAddress(), tc.rateConfig)
 
 			ctx := context.Background()
@@ -385,7 +337,8 @@ func TestUSDCReader_rateLimiting(t *testing.T) {
 					<-trigger
 					_, err := usdcService.ReadTokenData(ctx, cciptypes.EVM2EVMOnRampCCIPSendRequestedWithMeta{
 						EVM2EVMMessage: cciptypes.EVM2EVMMessage{
-							TokenAmounts: []cciptypes.TokenAmount{{Token: ccipcalc.EvmAddrToGeneric(utils.ZeroAddress), Amount: nil}}, // trigger failure due to wrong address
+							TokenAmounts:    []cciptypes.TokenAmount{{Token: ccipcalc.EvmAddrToGeneric(utils.ZeroAddress), Amount: nil}}, // trigger failure due to wrong address
+							SourceTokenData: [][]byte{nonce[:]},
 						},
 					}, 0)
 
@@ -405,12 +358,11 @@ func TestUSDCReader_rateLimiting(t *testing.T) {
 			// Collect errors
 			errorFound := false
 			for err := range errorChan {
+				if err == nil {
+					continue
+				}
 				if tc.err != "" && !strings.Contains(err.Error(), tc.err) {
 					errorFound = true
-				} else if err != nil && !strings.Contains(err.Error(), "get usdc token 0 end offset") {
-					// Ignore that one error, it's expected because of how mocking is used.
-					// Anything else is unexpected.
-					require.Fail(t, "unexpected error", err)
 				}
 			}
 			if tc.err != "" {

--- a/integration-tests/ccip-tests/actions/ccip_helpers.go
+++ b/integration-tests/ccip-tests/actions/ccip_helpers.go
@@ -890,9 +890,6 @@ func (ccipModule *CCIPCommon) DeployContracts(
 						}
 					}
 					if ccipModule.TokenMessenger == nil {
-						if ccipModule.TokenTransmitter == nil {
-							return fmt.Errorf("TokenTransmitter contract address is not provided")
-						}
 						ccipModule.TokenMessenger, err = ccipModule.tokenDeployer.DeployTokenMessenger(ccipModule.TokenTransmitter.ContractAddress)
 						if err != nil {
 							return fmt.Errorf("deploying token messenger shouldn't fail %w", err)


### PR DESCRIPTION
## Motivation
We don't want to have the offchain code be reliant on onchain ordering of events.

## Solution
Since we only relied on the ordering of USDC events, we can solve the dependency by removing the ordering requirement for USDC. With this new method we look for the exact nonce, which is significantly less brittle overal. It should not care about log ordering, so we can remove the comment from the onRamps