### PR TITLE
OCR3 execute plugin: report phase

### DIFF
--- a/core/services/ocr3/plugins/ccip/commit/plugin.go
+++ b/core/services/ocr3/plugins/ccip/commit/plugin.go
@@ -8,14 +8,13 @@ import (
 
 	mapset "github.com/deckarep/golang-set/v2"
 
-	"github.com/smartcontractkit/ccipocr3/internal/reader"
-
 	"github.com/smartcontractkit/libocr/commontypes"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 	libocrtypes "github.com/smartcontractkit/libocr/ragep2p/types"
 
 	"github.com/smartcontractkit/ccipocr3/internal/libs/slicelib"
+	"github.com/smartcontractkit/ccipocr3/internal/reader"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"

--- a/core/services/ocr3/plugins/ccip/execute/errors.go
+++ b/core/services/ocr3/plugins/ccip/execute/errors.go
@@ -1,0 +1,5 @@
+package execute
+
+import "errors"
+
+var errNothingExecuted = errors.New("no reports were executed")

--- a/core/services/ocr3/plugins/ccip/execute/factory.go
+++ b/core/services/ocr3/plugins/ccip/execute/factory.go
@@ -51,6 +51,7 @@ func (p PluginFactory) NewReportingPlugin(
 		config,
 		cciptypes.ExecutePluginConfig{},
 		nil,
+		nil,
 	), ocr3types.ReportingPluginInfo{}, nil
 }
 

--- a/core/services/ocr3/plugins/ccip/execute/factory.go
+++ b/core/services/ocr3/plugins/ccip/execute/factory.go
@@ -52,6 +52,8 @@ func (p PluginFactory) NewReportingPlugin(
 		cciptypes.ExecutePluginConfig{},
 		nil,
 		nil,
+		nil,
+		nil,
 	), ocr3types.ReportingPluginInfo{}, nil
 }
 

