### PR TITLE
aggregate token and gas price heartbeat updates into batches

### DIFF
--- a/core/services/ocr2/plugins/ccip/ccipcommit/ocr2.go
+++ b/core/services/ocr2/plugins/ccip/ccipcommit/ocr2.go
@@ -548,7 +548,6 @@ func (r *CommitReportingPlugin) calculatePriceUpdates(gasPriceObs map[uint64][]*
 				})
 			}
 		}
-
 	}
 
 	sort.Slice(gasPriceUpdate, func(i, j int) bool {

--- a/core/services/ocr2/plugins/ccip/ccipcommit/ocr2.go
+++ b/core/services/ocr2/plugins/ccip/ccipcommit/ocr2.go
@@ -461,24 +461,42 @@ func (r *CommitReportingPlugin) selectPriceUpdates(ctx context.Context, now time
 // The returned latestGasPrice and latestTokenPrices should not contain nil values.
 func (r *CommitReportingPlugin) calculatePriceUpdates(gasPriceObs map[uint64][]*big.Int, tokenPriceObs map[cciptypes.Address][]*big.Int, latestGasPrice map[uint64]update, latestTokenPrices map[cciptypes.Address]update) ([]cciptypes.GasPrice, []cciptypes.TokenPrice, error) {
 	var tokenPriceUpdates []cciptypes.TokenPrice
+	// Token prices are mostly heartbeat driven. To maximize heartbeat batching, the price inclusion rule is as follows:
+	// If any token requires heartbeat update, include all token prices in the report.
+	// Otherwise, only include token prices that exceed deviation threshold.
+	needTokenHeartbeat := false
+	for token := range tokenPriceObs {
+		latestTokenPrice, exists := latestTokenPrices[token]
+		if !exists || time.Since(latestTokenPrice.timestamp) >= r.offchainConfig.TokenPriceHeartBeat {
+			r.lggr.Infow("Token requires heartbeat update", "token", token)
+			needTokenHeartbeat = true
+			break
+		}
+	}
+
 	for token, tokenPriceObservations := range tokenPriceObs {
 		medianPrice := ccipcalc.BigIntSortedMiddle(tokenPriceObservations)
 
-		latestTokenPrice, exists := latestTokenPrices[token]
-		if exists {
-			tokenPriceUpdatedRecently := time.Since(latestTokenPrice.timestamp) < r.offchainConfig.TokenPriceHeartBeat
-			tokenPriceNotChanged := !ccipcalc.Deviates(medianPrice, latestTokenPrice.value, int64(r.offchainConfig.TokenPriceDeviationPPB))
-			if tokenPriceUpdatedRecently && tokenPriceNotChanged {
-				r.lggr.Debugw("token price was updated recently, skipping the update",
-					"token", token, "newPrice", medianPrice, "existingPrice", latestTokenPrice.value)
-				continue // skip the update if we recently had a price update close to the new value
-			}
+		if needTokenHeartbeat {
+			r.lggr.Debugw("Token price update included due to heartbeat", "token", token, "newPrice", medianPrice)
+			tokenPriceUpdates = append(tokenPriceUpdates, cciptypes.TokenPrice{
+				Token: token,
+				Value: medianPrice,
+			})
+			continue
 		}
 
-		tokenPriceUpdates = append(tokenPriceUpdates, cciptypes.TokenPrice{
-			Token: token,
-			Value: medianPrice,
-		})
+		latestTokenPrice, exists := latestTokenPrices[token]
+		if exists {
+			if ccipcalc.Deviates(medianPrice, latestTokenPrice.value, int64(r.offchainConfig.TokenPriceDeviationPPB)) {
+				r.lggr.Debugw("Token price update included due to deviation",
+					"token", token, "newPrice", medianPrice, "existingPrice", latestTokenPrice.value)
+				tokenPriceUpdates = append(tokenPriceUpdates, cciptypes.TokenPrice{
+					Token: token,
+					Value: medianPrice,
+				})
+			}
+		}
 	}
 
 	// Determinism required.
@@ -487,31 +505,50 @@ func (r *CommitReportingPlugin) calculatePriceUpdates(gasPriceObs map[uint64][]*
 	})
 
 	var gasPriceUpdate []cciptypes.GasPrice
+	// Gas prices are mostly heartbeat driven. To maximize heartbeat batching, the price inclusion rule is as follows:
+	// If any source chain gas price requires heartbeat update, include all gas prices in the report.
+	// Otherwise, only include gas prices that exceed deviation threshold.
+	needGasHeartbeat := false
+	for chainSelector := range gasPriceObs {
+		latestGasPrice, exists := latestGasPrice[chainSelector]
+		if !exists || latestGasPrice.value == nil || time.Since(latestGasPrice.timestamp) >= r.offchainConfig.GasPriceHeartBeat {
+			r.lggr.Infow("Chain gas price requires heartbeat update", "chainSelector", chainSelector)
+			needGasHeartbeat = true
+			break
+		}
+	}
+
 	for chainSelector, gasPriceObservations := range gasPriceObs {
 		newGasPrice, err := r.gasPriceEstimator.Median(gasPriceObservations) // Compute the median price
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to calculate median gas price for chain selector %d: %w", chainSelector, err)
 		}
 
-		// Default to updating so that we update if there are no prior updates.
+		if needGasHeartbeat {
+			r.lggr.Debugw("Gas price update included due to heartbeat", "chainSelector", chainSelector)
+			gasPriceUpdate = append(gasPriceUpdate, cciptypes.GasPrice{
+				DestChainSelector: chainSelector,
+				Value:             newGasPrice,
+			})
+			continue
+		}
+
 		latestGasPrice, exists := latestGasPrice[chainSelector]
 		if exists && latestGasPrice.value != nil {
-			gasPriceUpdatedRecently := time.Since(latestGasPrice.timestamp) < r.offchainConfig.GasPriceHeartBeat
 			gasPriceDeviated, err := r.gasPriceEstimator.Deviates(newGasPrice, latestGasPrice.value)
 			if err != nil {
 				return nil, nil, err
 			}
-			if gasPriceUpdatedRecently && !gasPriceDeviated {
-				r.lggr.Debugw("gas price was updated recently and not deviated sufficiently, skipping the update",
+			if gasPriceDeviated {
+				r.lggr.Debugw("Gas price update included due to deviation",
 					"chainSelector", chainSelector, "newPrice", newGasPrice, "existingPrice", latestGasPrice.value)
-				continue
+				gasPriceUpdate = append(gasPriceUpdate, cciptypes.GasPrice{
+					DestChainSelector: chainSelector,
+					Value:             newGasPrice,
+				})
 			}
 		}
 
-		gasPriceUpdate = append(gasPriceUpdate, cciptypes.GasPrice{
-			DestChainSelector: chainSelector,
-			Value:             newGasPrice,
-		})
 	}
 
 	sort.Slice(gasPriceUpdate, func(i, j int) bool {


### PR DESCRIPTION
## Motivation
Price reporting frequencies have been turned to following values on Eth mainnet (where most price update costs is)
```
GasHeartBeat: 2hr
ExecGasPriceDeviation: 400%
DAPriceDeviation: 400%
TokenPriceHeartBeat: 12hr
TokenPriceDeviation: 20%
```

As a result, updates are mostly heartbeat driven as opposed to deviation driven. A simple trick to improve leader-lane batching is to always batch report all heartbeat prices.

In clam environments where prices are heartbeat driven, this absolutely minimizes number of price reports.

In flux environments where good number of prices are deviation driven while some remain heartbeat driven, e.g. in case of Eth blob base fee spike, the penalty we take for including each additional prices is low (~6k gas) v.s the OCR tx overhead (~110k gas)

