### PR TITLE
Fixes Erroneous Approval Error

### DIFF
--- a/integration-tests/ccip-tests/actions/ccip_helpers.go
+++ b/integration-tests/ccip-tests/actions/ccip_helpers.go
@@ -402,7 +402,8 @@ func (ccipModule *CCIPCommon) ApproveTokens() error {
 			return fmt.Errorf("failed to get allowance for token %s: %w", token.ContractAddress.Hex(), err)
 		}
 		if allowance.Cmp(ApprovedAmountToRouter) < 0 {
-			err := token.Approve(ccipModule.ChainClient.GetDefaultWallet(), ccipModule.Router.Address(), ApprovedAmountToRouter)
+			allowanceApprovalDelta := new(big.Int).Sub(ApprovedAmountToRouter, allowance)
+			err := token.Approve(ccipModule.ChainClient.GetDefaultWallet(), ccipModule.Router.Address(), allowanceApprovalDelta)
 			if err != nil {
 				return fmt.Errorf("failed to approve token %s: %w", token.ContractAddress.Hex(), err)
 			}

--- a/integration-tests/ccip-tests/contracts/contract_models.go
+++ b/integration-tests/ccip-tests/contracts/contract_models.go
@@ -271,16 +271,6 @@ func (token *ERC20Token) Approve(onBehalf *blockchain.EthereumWallet, spender st
 	if err != nil {
 		return fmt.Errorf("failed to get balance of onBehalf: %w", err)
 	}
-	if onBehalfBalance.Cmp(amount) < 0 {
-		token.logger.Warn().
-			Str("Token", token.Address()).
-			Str("On Behalf", onBehalf.Address()).
-			Uint64("On Behalf's Balance", onBehalfBalance.Uint64()).
-			Uint64("Approve Amount", amount.Uint64()).
-			Str("Spender", spender).
-			Msg("Approving ERC20 transfer for more than balance")
-		return fmt.Errorf("onBehalf '%s' does not have enough balance to approve", onBehalf.Address())
-	}
 	currentAllowance, err := token.Allowance(onBehalf.Address(), spender)
 	if err != nil {
 		return fmt.Errorf("failed to get current allowance for '%s' on behalf of '%s': %w", spender, onBehalf.Address(), err)

--- a/integration-tests/ccip-tests/contracts/contract_models.go
+++ b/integration-tests/ccip-tests/contracts/contract_models.go
@@ -272,6 +272,13 @@ func (token *ERC20Token) Approve(onBehalf *blockchain.EthereumWallet, spender st
 		return fmt.Errorf("failed to get balance of onBehalf: %w", err)
 	}
 	if onBehalfBalance.Cmp(amount) < 0 {
+		token.logger.Warn().
+			Str("Token", token.Address()).
+			Str("On Behalf", onBehalf.Address()).
+			Uint64("On Behalf's Balance", onBehalfBalance.Uint64()).
+			Uint64("Approve Amount", amount.Uint64()).
+			Str("Spender", spender).
+			Msg("Approving ERC20 transfer for more than balance")
 		return fmt.Errorf("onBehalf '%s' does not have enough balance to approve", onBehalf.Address())
 	}
 	currentAllowance, err := token.Allowance(onBehalf.Address(), spender)


### PR DESCRIPTION
## Motivation

We were erroneously blocking you from calling `approve()` with too low of a balance. This doesn't reflect how things work on chain.

## Solution

Remove that check