### PR TITLE
Update stale action to close PRs more aggressively.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,8 +1,5 @@
-# Workflow is triggered daily midnight UTC
-# A PR with more than 60 days of inactivity will be marked as stale
-# A PR that's stale for more than 7 days will be automatically closed
-# Issues are exempt from auto marking as stale but issues with manually added 'stale' label are eligible for auto closure after 7 days.
-# PRs with assignees are exempt from auto stale marking, it's the responsibility of the assignee to get the PR progressed either with review/merge or closure.
+# Workflow to manage automatically closing stale pull requests and issues.
+# See configuration for configuration.
 name: Manage stale Issues and PRs
 
 on:
@@ -21,6 +18,8 @@ jobs:
     - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        exempt-all-pr-assignees: true
-        stale-pr-message: 'This PR is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
         days-before-issue-stale: -1 # disables marking issues as stale automatically. Issues can still be marked as stale manually, in which the closure policy applies.
+        stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+        close-pr-message: 'This PR was closed because it has been stalled for 10 days with no activity.'
+        days-before-pr-stale: 45
+        days-before-pr-close: 10


### PR DESCRIPTION
## Motivation

Clean up old pull requests without human intervention. Closing a pull request shouldn't be seen as a bad thing, it can always be re-opened at a later date if the work becomes relevant again.

## Solution

Update the stale action to be more aggressive for pull requests. They will be marked as stale when there is no activity for 45 days and closed 10 days after being marked stale.