### PR TITLE
Returning messageVisibilityInterval always from commit roots cache  (…

### DIFF
--- a/core/services/ocr2/plugins/ccip/internal/cache/commit_roots.go
+++ b/core/services/ocr2/plugins/ccip/internal/cache/commit_roots.go
@@ -131,38 +131,41 @@ func (s *commitRootsCache) Snooze(merkleRoot [32]byte) {
 }
 
 func (s *commitRootsCache) OldestRootTimestamp() time.Time {
-	permissionlessExecWindow := time.Now().Add(-s.permissionLessExecutionThresholdDuration)
-	timestamp, ok := s.pickOldestRootBlockTimestamp(permissionlessExecWindow)
-
-	if ok {
-		return timestamp
-	}
-
-	s.rootsQueueMu.Lock()
-	defer s.rootsQueueMu.Unlock()
-
-	// If rootsSearchFilter is before permissionlessExecWindow, it means that we have roots that are stuck forever and will never be executed
-	// In that case, we wipe out the entire queue. Next round should start from the permissionlessExecThreshold and rebuild cache from scratch.
-	s.unexecutedRootsQueue = orderedmap.New[string, time.Time]()
-	return permissionlessExecWindow
+	return time.Now().Add(-s.permissionLessExecutionThresholdDuration)
+	// TODO we can't rely on block timestamps, because in case of re-org they can change and therefore affect
+	// the logic in the case. In the meantime, always fallback to the default behaviour and use permissionlessThresholdWindow
+	//timestamp, ok := s.pickOldestRootBlockTimestamp(messageVisibilityInterval)
+	//
+	//if ok {
+	//	return timestamp
+	//}
+	//
+	//s.rootsQueueMu.Lock()
+	//defer s.rootsQueueMu.Unlock()
+	//
+	//// If rootsSearchFilter is before messageVisibilityInterval, it means that we have roots that are stuck forever and will never be executed
+	//// In that case, we wipe out the entire queue. Next round should start from the messageVisibilityInterval and rebuild cache from scratch.
+	//s.unexecutedRootsQueue = orderedmap.New[string, time.Time]()
+	//return messageVisibilityInterval
 }
 
-func (s *commitRootsCache) pickOldestRootBlockTimestamp(permissionlessExecWindow time.Time) (time.Time, bool) {
-	s.rootsQueueMu.RLock()
-	defer s.rootsQueueMu.RUnlock()
+//func (s *commitRootsCache) pickOldestRootBlockTimestamp(permissionlessExecWindow time.Time) (time.Time, bool) {
+//	s.rootsQueueMu.RLock()
+//	defer s.rootsQueueMu.RUnlock()
+//
+//	// If there are no roots in the queue, we can return the permissionlessExecWindow
+//	if s.oldestRootTimestamp.IsZero() {
+//		return permissionlessExecWindow, true
+//	}
+//
+//	if s.oldestRootTimestamp.After(messageVisibilityInterval) {
+//		// Query used for fetching roots from the database is exclusive (block_timestamp > :timestamp)
+//		// so we need to subtract 1 second from the head timestamp to make sure that this root is included in the results
+//		return s.oldestRootTimestamp.Add(-time.Second), true
+//	}
+//	return time.Time{}, false
+//}
 
-	// If there are no roots in the queue, we can return the permissionlessExecWindow
-	if s.oldestRootTimestamp.IsZero() {
-		return permissionlessExecWindow, true
-	}
-
-	if s.oldestRootTimestamp.After(permissionlessExecWindow) {
-		// Query used for fetching roots from the database is exclusive (block_timestamp > :timestamp)
-		// so we need to subtract 1 second from the head timestamp to make sure that this root is included in the results
-		return s.oldestRootTimestamp.Add(-time.Second), true
-	}
-	return time.Time{}, false
-}
 func (s *commitRootsCache) AppendUnexecutedRoot(merkleRoot [32]byte, blockTimestamp time.Time) {
 	prettyMerkleRoot := merkleRootToString(merkleRoot)
 


### PR DESCRIPTION
…#1155)

Commit's Roots cache stores block_timestamps for the CommitReports, but when reorgs happens block_timestamp can also change because TX could be included in a different block.

Example scenario:

CommitRoot with 10:30:00 UTC block timestamp is inserted with `AppendUnexecutedRoot` (so it's block_timestamp is persisted in the cache). Then reorg happens on the destination and the same CommitRoot is inserted into the blockchain but let's say with 10:29:00 UTC (different block_time), which is never updated. Commit Roots cache returns persisted 10:30:00 as the oldest block timestamp and we keep searching LogPoller using the wrong lower bound filter - this Commit Root never pops up in the execution because it's never returned from DB

## Motivation


## Solution
