### PR TITLE
CCIP-2642: Fixing panic in regex parsing

### DIFF
--- a/.github/workflows/ccip-load-tests.yml
+++ b/.github/workflows/ccip-load-tests.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - ccip-develop
+      - ccip-2642
     tags:
       - '*'
   workflow_dispatch:
@@ -207,7 +208,7 @@ jobs:
   # Reporting Jobs
   start-slack-thread:
     name: Start Slack Thread
-    if: ${{ failure() && needs.ccip-load-test.result != 'skipped' && needs.ccip-load-test.result != 'cancelled' }}
+    if: ${{ always() && needs.ccip-load-test.result != 'skipped' && needs.ccip-load-test.result != 'cancelled' }}
     environment: integration
     outputs:
       thread_ts: ${{ steps.slack.outputs.thread_ts }}
@@ -225,7 +226,7 @@ jobs:
         uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
         id: slack
         with:
-          channel-id: "#ccip-testing"
+          channel-id: "#test_notif"
           payload: |
             {
               "attachments": [
@@ -258,8 +259,8 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.QA_SLACK_API_KEY }}
 
   post-test-results-to-slack:
-    name: Post Test Results for ${{ matrix.network }}
-    if: ${{ failure() && needs.start-slack-thread.result != 'skipped' && needs.start-slack-thread.result != 'cancelled' }}
+    name: Post Test Results
+    if: ${{ always() && needs.start-slack-thread.result != 'skipped' && needs.start-slack-thread.result != 'cancelled' }}
     environment: integration
     permissions:
       checks: write
@@ -268,10 +269,6 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     needs: start-slack-thread
-    strategy:
-      fail-fast: false
-      matrix:
-        network: [CCIP]
     steps:
       - name: Checkout the repo
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
@@ -283,9 +280,9 @@ jobs:
           github_token: ${{ github.token }}
           github_repository: ${{ github.repository }}
           workflow_run_id: ${{ github.run_id }}
-          github_job_name_regex: ^${{ matrix.network }} (.*?)$
-          message_title: ${{ matrix.network }}
-          slack_channel_id: "#ccip-testing"
+          github_job_name_regex: ^CCIP (.*)$
+          message_title: CCIP
+          slack_channel_id: "#test_notif"
           slack_bot_token: ${{ secrets.QA_SLACK_API_KEY }}
           slack_thread_ts: ${{ needs.start-slack-thread.outputs.thread_ts }}
 

--- a/.github/workflows/ccip-load-tests.yml
+++ b/.github/workflows/ccip-load-tests.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - ccip-develop
-      - ccip-2642
     tags:
       - '*'
   workflow_dispatch:
@@ -27,78 +26,78 @@ env:
   MOD_CACHE_VERSION: 1
 
 jobs:
