### PR TITLE
ocr2/plugins/ccip/internal/pricegetter: format correct error

### DIFF
--- a/core/services/ocr2/plugins/ccip/internal/pricegetter/evm.go
+++ b/core/services/ocr2/plugins/ccip/internal/pricegetter/evm.go
@@ -156,7 +156,7 @@ func (d *DynamicPriceGetter) performBatchCall(ctx context.Context, chainID uint6
 		v, err1 := rpclib.ParseOutput[uint8](res, 0)
 		if err1 != nil {
 			callSignature := batchCalls.decimalCalls[i].String()
-			return fmt.Errorf("parse contract output while calling %v on chain %d: %w", callSignature, chainID, err)
+			return fmt.Errorf("parse contract output while calling %v on chain %d: %w", callSignature, chainID, err1)
 		}
 		decimals = append(decimals, v)
 	}
@@ -167,7 +167,7 @@ func (d *DynamicPriceGetter) performBatchCall(ctx context.Context, chainID uint6
 		v, err1 := rpclib.ParseOutput[*big.Int](res, 1)
 		if err1 != nil {
 			callSignature := batchCalls.latestRoundDataCalls[i].String()
-			return fmt.Errorf("parse contract output while calling %v on chain %d: %w", callSignature, chainID, err)
+			return fmt.Errorf("parse contract output while calling %v on chain %d: %w", callSignature, chainID, err1)
 		}
 		latestRounds = append(latestRounds, v)
 	}


### PR DESCRIPTION
## Motivation

We are formatting the wrong error in `fmt.Errorf`. This was actually the root cause of `errcheck` not correctly flagging `err` as unchecked prior to PR https://github.com/smartcontractkit/ccip/pull/1145/

## Solution

Format the correct error.