--- a/core/services/ocr3/plugins/ccip/execute/factory.go
+++ b/core/services/ocr3/plugins/ccip/execute/factory.go
@@ -47,7 +47,6 @@ func (p PluginFactory) NewReportingPlugin(
 	config ocr3types.ReportingPluginConfig,
 ) (ocr3types.ReportingPlugin[[]byte], ocr3types.ReportingPluginInfo, error) {
 	return NewPlugin(
-		context.Background(),
 		config,
 		cciptypes.ExecutePluginConfig{},
 		nil,

--- a/core/services/ocr3/plugins/ccip/execute/plugin.go
+++ b/core/services/ocr3/plugins/ccip/execute/plugin.go
@@ -351,9 +351,14 @@ func selectReport(ctx context.Context, lggr logger.Logger, hasher cciptypes.Mess
 				}
 			}
 
+			if high == 0 {
+				// No messages could fit in the report.
+				break
+			}
+
 			// Mark new messages executed.
 			for i := 0; i < len(finalReport.Messages); i++ {
-				reports[reportIdx].ExecutedMessages = append(reports[reportIdx].ExecutedMessages, report.Messages[i].SeqNum-report.SequenceNumberRange.Start())
+				reports[reportIdx].ExecutedMessages = append(reports[reportIdx].ExecutedMessages, finalReport.Messages[i].SeqNum)
 			}
 			sort.Slice(report.ExecutedMessages, func(i, j int) bool { return report.ExecutedMessages[i] < report.ExecutedMessages[j] })
 		} else {

--- a/core/services/ocr3/plugins/ccip/execute/plugin.go
+++ b/core/services/ocr3/plugins/ccip/execute/plugin.go
@@ -309,7 +309,7 @@ func buildSingleChainReport(
 	tree, err := constructMerkleTree(ctx, hasher, report)
 	if err != nil {
 		return cciptypes.ExecutePluginReportSingleChain{}, 0,
-			fmt.Errorf("unable to constructing merkle tree from messages: %w", err)
+			fmt.Errorf("unable to construct merkle tree from messages: %w", err)
 	}
 	lggr.Debugw(
 		"constructing merkle tree",

--- a/core/services/ocr3/plugins/ccip/execute/plugin.go
+++ b/core/services/ocr3/plugins/ccip/execute/plugin.go
@@ -271,8 +271,10 @@ func buildSingleChainReport(ctx context.Context, lggr logger.Logger, hasher ccip
 			msg := report.Messages[i]
 			tokenData, err := tokenDataReader.ReadTokenData(context.Background(), report.SourceChain, msg.SeqNum)
 			if err != nil {
+				// TODO: skip message instead of failing the whole thing.
+				//       that might mean moving the token data reading out of the loop.
 				lggr.Info("unable to read token data", "source-chain", report.SourceChain, "seq-num", msg.SeqNum, "error", err)
-				offchainTokenData = append(offchainTokenData, nil)
+				return cciptypes.ExecutePluginReportSingleChain{}, 0, fmt.Errorf("unable to read token data for message %d: %w", msg.SeqNum, err)
 			} else {
 				lggr.Debugw("read token data", "source-chain", report.SourceChain, "seq-num", msg.SeqNum, "data", tokenData)
 				offchainTokenData = append(offchainTokenData, tokenData)

--- a/core/services/ocr3/plugins/ccip/execute/plugin.go
+++ b/core/services/ocr3/plugins/ccip/execute/plugin.go
@@ -23,7 +23,6 @@ const maxReportSizeBytes = 250_000
 
 // Plugin implements the main ocr3 plugin logic.
 type Plugin struct {
-	ctx             context.Context
 	reportingCfg    ocr3types.ReportingPluginConfig
 	cfg             cciptypes.ExecutePluginConfig
 	ccipReader      cciptypes.CCIPReader
@@ -37,7 +36,6 @@ type Plugin struct {
 }
 
 func NewPlugin(
-	ctx context.Context,
 	reportingCfg ocr3types.ReportingPluginConfig,
 	cfg cciptypes.ExecutePluginConfig,
 	ccipReader cciptypes.CCIPReader,
@@ -51,7 +49,6 @@ func NewPlugin(
 	// TODO: initialize tokenDataReader.
 
 	return &Plugin{
-		ctx:          ctx,
 		reportingCfg: reportingCfg,
 		cfg:          cfg,
 		ccipReader:   ccipReader,
@@ -492,8 +489,9 @@ func (p *Plugin) Outcome(
 		}
 	}
 
+	// TODO: this function should be pure, a context should not be needed.
 	outcomeReports, commitReports, err :=
-		selectReport(p.ctx, p.lggr, p.msgHasher, p.reportCodec, p.tokenDataReader, commitReports, maxReportSizeBytes)
+		selectReport(context.Background(), p.lggr, p.msgHasher, p.reportCodec, p.tokenDataReader, commitReports, maxReportSizeBytes)
 	if err != nil {
 		return ocr3types.Outcome{}, fmt.Errorf("unable to extract proofs: %w", err)
 	}
@@ -511,7 +509,8 @@ func (p *Plugin) Reports(seqNr uint64, outcome ocr3types.Outcome) ([]ocr3types.R
 		return nil, err
 	}
 
-	encoded, err := p.reportCodec.Encode(p.ctx, decodedOutcome.Report)
+	// TODO: this function should be pure, a context should not be needed.
+	encoded, err := p.reportCodec.Encode(context.Background(), decodedOutcome.Report)
 	if err != nil {
 		return nil, err
 	}

--- a/core/services/ocr3/plugins/ccip/execute/plugin.go
+++ b/core/services/ocr3/plugins/ccip/execute/plugin.go
@@ -317,8 +317,7 @@ func buildSingleChainReport(
 		"selected messages from commit report for execution",
 		"sourceChain", report.SourceChain,
 		"commitRoot", report.MerkleRoot.String(),
-		"numMessages", len(toExecute),
-		"totalMessages", numMsgs,
+		"numMessages", numMsgs,
 		"toExecute", len(toExecute))
 	proof, err := tree.Prove(toExecute)
 	if err != nil {

--- a/core/services/ocr3/plugins/ccip/execute/plugin.go
+++ b/core/services/ocr3/plugins/ccip/execute/plugin.go
@@ -492,7 +492,8 @@ func (p *Plugin) Outcome(
 		}
 	}
 
-	outcomeReports, commitReports, err := selectReport(p.ctx, p.lggr, p.msgHasher, p.reportCodec, nil, commitReports, maxReportSizeBytes)
+	outcomeReports, commitReports, err :=
+		selectReport(p.ctx, p.lggr, p.msgHasher, p.reportCodec, nil, commitReports, maxReportSizeBytes)
 	if err != nil {
 		return ocr3types.Outcome{}, fmt.Errorf("unable to extract proofs: %w", err)
 	}

--- a/core/services/ocr3/plugins/ccip/execute/plugin.go
+++ b/core/services/ocr3/plugins/ccip/execute/plugin.go
@@ -239,11 +239,11 @@ func buildSingleChainReport(
 		maxMessages = len(report.Messages)
 	}
 
-	numMsg := int(report.SequenceNumberRange.End() - report.SequenceNumberRange.Start() + 1)
-	if numMsg != len(report.Messages) {
+	numMsgs := int(report.SequenceNumberRange.End() - report.SequenceNumberRange.Start() + 1)
+	if numMsgs != len(report.Messages) {
 		return cciptypes.ExecutePluginReportSingleChain{}, 0, fmt.Errorf(
 			"malformed report %s, unexpected number of messages: expected %d, got %d",
-			report.MerkleRoot.String(), numMsg, len(report.Messages))
+			report.MerkleRoot.String(), numMsgs, len(report.Messages))
 	}
 
 	treeLeaves := make([][32]byte, 0)
@@ -281,7 +281,7 @@ func buildSingleChainReport(
 	var offchainTokenData [][][]byte
 	var msgInRoot []cciptypes.CCIPMsg
 	executedIdx := 0
-	for i := 0; i < numMsg && len(toExecute) <= maxMessages; i++ {
+	for i := 0; i < numMsgs && len(toExecute) <= maxMessages; i++ {
 		seqNum := report.SequenceNumberRange.Start() + cciptypes.SeqNum(i)
 		// Skip messages which are already executed
 		if executedIdx < len(report.ExecutedMessages) && report.ExecutedMessages[executedIdx] == seqNum {
@@ -317,7 +317,7 @@ func buildSingleChainReport(
 		"sourceChain", report.SourceChain,
 		"commitRoot", report.MerkleRoot.String(),
 		"numMessages", len(toExecute),
-		"totalMessages", numMsg,
+		"totalMessages", numMsgs,
 		"toExecute", len(toExecute))
 	proof, err := tree.Prove(toExecute)
 	if err != nil {

--- a/core/services/ocr3/plugins/ccip/execute/plugin.go
+++ b/core/services/ocr3/plugins/ccip/execute/plugin.go
@@ -8,13 +8,14 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/smartcontractkit/ccipocr3/internal/libs/slicelib"
 	"github.com/smartcontractkit/chainlink-common/pkg/hashutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/merklemulti"
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+
+	"github.com/smartcontractkit/ccipocr3/internal/libs/slicelib"
 )
 
 // maxReportSizeBytes that should be returned as an execution report payload.
@@ -299,14 +300,14 @@ func buildSingleChainReport(
 					"error", err)
 				return cciptypes.ExecutePluginReportSingleChain{}, 0, fmt.Errorf(
 					"unable to read token data for message %d: %w", msg.SeqNum, err)
-			} else {
-				lggr.Debugw(
-					"read token data",
-					"source-chain", report.SourceChain,
-					"seq-num", msg.SeqNum,
-					"data", tokenData)
-				offchainTokenData = append(offchainTokenData, tokenData)
 			}
+
+			lggr.Debugw(
+				"read token data",
+				"source-chain", report.SourceChain,
+				"seq-num", msg.SeqNum,
+				"data", tokenData)
+			offchainTokenData = append(offchainTokenData, tokenData)
 			toExecute = append(toExecute, i)
 			msgInRoot = append(msgInRoot, msg)
 		}
@@ -493,7 +494,7 @@ func (p *Plugin) Outcome(
 	}
 
 	outcomeReports, commitReports, err :=
-		selectReport(p.ctx, p.lggr, p.msgHasher, p.reportCodec, nil, commitReports, maxReportSizeBytes)
+		selectReport(p.ctx, p.lggr, p.msgHasher, p.reportCodec, p.tokenDataReader, commitReports, maxReportSizeBytes)
 	if err != nil {
 		return ocr3types.Outcome{}, fmt.Errorf("unable to extract proofs: %w", err)
 	}

--- a/core/services/ocr3/plugins/ccip/execute/plugin.go
+++ b/core/services/ocr3/plugins/ccip/execute/plugin.go
@@ -241,7 +241,6 @@ func buildSingleChainReport(ctx context.Context, lggr logger.Logger, hasher ccip
 		if !report.SequenceNumberRange.Contains(msg.SeqNum) {
 			return cciptypes.ExecutePluginReportSingleChain{}, 0, fmt.Errorf("malformed report %s, message with sequence number %d outside of report range %s", report.MerkleRoot.String(), msg.SeqNum, report.SequenceNumberRange)
 		}
-		// TODO: pass in a hasher to construct the chain specific merkle tree.
 		leaf, err := hasher.Hash(ctx, msg)
 		if err != nil {
 			return cciptypes.ExecutePluginReportSingleChain{}, 0, fmt.Errorf("unable to hash message (%d, %d): %w", msg.SourceChain, msg.SeqNum, err)

--- a/core/services/ocr3/plugins/ccip/execute/plugin.go
+++ b/core/services/ocr3/plugins/ccip/execute/plugin.go
@@ -9,9 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/hashutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-	"github.com/smartcontractkit/chainlink-common/pkg/merklemulti"
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
@@ -286,32 +284,6 @@ func buildSingleChainReportMaxSize(
 	return finalReport, encodedSize, report, nil
 }
 
-func constructMerkleTree(
-	ctx context.Context,
-	hasher cciptypes.MessageHasher,
-	report cciptypes.ExecutePluginCommitDataWithMessages,
-) (*merklemulti.Tree[[32]byte], error) {
-	treeLeaves := make([][32]byte, 0)
-	for _, msg := range report.Messages {
-		if !report.SequenceNumberRange.Contains(msg.SeqNum) {
-			return nil, fmt.Errorf(
-				"malformed message %s, message with sequence number %d outside of report range %s",
-				report.MerkleRoot.String(), msg.SeqNum, report.SequenceNumberRange)
-		}
-		if report.SourceChain != msg.SourceChain {
-			return nil, fmt.Errorf("malformed message %s, unexpected source chain: expected %d, got %d",
-				report.MerkleRoot.String(), report.SourceChain, msg.SourceChain)
-		}
-		leaf, err := hasher.Hash(ctx, msg)
-		if err != nil {
-			return nil, fmt.Errorf("unable to hash message (%d, %d): %w", msg.SourceChain, msg.SeqNum, err)
-		}
-		treeLeaves = append(treeLeaves, leaf)
-	}
-
-	return merklemulti.NewTree(hashutil.NewKeccak(), treeLeaves)
-}
-
 // buildSingleChainReport converts the on-chain event data stored in cciptypes.ExecutePluginCommitDataWithMessages into
 // the final on-chain report format.
 //
@@ -334,25 +306,16 @@ func buildSingleChainReport(
 		maxMessages = len(report.Messages)
 	}
 
-	numMsgs := int(report.SequenceNumberRange.End() - report.SequenceNumberRange.Start() + 1)
-	if numMsgs != len(report.Messages) {
-		return cciptypes.ExecutePluginReportSingleChain{}, 0, fmt.Errorf(
-			"malformed report %s, unexpected number of messages: expected %d, got %d",
-			report.MerkleRoot.String(), numMsgs, len(report.Messages))
-	}
-
 	tree, err := constructMerkleTree(ctx, hasher, report)
 	if err != nil {
 		return cciptypes.ExecutePluginReportSingleChain{}, 0,
 			fmt.Errorf("unable to constructing merkle tree from messages: %w", err)
 	}
-	if err != nil {
-		return cciptypes.ExecutePluginReportSingleChain{}, 0, err
-	}
 	lggr.Debugw(
 		"constructing merkle tree",
 		"sourceChain", report.SourceChain,
 		"treeLeaves", len(report.Messages))
+	numMsgs := len(report.Messages)
 
 	// Iterate sequence range and executed messages to select messages to execute.
 	var toExecute []int

--- a/core/services/ocr3/plugins/ccip/execute/plugin_functions.go
+++ b/core/services/ocr3/plugins/ccip/execute/plugin_functions.go
@@ -315,3 +315,20 @@ func mergeCommitObservations(
 
 	return results, nil
 }
+
+// markNewMessagesExecuted compares an execute plugin report with the commit report metadata and marks the new messages
+// as executed.
+func markNewMessagesExecuted(
+	execReport cciptypes.ExecutePluginReportSingleChain, report cciptypes.ExecutePluginCommitDataWithMessages,
+) cciptypes.ExecutePluginCommitDataWithMessages {
+	// Mark new messages executed.
+	for i := 0; i < len(execReport.Messages); i++ {
+		report.ExecutedMessages =
+			append(report.ExecutedMessages, execReport.Messages[i].SeqNum)
+	}
+	sort.Slice(
+		report.ExecutedMessages,
+		func(i, j int) bool { return report.ExecutedMessages[i] < report.ExecutedMessages[j] })
+
+	return report
+}

--- a/core/services/ocr3/plugins/ccip/execute/plugin_test.go
+++ b/core/services/ocr3/plugins/ccip/execute/plugin_test.go
@@ -11,12 +11,13 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/ccipocr3/internal/libs/slicelib"
-	"github.com/smartcontractkit/ccipocr3/internal/mocks"
 	"github.com/smartcontractkit/chainlink-common/pkg/hashutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/merklemulti"
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
+
+	"github.com/smartcontractkit/ccipocr3/internal/libs/slicelib"
+	"github.com/smartcontractkit/ccipocr3/internal/mocks"
 )
 
 func Test_getPendingExecutedReports(t *testing.T) {
@@ -244,7 +245,6 @@ func assertMerkleRoot(
 	proofCast := make([][32]byte, len(execReport.Proofs))
 	for i, p := range execReport.Proofs {
 		copy(proofCast[i][:], p[:32])
-		proofCast[i][2] = proofCast[i][2]
 	}
 	var proof merklemulti.Proof[[32]byte]
 	proof.Hashes = proofCast

--- a/core/services/ocr3/plugins/ccip/execute/plugin_test.go
+++ b/core/services/ocr3/plugins/ccip/execute/plugin_test.go
@@ -28,7 +28,6 @@ func Test_getPendingExecutedReports(t *testing.T) {
 		want1   time.Time
 		wantErr assert.ErrorAssertionFunc
 	}{
-		// TODO: Add test cases.
 		{
 			name:    "empty",
 			reports: nil,

--- a/core/services/ocr3/plugins/ccip/execute/plugin_test.go
+++ b/core/services/ocr3/plugins/ccip/execute/plugin_test.go
@@ -2,9 +2,7 @@ package execute
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"math"
 	"testing"
 	"time"
 
@@ -20,22 +18,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/merklemulti"
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 )
-
-func TestSomethingCool(t *testing.T) {
-
-	foo := map[cciptypes.ChainSelector]int{
-		cciptypes.ChainSelector(1):              1,
-		cciptypes.ChainSelector(math.MaxUint64): 1,
-	}
-
-	js, _ := json.Marshal(foo)
-	t.Log(string(js))
-
-	b := []byte(`{"1":1,"18446744073709551615":1}`)
-	var bar map[cciptypes.ChainSelector]int
-	assert.NoError(t, json.Unmarshal(b, &bar))
-	t.Log(bar)
-}
 
 func Test_getPendingExecutedReports(t *testing.T) {
 	tests := []struct {

--- a/core/services/ocr3/plugins/ccip/execute/plugin_test.go
+++ b/core/services/ocr3/plugins/ccip/execute/plugin_test.go
@@ -219,7 +219,7 @@ func assertMerkleRoot(
 	t *testing.T,
 	hasher cciptypes.MessageHasher,
 	execReport cciptypes.ExecutePluginReportSingleChain,
-	commitReport cciptypes.ExecutePluginCommitDataWithMessages
+	commitReport cciptypes.ExecutePluginCommitDataWithMessages,
 ) {
 	keccak := hashutil.NewKeccak()
 	// Generate merkle root from commit report messages
@@ -419,7 +419,7 @@ func Test_selectReport(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()
 			execReports, commitReports, err :=
-				 selectReport(ctx, lggr, hasher, codec, tokenDataReader, tt.args.reports, tt.args.maxReportSize)
+				selectReport(ctx, lggr, hasher, codec, tokenDataReader, tt.args.reports, tt.args.maxReportSize)
 			if tt.wantErr != "" {
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
@@ -477,8 +477,8 @@ func Test_buildSingleChainReport_Errors(t *testing.T) {
 		codec           cciptypes.ExecutePluginCodec
 	}
 	tests := []struct {
-		name string
-		args args
+		name    string
+		args    args
 		wantErr string
 	}{
 		{

--- a/core/services/ocr3/plugins/ccip/execute/plugin_test.go
+++ b/core/services/ocr3/plugins/ccip/execute/plugin_test.go
@@ -371,6 +371,31 @@ func Test_selectReport(t *testing.T) {
 			expectedExecThings:    []int{4},
 			lastReportExecuted:    []cciptypes.SeqNum{100, 101, 102, 103, 104, 105, 106, 107, 108},
 		},
+		{
+			name: "execute remainder of sparsely executed report",
+			args: args{
+				maxReportSize: 2500,
+				reports: []cciptypes.ExecutePluginCommitDataWithMessages{
+					makeTestMessage(10, 1, 100, 999, 10101010101, []cciptypes.SeqNum{100, 102, 104, 106, 108}),
+				},
+			},
+			expectedExecReports:   1,
+			expectedCommitReports: 0,
+			expectedExecThings:    []int{5},
+		},
+		{
+			name: "partially execute remainder of partially executed sparse report",
+			args: args{
+				maxReportSize: 2000,
+				reports: []cciptypes.ExecutePluginCommitDataWithMessages{
+					makeTestMessage(10, 1, 100, 999, 10101010101, []cciptypes.SeqNum{100, 102, 104, 106, 108}),
+				},
+			},
+			expectedExecReports:   1,
+			expectedCommitReports: 1,
+			expectedExecThings:    []int{4},
+			lastReportExecuted:    []cciptypes.SeqNum{100, 101, 102, 103, 104, 105, 106, 107, 108},
+		},
 		// TODO: error cases
 	}
 	for _, tt := range tests {

--- a/core/services/ocr3/plugins/ccip/execute/plugin_test.go
+++ b/core/services/ocr3/plugins/ccip/execute/plugin_test.go
@@ -498,7 +498,7 @@ func Test_buildSingleChainReport_Errors(t *testing.T) {
 		},
 		{
 			name:    "wrong sequence numbers",
-			wantErr: "message with sequence number 102 outside of report range [100 -> 101]",
+			wantErr: "sequence number 102 outside of report range [100 -> 101]",
 			args: args{
 				report: cciptypes.ExecutePluginCommitDataWithMessages{
 					ExecutePluginCommitData: cciptypes.ExecutePluginCommitData{

--- a/core/services/ocr3/plugins/ccip/go.mod
+++ b/core/services/ocr3/plugins/ccip/go.mod
@@ -4,7 +4,7 @@ go 1.21.7
 
 require (
 	github.com/deckarep/golang-set/v2 v2.6.0
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240625074419-c278d083facf
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240624191350-e000707a4cf7
 	github.com/smartcontractkit/libocr v0.0.0-20240419185742-fd3cab206b2c
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/crypto v0.24.0

--- a/core/services/ocr3/plugins/ccip/go.mod
+++ b/core/services/ocr3/plugins/ccip/go.mod
@@ -4,7 +4,7 @@ go 1.21.7
 
 require (
 	github.com/deckarep/golang-set/v2 v2.6.0
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240624191350-e000707a4cf7
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240626200607-030cd3975e55
 	github.com/smartcontractkit/libocr v0.0.0-20240419185742-fd3cab206b2c
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/crypto v0.24.0

--- a/core/services/ocr3/plugins/ccip/go.sum
+++ b/core/services/ocr3/plugins/ccip/go.sum
@@ -54,6 +54,8 @@ github.com/smartcontractkit/chainlink-common v0.1.7-0.20240624191350-e000707a4cf
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240624191350-e000707a4cf7/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240625074419-c278d083facf h1:d9AS/K8RSVG64USb20N/U7RaPOsYPcmuLGJq7iE+caM=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240625074419-c278d083facf/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240626200607-030cd3975e55 h1:bKcZAqP+UuXijzswFr4WssWuuhaXFkJF8Jbg8vhOWPY=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240626200607-030cd3975e55/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
 github.com/smartcontractkit/libocr v0.0.0-20240419185742-fd3cab206b2c h1:lIyMbTaF2H0Q71vkwZHX/Ew4KF2BxiKhqEXwF8rn+KI=
 github.com/smartcontractkit/libocr v0.0.0-20240419185742-fd3cab206b2c/go.mod h1:fb1ZDVXACvu4frX3APHZaEBp0xi1DIm34DcA0CwTsZM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/core/services/ocr3/plugins/ccip/go.sum
+++ b/core/services/ocr3/plugins/ccip/go.sum
@@ -50,6 +50,8 @@ github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6Ng
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240624191350-e000707a4cf7 h1:3GjsV3Daa9POHEfUgjC0pbnxsL/iL/nbhVaju1TZpVU=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240624191350-e000707a4cf7/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240625074419-c278d083facf h1:d9AS/K8RSVG64USb20N/U7RaPOsYPcmuLGJq7iE+caM=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240625074419-c278d083facf/go.mod h1:L32xvCpk84Nglit64OhySPMP1tM3TTBK7Tw0qZl7Sd4=
 github.com/smartcontractkit/libocr v0.0.0-20240419185742-fd3cab206b2c h1:lIyMbTaF2H0Q71vkwZHX/Ew4KF2BxiKhqEXwF8rn+KI=

--- a/core/services/ocr3/plugins/ccip/internal/libs/crypto/hasher.go
+++ b/core/services/ocr3/plugins/ccip/internal/libs/crypto/hasher.go
@@ -1,1 +1,0 @@
-package crypto

--- a/core/services/ocr3/plugins/ccip/internal/libs/crypto/hasher.go
+++ b/core/services/ocr3/plugins/ccip/internal/libs/crypto/hasher.go
@@ -1,0 +1,1 @@
+package crypto

--- a/core/services/ocr3/plugins/ccip/internal/libs/slicelib/bits.go
+++ b/core/services/ocr3/plugins/ccip/internal/libs/slicelib/bits.go
@@ -12,3 +12,11 @@ func BoolsToBitFlags(bools []bool) *big.Int {
 	}
 	return encodedFlags
 }
+
+func BitFlagsToBools(encodedFlags *big.Int, size int) []bool {
+	var bools []bool
+	for i := 0; i < size; i++ {
+		bools = append(bools, encodedFlags.Bit(i) == 1)
+	}
+	return bools
+}

--- a/core/services/ocr3/plugins/ccip/internal/libs/slicelib/bits.go
+++ b/core/services/ocr3/plugins/ccip/internal/libs/slicelib/bits.go
@@ -1,0 +1,14 @@
+package slicelib
+
+import "math/big"
+
+// BoolsToBitFlags transforms a list of boolean flags to a *big.Int encoded number.
+func BoolsToBitFlags(bools []bool) *big.Int {
+	encodedFlags := big.NewInt(0)
+	for i := 0; i < len(bools); i++ {
+		if bools[i] {
+			encodedFlags.SetBit(encodedFlags, i, 1)
+		}
+	}
+	return encodedFlags
+}

--- a/core/services/ocr3/plugins/ccip/internal/libs/slicelib/bits_test.go
+++ b/core/services/ocr3/plugins/ccip/internal/libs/slicelib/bits_test.go
@@ -1,0 +1,59 @@
+package slicelib
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBoolsToBitFlags(t *testing.T) {
+	genFlags := func(indexesSet []int, size int) []bool {
+		bools := make([]bool, size)
+		for _, indexSet := range indexesSet {
+			bools[indexSet] = true
+		}
+		return bools
+	}
+	tt := []struct {
+		flags    []bool
+		expected *big.Int
+	}{
+		{
+			[]bool{true, false, true},
+			big.NewInt(5),
+		},
+		{
+			[]bool{true, true, false}, // Note the bits are reversed, slightly easier to implement.
+			big.NewInt(3),
+		},
+		{
+			[]bool{false, true, true},
+			big.NewInt(6),
+		},
+		{
+			[]bool{false, false, false},
+			big.NewInt(0),
+		},
+		{
+			[]bool{true, true, true},
+			big.NewInt(7),
+		},
+		{
+			genFlags([]int{266}, 300),
+			big.NewInt(0).SetBit(big.NewInt(0), 266, 1),
+		},
+	}
+	for i, tc := range tt {
+		tc := tc
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			t.Parallel()
+			a := BoolsToBitFlags(tc.flags)
+			assert.Equal(t, tc.expected.String(), a.String())
+
+			b := BitFlagsToBools(a, len(tc.flags))
+			assert.ElementsMatch(t, tc.flags, b)
+		})
+	}
+}

--- a/core/services/ocr3/plugins/ccip/internal/mocks/reportcodec.go
+++ b/core/services/ocr3/plugins/ccip/internal/mocks/reportcodec.go
@@ -29,11 +29,11 @@ func NewExecutePluginJSONReportCodec() *ExecutePluginJSONReportCodec {
 	return &ExecutePluginJSONReportCodec{}
 }
 
-func (c ExecutePluginJSONReportCodec) Encode(ctx context.Context, report cciptypes.ExecutePluginReport) ([]byte, error) {
+func (c ExecutePluginJSONReportCodec) Encode(_ context.Context, report cciptypes.ExecutePluginReport) ([]byte, error) {
 	return json.Marshal(report)
 }
 
-func (c ExecutePluginJSONReportCodec) Decode(ctx context.Context, bytes []byte) (cciptypes.ExecutePluginReport, error) {
+func (c ExecutePluginJSONReportCodec) Decode(_ context.Context, bytes []byte) (cciptypes.ExecutePluginReport, error) {
 	report := cciptypes.ExecutePluginReport{}
 	err := json.Unmarshal(bytes, &report)
 	return report, err

--- a/core/services/ocr3/plugins/ccip/internal/mocks/reportcodec.go
+++ b/core/services/ocr3/plugins/ccip/internal/mocks/reportcodec.go
@@ -22,3 +22,19 @@ func (c CommitPluginJSONReportCodec) Decode(ctx context.Context, bytes []byte) (
 	err := json.Unmarshal(bytes, &report)
 	return report, err
 }
+
+type ExecutePluginJSONReportCodec struct{}
+
+func NewExecutePluginJSONReportCodec() *ExecutePluginJSONReportCodec {
+	return &ExecutePluginJSONReportCodec{}
+}
+
+func (c ExecutePluginJSONReportCodec) Encode(ctx context.Context, report cciptypes.ExecutePluginReport) ([]byte, error) {
+	return json.Marshal(report)
+}
+
+func (c ExecutePluginJSONReportCodec) Decode(ctx context.Context, bytes []byte) (cciptypes.ExecutePluginReport, error) {
+	report := cciptypes.ExecutePluginReport{}
+	err := json.Unmarshal(bytes, &report)
+	return report, err
+}


### PR DESCRIPTION
Select commit reports from the outcome to include in the final execution report and build the report.