-#  build-chainlink:
-#    environment: integration
-#    permissions:
-#      id-token: write
-#      contents: read
-#    name: Build Chainlink Image
-#    runs-on: ubuntu20.04-16cores-64GB
-#    steps:
-#      - name: Checkout the repo
-#        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
-#      - name: Check if image exists
-#        id: check-image
-#        uses: smartcontractkit/chainlink-github-actions/docker/image-exists@b49a9d04744b0237908831730f8553f26d73a94b # v2.3.17
-#        with:
-#          repository: chainlink
-#          tag: ${{ env.CHAINLINK_VERSION }}
-#          AWS_REGION: ${{ secrets.QA_AWS_REGION }}
-#          AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
-#      - name: Build Image
-#        if: steps.check-image.outputs.exists == 'false'
-#        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/build-image@b49a9d04744b0237908831730f8553f26d73a94b # v2.3.17
-#        env:
-#          GH_TOKEN: ${{ github.token }}
-#        with:
-#          cl_repo: smartcontractkit/chainlink-ccip
-#          cl_ref: ${{ env.CHAINLINK_VERSION }}
-#          push_tag: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink:${{ env.CHAINLINK_VERSION }}
-#          QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
-#          QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
-#      - name: Collect Metrics
-#        if: always()
-#        id: collect-gha-metrics
-#        uses: smartcontractkit/push-gha-metrics-action@dea9b546553cb4ca936607c2267a09c004e4ab3f # v3.0.0
-#        with:
-#          id: ccip-load-test-build-chainlink-image
-#          org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
-#          basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
-#          hostname: ${{ secrets.GRAFANA_INTERNAL_HOST }}
-#          this-job-name: Build Chainlink Image
-#        continue-on-error: true
-#
-#  build-test-image:
-#    environment: integration
-#    permissions:
-#      id-token: write
-#      contents: read
-#    name: Build Test Image
-#    runs-on: ubuntu20.04-16cores-64GB
-#    steps:
-#      - name: Collect Metrics
-#        id: collect-gha-metrics
-#        uses: smartcontractkit/push-gha-metrics-action@dea9b546553cb4ca936607c2267a09c004e4ab3f # v3.0.0
-#        with:
-#          id: ccip-load-test-build-test-image
-#          org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
-#          basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
-#          hostname: ${{ secrets.GRAFANA_INTERNAL_HOST }}
-#          this-job-name: Build Test Image
-#        continue-on-error: true
-#      - name: Checkout the repo
-#        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
-#      - name: Build Test Image
-#        uses: ./.github/actions/build-test-image
-#        with:
-#          tag: ${{ env.INPUT_CHAINLINK_TEST_VERSION }}
-#          QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
-#          QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
-#          QA_AWS_ACCOUNT_NUMBER: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
+  build-chainlink:
+    environment: integration
+    permissions:
+      id-token: write
+      contents: read
+    name: Build Chainlink Image
+    runs-on: ubuntu20.04-16cores-64GB
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+      - name: Check if image exists
+        id: check-image
+        uses: smartcontractkit/chainlink-github-actions/docker/image-exists@b49a9d04744b0237908831730f8553f26d73a94b # v2.3.17
+        with:
+          repository: chainlink
+          tag: ${{ env.CHAINLINK_VERSION }}
+          AWS_REGION: ${{ secrets.QA_AWS_REGION }}
+          AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
+      - name: Build Image
+        if: steps.check-image.outputs.exists == 'false'
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/build-image@b49a9d04744b0237908831730f8553f26d73a94b # v2.3.17
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          cl_repo: smartcontractkit/chainlink-ccip
+          cl_ref: ${{ env.CHAINLINK_VERSION }}
+          push_tag: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink:${{ env.CHAINLINK_VERSION }}
+          QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
+          QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
+      - name: Collect Metrics
+        if: always()
+        id: collect-gha-metrics
+        uses: smartcontractkit/push-gha-metrics-action@dea9b546553cb4ca936607c2267a09c004e4ab3f # v3.0.0
+        with:
+          id: ccip-load-test-build-chainlink-image
+          org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
+          basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
+          hostname: ${{ secrets.GRAFANA_INTERNAL_HOST }}
+          this-job-name: Build Chainlink Image
+        continue-on-error: true
+
+  build-test-image:
+    environment: integration
+    permissions:
+      id-token: write
+      contents: read
+    name: Build Test Image
+    runs-on: ubuntu20.04-16cores-64GB
+    steps:
+      - name: Collect Metrics
+        id: collect-gha-metrics
+        uses: smartcontractkit/push-gha-metrics-action@dea9b546553cb4ca936607c2267a09c004e4ab3f # v3.0.0
+        with:
+          id: ccip-load-test-build-test-image
+          org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
+          basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
+          hostname: ${{ secrets.GRAFANA_INTERNAL_HOST }}
+          this-job-name: Build Test Image
+        continue-on-error: true
+      - name: Checkout the repo
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+      - name: Build Test Image
+        uses: ./.github/actions/build-test-image
+        with:
+          tag: ${{ env.INPUT_CHAINLINK_TEST_VERSION }}
+          QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
+          QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
+          QA_AWS_ACCOUNT_NUMBER: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
 
   ccip-load-test:
     environment: integration
