### PR TITLE
Remove destination chain rate limiting as it is not needed

### DIFF
--- a/integration-tests/ccip-tests/smoke/ccip_test.go
+++ b/integration-tests/ccip-tests/smoke/ccip_test.go
@@ -92,7 +92,6 @@ func TestSmokeCCIPForBidirectionalLane(t *testing.T) {
 
 func TestSmokeCCIPRateLimit(t *testing.T) {
 	t.Parallel()
-
 	log := logging.GetTestLogger(t)
 	TestCfg := testsetups.NewCCIPTestConfig(t, log, testconfig.Smoke)
 	require.True(t, TestCfg.TestGroupInput.MsgDetails.IsTokenTransfer(), "Test config should have token transfer message type")
@@ -492,18 +491,17 @@ func TestSmokeCCIPSelfServeRateLimitOnRamp(t *testing.T) {
 			require.NoError(t, err)
 			tc.lane.ValidateRequests()
 
-			// Enable aggregate rate limiting on the destination and source chains for the limited token
-			err = dest.AddRateLimitTokens([]*contracts.ERC20Token{limitedSrcToken}, []*contracts.ERC20Token{limitedDestToken})
-			require.NoError(t, err, "Error setting destination rate limits")
-			err = dest.OffRamp.SetRateLimit(contracts.RateLimiterConfig{
-				IsEnabled: true,
-				Capacity:  aggregateRateLimit,
-				Rate:      aggregateRateLimit,
-			})
-			require.NoError(t, err, "Error setting destination rate limits")
-			err = dest.Common.ChainClient.WaitForEvents()
-			require.NoError(t, err, "Error waiting for events")
-			tc.lane.Logger.Debug().Str("Token", limitedSrcToken.ContractAddress.Hex()).Msg("Enabled aggregate rate limit on destination chain")
+			// Enable aggregate rate limiting on the source chains for the limited token
+			// err = dest.AddRateLimitTokens([]*contracts.ERC20Token{limitedSrcToken}) //, []*contracts.ERC20Token{limitedDestToken})
+			// require.NoError(t, err, "Error adding rate limit tokens")
+			// err = dest.OffRamp.SetRateLimit(contracts.RateLimiterConfig{
+			// 	IsEnabled: true,
+			// 	Capacity:  aggregateRateLimit,
+			// 	Rate:      aggregateRateLimit,
+			// })
+			// require.NoError(t, err, "Error setting destination rate limits")
+			// err = dest.Common.ChainClient.WaitForEvents()
+			// require.NoError(t, err, "Error waiting for events")
 
 			err = src.OnRamp.SetTokenTransferFeeConfig([]evm_2_evm_onramp.EVM2EVMOnRampTokenTransferFeeConfigArgs{
 				{
@@ -520,7 +518,7 @@ func TestSmokeCCIPSelfServeRateLimitOnRamp(t *testing.T) {
 			require.NoError(t, err, "Error setting OnRamp rate limits")
 			err = src.Common.ChainClient.WaitForEvents()
 			require.NoError(t, err, "Error waiting for events")
-
+			tc.lane.Logger.Debug().Str("Token", limitedSrcToken.ContractAddress.Hex()).Msg("Enabled aggregate rate limit on source chain")
 			// Send free token that should not have a rate limit and should succeed
 			src.TransferAmount[freeTokenIndex] = overLimitAmount
 			src.TransferAmount[limitedTokenIndex] = big.NewInt(0)

--- a/integration-tests/ccip-tests/smoke/ccip_test.go
+++ b/integration-tests/ccip-tests/smoke/ccip_test.go
@@ -492,17 +492,6 @@ func TestSmokeCCIPSelfServeRateLimitOnRamp(t *testing.T) {
 			tc.lane.ValidateRequests()
 
 			// Enable aggregate rate limiting on the source chains for the limited token
-			// err = dest.AddRateLimitTokens([]*contracts.ERC20Token{limitedSrcToken}) //, []*contracts.ERC20Token{limitedDestToken})
-			// require.NoError(t, err, "Error adding rate limit tokens")
-			// err = dest.OffRamp.SetRateLimit(contracts.RateLimiterConfig{
-			// 	IsEnabled: true,
-			// 	Capacity:  aggregateRateLimit,
-			// 	Rate:      aggregateRateLimit,
-			// })
-			// require.NoError(t, err, "Error setting destination rate limits")
-			// err = dest.Common.ChainClient.WaitForEvents()
-			// require.NoError(t, err, "Error waiting for events")
-
 			err = src.OnRamp.SetTokenTransferFeeConfig([]evm_2_evm_onramp.EVM2EVMOnRampTokenTransferFeeConfigArgs{
 				{
 					Token:                     limitedSrcToken.ContractAddress,


### PR DESCRIPTION
## Motivation
The test `TestSmokeCCIPSelfServeRateLimitOnRamp` intends to set rate limit to OnRamp contract and verify it. In this, rate limiting on the source chain is good enough and rate limiting on the destination is not needed.

## Solution
Remove the rate limiting on the destination part.