### PR TITLE
Commit NewReportingPlugin retries on error (#1160)

### DIFF
--- a/.changeset/red-balloons-repeat.md
+++ b/.changeset/red-balloons-repeat.md
@@ -1,0 +1,5 @@
+---
+"ccip": patch
+---
+
+Commit NewReportingPlugin retries on error

--- a/core/services/ocr2/plugins/ccip/ccipcommit/factory_test.go
+++ b/core/services/ocr2/plugins/ccip/ccipcommit/factory_test.go
@@ -1,0 +1,100 @@
+package ccipcommit
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/types/ccip"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipdata"
+	ccipdataprovidermocks "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipdata/ccipdataprovider/mocks"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipdata/mocks"
+	dbMocks "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/ccipdb/mocks"
+)
+
+// Assert that NewReportingPlugin keeps retrying until it succeeds.
+//
+// NewReportingPlugin makes several calls (e.g. CommitStoreReader.ChangeConfig) that can fail. We use mocks to cause the
+// first call to each of these functions to fail, then all subsequent calls succeed. We assert that NewReportingPlugin
+// retries a sufficient number of times to get through the transient errors and eventually succeed.
+func TestNewReportingPluginRetriesUntilSuccess(t *testing.T) {
+	commitConfig := CommitPluginStaticConfig{}
+
+	// For this unit test, ensure that there is no delay between retries
+	commitConfig.newReportingPluginRetryConfig = ccipdata.RetryConfig{
+		InitialDelay: 0 * time.Nanosecond,
+		MaxDelay:     0 * time.Nanosecond,
+	}
+
+	// Set up the OffRampReader mock
+	mockCommitStore := new(mocks.CommitStoreReader)
+
+	// The first call is set to return an error, the following calls return a nil error
+	mockCommitStore.
+		On("ChangeConfig", mock.Anything, mock.Anything, mock.Anything).
+		Return(ccip.Address(""), errors.New("")).
+		Once()
+	mockCommitStore.
+		On("ChangeConfig", mock.Anything, mock.Anything, mock.Anything).
+		Return(ccip.Address("0x7c6e4F0BDe29f83BC394B75a7f313B7E5DbD2d77"), nil).
+		Times(5)
+
+	mockCommitStore.
+		On("OffchainConfig", mock.Anything).
+		Return(ccip.CommitOffchainConfig{}, errors.New("")).
+		Once()
+	mockCommitStore.
+		On("OffchainConfig", mock.Anything).
+		Return(ccip.CommitOffchainConfig{}, nil).
+		Times(3)
+
+	mockCommitStore.
+		On("GasPriceEstimator", mock.Anything).
+		Return(nil, errors.New("")).
+		Once()
+	mockCommitStore.
+		On("GasPriceEstimator", mock.Anything).
+		Return(nil, nil).
+		Times(2)
+
+	commitConfig.commitStore = mockCommitStore
+
+	mockPriceService := new(dbMocks.PriceService)
+
+	mockPriceService.
+		On("UpdateDynamicConfig", mock.Anything, mock.Anything, mock.Anything).
+		Return(errors.New("")).
+		Once()
+	mockPriceService.
+		On("UpdateDynamicConfig", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil)
+
+	commitConfig.priceService = mockPriceService
+
+	priceRegistryProvider := new(ccipdataprovidermocks.PriceRegistry)
+	priceRegistryProvider.
+		On("NewPriceRegistryReader", mock.Anything, mock.Anything).
+		Return(nil, errors.New("")).
+		Once()
+	priceRegistryProvider.
+		On("NewPriceRegistryReader", mock.Anything, mock.Anything).
+		Return(nil, nil).
+		Once()
+	commitConfig.priceRegistryProvider = priceRegistryProvider
+
+	commitConfig.lggr, _ = logger.NewLogger()
+
+	factory := NewCommitReportingPluginFactory(commitConfig)
+	reportingConfig := types.ReportingPluginConfig{}
+	reportingConfig.OnchainConfig = []byte{1, 2, 3}
+	reportingConfig.OffchainConfig = []byte{1, 2, 3}
+
+	// Assert that NewReportingPlugin succeeds despite many transient internal failures (mocked out above)
+	_, _, err := factory.NewReportingPlugin(reportingConfig)
+	assert.Equal(t, nil, err)
+}

--- a/core/services/ocr2/plugins/ccip/ccipcommit/initializers.go
+++ b/core/services/ocr2/plugins/ccip/ccipcommit/initializers.go
@@ -6,19 +6,19 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
+	"time"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
-	chainselectors "github.com/smartcontractkit/chain-selectors"
-	libocr2 "github.com/smartcontractkit/libocr/offchainreporting2plus"
 	"go.uber.org/multierr"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
+	chainselectors "github.com/smartcontractkit/chain-selectors"
+	libocr2 "github.com/smartcontractkit/libocr/offchainreporting2plus"
 
 	commonlogger "github.com/smartcontractkit/chainlink-common/pkg/logger"
-
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccip"
 
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/ccip/generated/commit_store"
@@ -45,6 +45,8 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/promwrapper"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pipeline"
 )
+
+var defaultNewReportingPluginRetryConfig = ccipdata.RetryConfig{InitialDelay: time.Second, MaxDelay: 5 * time.Minute}
 
 func NewCommitServices(ctx context.Context, ds sqlutil.DataSource, lggr logger.Logger, jb job.Job, chainSet legacyevm.LegacyChainContainer, new bool, pr pipeline.Runner, argsNoPlugin libocr2.OCR2OracleArgs, logError func(string)) ([]job.ServiceCtx, error) {
 	orm, err := cciporm.NewORM(ds)
@@ -271,8 +273,8 @@ func jobSpecToCommitPluginConfig(ctx context.Context, orm cciporm.ORM, lggr logg
 		"sourceNative", sourceNative,
 		"sourceRouter", sourceRouter.Address())
 	return &CommitPluginStaticConfig{
-			lggr:                  commitLggr,
-			onRampReader:          onRampReader,
+			lggr:                          commitLggr,
+			newReportingPluginRetryConfig: defaultNewReportingPluginRetryConfig, onRampReader: onRampReader,
 			offRamp:               offRampReader,
 			sourceNative:          ccipcalc.EvmAddrToGeneric(sourceNative),
 			sourceChainSelector:   params.commitStoreStaticCfg.SourceChainSelector,

--- a/core/services/ocr2/plugins/ccip/ccipcommit/ocr2.go
+++ b/core/services/ocr2/plugins/ccip/ccipcommit/ocr2.go
@@ -50,7 +50,8 @@ type update struct {
 }
 
 type CommitPluginStaticConfig struct {
-	lggr logger.Logger
+	lggr                          logger.Logger
+	newReportingPluginRetryConfig ccipdata.RetryConfig
 	// Source
 	onRampReader        ccipdata.OnRampReader
 	sourceChainSelector uint64


### PR DESCRIPTION
Previously, if there was an error when starting the Commit Pluging (i.e. calling NewReportingPlugin), the Commit Plugin would remain in a non-started state. Now, NewReportingPlugin will retry until the Commit Plugin successfully starts.

## Motivation


## Solution