-#    needs: [ build-chainlink, build-test-image ]
+    needs: [ build-chainlink, build-test-image ]
     if: ${{ always() && !contains(needs.*.result, 'failure') }}
     permissions:
       issues: read
@@ -178,37 +177,37 @@ jobs:
           logstreamLogTargets: ${{ vars.LOGSTREAM_LOG_TARGETS }}
           grafanaUrl: ${{ vars.GRAFANA_URL }}
           grafanaDashboardUrl: "/d/6vjVx-1V8/ccip-long-running-tests"
-#      - name: Run Tests
-#        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@b49a9d04744b0237908831730f8553f26d73a94b # v2.3.17
-#        env:
-#          TEST_SUITE: load
-#          TEST_ARGS: -test.timeout 900h
-#          DATABASE_URL: postgresql://postgres:node@localhost:5432/chainlink_test?sslmode=disable
-#          RR_MEM: 8Gi
-#          RR_CPU: 4
-#          TEST_TRIGGERED_BY: ccip-load-test-ci-${{ matrix.type.name }}
-#        with:
-#          test_command_to_run: cd ./integration-tests/ccip-tests && go test -v -timeout 70m -count=1 -json -run ${{ matrix.type.run }} ./load 2>&1 | tee /tmp/gotest.log | gotestloghelper -ci
-#          test_download_vendor_packages_command: cd ./integration-tests && go mod download
-#          cl_repo: ${{ env.CHAINLINK_IMAGE }}
-#          cl_image_tag: ${{ env.CHAINLINK_VERSION }}
-#          token: ${{ secrets.GITHUB_TOKEN }}
-#          go_mod_path: ./integration-tests/go.mod
-#          QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
-#          QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
-#          QA_KUBECONFIG: ${{ secrets.QA_KUBECONFIG }}
-#          triggered_by: ${{ env.TEST_TRIGGERED_BY }}
-#          publish_check_name: ${{ matrix.type.name }}
-#          artifacts_location: ./integration-tests/load/logs/payload_ccip.json
-#          aws_registries: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
-#          cache_key_id: ccip-load-${{ env.MOD_CACHE_VERSION }}
-#          cache_restore_only: "true"
-#          should_cleanup: "true"
+      - name: Run Tests
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@b49a9d04744b0237908831730f8553f26d73a94b # v2.3.17
+        env:
+          TEST_SUITE: load
+          TEST_ARGS: -test.timeout 900h
+          DATABASE_URL: postgresql://postgres:node@localhost:5432/chainlink_test?sslmode=disable
+          RR_MEM: 8Gi
+          RR_CPU: 4
+          TEST_TRIGGERED_BY: ccip-load-test-ci-${{ matrix.type.name }}
+        with:
+          test_command_to_run: cd ./integration-tests/ccip-tests && go test -v -timeout 70m -count=1 -json -run ${{ matrix.type.run }} ./load 2>&1 | tee /tmp/gotest.log | gotestloghelper -ci
+          test_download_vendor_packages_command: cd ./integration-tests && go mod download
+          cl_repo: ${{ env.CHAINLINK_IMAGE }}
+          cl_image_tag: ${{ env.CHAINLINK_VERSION }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          go_mod_path: ./integration-tests/go.mod
+          QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
+          QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
+          QA_KUBECONFIG: ${{ secrets.QA_KUBECONFIG }}
+          triggered_by: ${{ env.TEST_TRIGGERED_BY }}
+          publish_check_name: ${{ matrix.type.name }}
+          artifacts_location: ./integration-tests/load/logs/payload_ccip.json
+          aws_registries: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
+          cache_key_id: ccip-load-${{ env.MOD_CACHE_VERSION }}
+          cache_restore_only: "true"
+          should_cleanup: "true"
 
   # Reporting Jobs
   start-slack-thread:
     name: Start Slack Thread
-    if: ${{ always() && needs.ccip-load-test.result != 'skipped' && needs.ccip-load-test.result != 'cancelled' }}
+    if: ${{ failure() && needs.ccip-load-test.result != 'skipped' && needs.ccip-load-test.result != 'cancelled' }}
     environment: integration
     outputs:
       thread_ts: ${{ steps.slack.outputs.thread_ts }}
@@ -226,7 +225,7 @@ jobs:
         uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
         id: slack
         with:
-          channel-id: "#test_notif"
+          channel-id: "#ccip-testing"
           payload: |
             {
               "attachments": [
@@ -260,7 +259,7 @@ jobs:
 
   post-test-results-to-slack:
     name: Post Test Results
-    if: ${{ always() && needs.start-slack-thread.result != 'skipped' && needs.start-slack-thread.result != 'cancelled' }}
+    if: ${{ failure() && needs.start-slack-thread.result != 'skipped' && needs.start-slack-thread.result != 'cancelled' }}
     environment: integration
     permissions:
       checks: write
@@ -281,8 +280,8 @@ jobs:
           github_repository: ${{ github.repository }}
           workflow_run_id: ${{ github.run_id }}
           github_job_name_regex: ^CCIP (.*)$
-          message_title: CCIP
-          slack_channel_id: "#test_notif"
+          message_title: CCIP Jobs
+          slack_channel_id: "#ccip-testing"
           slack_bot_token: ${{ secrets.QA_SLACK_API_KEY }}
           slack_thread_ts: ${{ needs.start-slack-thread.outputs.thread_ts }}
 

--- a/.github/workflows/ccip-load-tests.yml
+++ b/.github/workflows/ccip-load-tests.yml
@@ -27,78 +27,78 @@ env:
   MOD_CACHE_VERSION: 1
 
 jobs:
-  build-chainlink:
-    environment: integration
-    permissions:
-      id-token: write
-      contents: read
-    name: Build Chainlink Image
-    runs-on: ubuntu20.04-16cores-64GB
-    steps:
-      - name: Checkout the repo
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
-      - name: Check if image exists
-        id: check-image
-        uses: smartcontractkit/chainlink-github-actions/docker/image-exists@b49a9d04744b0237908831730f8553f26d73a94b # v2.3.17
-        with:
-          repository: chainlink
-          tag: ${{ env.CHAINLINK_VERSION }}
-          AWS_REGION: ${{ secrets.QA_AWS_REGION }}
-          AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
-      - name: Build Image
-        if: steps.check-image.outputs.exists == 'false'
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/build-image@b49a9d04744b0237908831730f8553f26d73a94b # v2.3.17
-        env:
-          GH_TOKEN: ${{ github.token }}
-        with:
-          cl_repo: smartcontractkit/chainlink-ccip
-          cl_ref: ${{ env.CHAINLINK_VERSION }}
-          push_tag: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink:${{ env.CHAINLINK_VERSION }}
-          QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
-          QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
-      - name: Collect Metrics
-        if: always()
-        id: collect-gha-metrics
-        uses: smartcontractkit/push-gha-metrics-action@dea9b546553cb4ca936607c2267a09c004e4ab3f # v3.0.0
-        with:
-          id: ccip-load-test-build-chainlink-image
-          org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
-          basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
-          hostname: ${{ secrets.GRAFANA_INTERNAL_HOST }}
-          this-job-name: Build Chainlink Image
-        continue-on-error: true
-
-  build-test-image:
-    environment: integration
-    permissions:
-      id-token: write
-      contents: read
-    name: Build Test Image
-    runs-on: ubuntu20.04-16cores-64GB
-    steps:
-      - name: Collect Metrics
-        id: collect-gha-metrics
-        uses: smartcontractkit/push-gha-metrics-action@dea9b546553cb4ca936607c2267a09c004e4ab3f # v3.0.0
-        with:
-          id: ccip-load-test-build-test-image
-          org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
-          basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
-          hostname: ${{ secrets.GRAFANA_INTERNAL_HOST }}
-          this-job-name: Build Test Image
-        continue-on-error: true
-      - name: Checkout the repo
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
-      - name: Build Test Image
-        uses: ./.github/actions/build-test-image
-        with:
-          tag: ${{ env.INPUT_CHAINLINK_TEST_VERSION }}
-          QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
-          QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
-          QA_AWS_ACCOUNT_NUMBER: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
+#  build-chainlink:
+#    environment: integration
+#    permissions:
+#      id-token: write
+#      contents: read
+#    name: Build Chainlink Image
+#    runs-on: ubuntu20.04-16cores-64GB
+#    steps:
+#      - name: Checkout the repo
+#        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+#      - name: Check if image exists
+#        id: check-image
+#        uses: smartcontractkit/chainlink-github-actions/docker/image-exists@b49a9d04744b0237908831730f8553f26d73a94b # v2.3.17
+#        with:
+#          repository: chainlink
+#          tag: ${{ env.CHAINLINK_VERSION }}
+#          AWS_REGION: ${{ secrets.QA_AWS_REGION }}
+#          AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
+#      - name: Build Image
+#        if: steps.check-image.outputs.exists == 'false'
+#        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/build-image@b49a9d04744b0237908831730f8553f26d73a94b # v2.3.17
+#        env:
+#          GH_TOKEN: ${{ github.token }}
+#        with:
+#          cl_repo: smartcontractkit/chainlink-ccip
+#          cl_ref: ${{ env.CHAINLINK_VERSION }}
+#          push_tag: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink:${{ env.CHAINLINK_VERSION }}
+#          QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
+#          QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
+#      - name: Collect Metrics
+#        if: always()
+#        id: collect-gha-metrics
+#        uses: smartcontractkit/push-gha-metrics-action@dea9b546553cb4ca936607c2267a09c004e4ab3f # v3.0.0
+#        with:
+#          id: ccip-load-test-build-chainlink-image
+#          org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
+#          basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
+#          hostname: ${{ secrets.GRAFANA_INTERNAL_HOST }}
+#          this-job-name: Build Chainlink Image
+#        continue-on-error: true
+#
+#  build-test-image:
+#    environment: integration
+#    permissions:
+#      id-token: write
+#      contents: read
+#    name: Build Test Image
+#    runs-on: ubuntu20.04-16cores-64GB
+#    steps:
+#      - name: Collect Metrics
+#        id: collect-gha-metrics
+#        uses: smartcontractkit/push-gha-metrics-action@dea9b546553cb4ca936607c2267a09c004e4ab3f # v3.0.0
+#        with:
+#          id: ccip-load-test-build-test-image
+#          org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
+#          basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
+#          hostname: ${{ secrets.GRAFANA_INTERNAL_HOST }}
+#          this-job-name: Build Test Image
+#        continue-on-error: true
+#      - name: Checkout the repo
+#        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+#      - name: Build Test Image
+#        uses: ./.github/actions/build-test-image
+#        with:
+#          tag: ${{ env.INPUT_CHAINLINK_TEST_VERSION }}
+#          QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
+#          QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
+#          QA_AWS_ACCOUNT_NUMBER: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
 
   ccip-load-test:
     environment: integration
-    needs: [ build-chainlink, build-test-image ]
+#    needs: [ build-chainlink, build-test-image ]
     if: ${{ always() && !contains(needs.*.result, 'failure') }}
     permissions:
       issues: read
@@ -178,32 +178,32 @@ jobs:
           logstreamLogTargets: ${{ vars.LOGSTREAM_LOG_TARGETS }}
           grafanaUrl: ${{ vars.GRAFANA_URL }}
           grafanaDashboardUrl: "/d/6vjVx-1V8/ccip-long-running-tests"
-      - name: Run Tests
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@b49a9d04744b0237908831730f8553f26d73a94b # v2.3.17
-        env:
-          TEST_SUITE: load
-          TEST_ARGS: -test.timeout 900h
-          DATABASE_URL: postgresql://postgres:node@localhost:5432/chainlink_test?sslmode=disable
-          RR_MEM: 8Gi
-          RR_CPU: 4
-          TEST_TRIGGERED_BY: ccip-load-test-ci-${{ matrix.type.name }}
-        with:
-          test_command_to_run: cd ./integration-tests/ccip-tests && go test -v -timeout 70m -count=1 -json -run ${{ matrix.type.run }} ./load 2>&1 | tee /tmp/gotest.log | gotestloghelper -ci
-          test_download_vendor_packages_command: cd ./integration-tests && go mod download
-          cl_repo: ${{ env.CHAINLINK_IMAGE }}
-          cl_image_tag: ${{ env.CHAINLINK_VERSION }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          go_mod_path: ./integration-tests/go.mod
-          QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
-          QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
-          QA_KUBECONFIG: ${{ secrets.QA_KUBECONFIG }}
-          triggered_by: ${{ env.TEST_TRIGGERED_BY }}
-          publish_check_name: ${{ matrix.type.name }}
-          artifacts_location: ./integration-tests/load/logs/payload_ccip.json
-          aws_registries: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
-          cache_key_id: ccip-load-${{ env.MOD_CACHE_VERSION }}
-          cache_restore_only: "true"
-          should_cleanup: "true"
+#      - name: Run Tests
+#        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@b49a9d04744b0237908831730f8553f26d73a94b # v2.3.17
+#        env:
+#          TEST_SUITE: load
+#          TEST_ARGS: -test.timeout 900h
+#          DATABASE_URL: postgresql://postgres:node@localhost:5432/chainlink_test?sslmode=disable
+#          RR_MEM: 8Gi
+#          RR_CPU: 4
+#          TEST_TRIGGERED_BY: ccip-load-test-ci-${{ matrix.type.name }}
+#        with:
+#          test_command_to_run: cd ./integration-tests/ccip-tests && go test -v -timeout 70m -count=1 -json -run ${{ matrix.type.run }} ./load 2>&1 | tee /tmp/gotest.log | gotestloghelper -ci
+#          test_download_vendor_packages_command: cd ./integration-tests && go mod download
+#          cl_repo: ${{ env.CHAINLINK_IMAGE }}
+#          cl_image_tag: ${{ env.CHAINLINK_VERSION }}
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#          go_mod_path: ./integration-tests/go.mod
+#          QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
+#          QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
+#          QA_KUBECONFIG: ${{ secrets.QA_KUBECONFIG }}
+#          triggered_by: ${{ env.TEST_TRIGGERED_BY }}
+#          publish_check_name: ${{ matrix.type.name }}
+#          artifacts_location: ./integration-tests/load/logs/payload_ccip.json
+#          aws_registries: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
+#          cache_key_id: ccip-load-${{ env.MOD_CACHE_VERSION }}
+#          cache_restore_only: "true"
+#          should_cleanup: "true"
 
   # Reporting Jobs
   start-slack-thread:


### PR DESCRIPTION
## Motivation
Post test result to slack job panics while parsing the github job name.
https://github.com/smartcontractkit/ccip/actions/runs/9670389604/job/26679921641

## Solution
Fix the regex per [golang/re2](https://github.com/google/re2/wiki/Syntax) syntax and remove the matrix which is not needed as we have only one thing to deal.

Sample successful run: https://github.com/smartcontractkit/ccip/actions/runs/9683107526/job/26717788969