### PR TITLE
Fix slice bounds out of range error in performBatchCall

### DIFF
--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/evm.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/evm.go
@@ -144,7 +144,6 @@ func (d *DynamicPriceGetter) performBatchCall(ctx context.Context, chainID uint6
 	calls = append(calls, batchCalls.latestRoundDataCalls...)
 
 	results, err := evmCaller.BatchCall(ctx, 0, calls)
-
 	if err != nil {
 		return fmt.Errorf("batch call on chain %d failed: %w", chainID, err)
 	}

--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/evm.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/evm.go
@@ -145,6 +145,10 @@ func (d *DynamicPriceGetter) performBatchCall(ctx context.Context, chainID uint6
 
 	results, err := evmCaller.BatchCall(ctx, 0, calls)
 
+	if err != nil {
+		return fmt.Errorf("batch call on chain %d failed: %w", chainID, err)
+	}
+
 	// Extract results.
 	decimals := make([]uint8, 0, nbDecimalCalls)
 	latestRounds := make([]*big.Int, 0, nbLatestRoundDataCalls)


### PR DESCRIPTION
Catching `err` if the evm call fails