### PR TITLE
Cherry pick handle errors for gnosis and arbitrum

### DIFF
--- a/.changeset/calm-badgers-jump.md
+++ b/.changeset/calm-badgers-jump.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+add error handling when arbitrum sequencer is not accessible #added

--- a/.changeset/chilly-cars-attend.md
+++ b/.changeset/chilly-cars-attend.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+add error handle for gnosis chiado for seen tx #added

--- a/core/chains/evm/client/errors.go
+++ b/core/chains/evm/client/errors.go
@@ -250,6 +250,19 @@ var zkEvm = ClientErrors{
 	TerminallyStuck: regexp.MustCompile(`(?:: |^)not enough .* counters to continue the execution$`),
 }
 
+var aStar = ClientErrors{
+	TerminallyUnderpriced: regexp.MustCompile(`(?:: |^)(gas price less than block base fee)$`),
+}
+
+var mantle = ClientErrors{
+	InsufficientEth: regexp.MustCompile(`(: |^)'*insufficient funds for gas \* price \+ value`),
+	Fatal:           regexp.MustCompile(`(: |^)'*invalid sender`),
+}
+
+var gnosis = ClientErrors{
+	TransactionAlreadyInMempool: regexp.MustCompile(`(: |^)(alreadyknown)`),
+}
+
 const TerminallyStuckMsg = "transaction terminally stuck"
 
 // Tx.Error messages that are set internally so they are not chain or client specific
@@ -257,7 +270,7 @@ var internal = ClientErrors{
 	TerminallyStuck: regexp.MustCompile(TerminallyStuckMsg),
 }
 
-var clients = []ClientErrors{parity, geth, arbitrum, metis, substrate, avalanche, nethermind, harmony, besu, erigon, klaytn, celo, zkSync, zkEvm, internal}
+var clients = []ClientErrors{parity, geth, arbitrum, metis, substrate, avalanche, nethermind, harmony, besu, erigon, klaytn, celo, zkSync, zkEvm, mantle, aStar, gnosis, internal}
 
 // ClientErrorRegexes returns a map of compiled regexes for each error type
 func ClientErrorRegexes(errsRegex config.ClientErrors) *ClientErrors {

--- a/core/chains/evm/client/errors.go
+++ b/core/chains/evm/client/errors.go
@@ -158,7 +158,7 @@ var arbitrum = ClientErrors{
 	Fatal:                 arbitrumFatal,
 	L2FeeTooLow:           regexp.MustCompile(`(: |^)max fee per gas less than block base fee(:|$)`),
 	L2Full:                regexp.MustCompile(`(: |^)(queue full|sequencer pending tx pool full, please try again)(:|$)`),
-	ServiceUnavailable:    regexp.MustCompile(`(: |^)502 Bad Gateway: [\s\S]*$`),
+	ServiceUnavailable:    regexp.MustCompile(`(: |^)502 Bad Gateway: [\s\S]*$|network is unreachable|i/o timeout`),
 }
 
 var celo = ClientErrors{

--- a/core/chains/evm/client/errors_test.go
+++ b/core/chains/evm/client/errors_test.go
@@ -227,6 +227,8 @@ func Test_Eth_Errors(t *testing.T) {
 		tests := []errorCase{
 			{"call failed: 503 Service Unavailable: <html>\r\n<head><title>503 Service Temporarily Unavailable</title></head>\r\n<body>\r\n<center><h1>503 Service Temporarily Unavailable</h1></center>\r\n</body>\r\n</html>\r\n", true, "Nethermind"},
 			{"call failed: 502 Bad Gateway: <html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n<hr><center>", true, "Arbitrum"},
+			{"i/o timeout", true, "Arbitrum"},
+			{"network is unreachable", true, "Arbitrum"},
 			{"client error service unavailable", true, "tomlConfig"},
 		}
 		for _, test := range tests {

--- a/core/chains/evm/client/errors_test.go
+++ b/core/chains/evm/client/errors_test.go
@@ -136,6 +136,7 @@ func Test_Eth_Errors(t *testing.T) {
 			// This seems to be an erroneous message from the zkSync client, we'll have to match it anyway
 			{"ErrorObject { code: ServerError(3), message: \\\"known transaction. transaction with hash 0xf016…ad63 is already in the system\\\", data: Some(RawValue(\\\"0x\\\")) }", true, "zkSync"},
 			{"client error transaction already in mempool", true, "tomlConfig"},
+			{"alreadyknown", true, "Gnosis"},
 		}
 		for _, test := range tests {
 			err = evmclient.NewSendErrorS(test.message)


### PR DESCRIPTION
Cherry-Pick: classify arbitrum sequencer inaccessible error as retryable ([#14100](https://github.com/smartcontractkit/chainlink/pull/14100))
Cherry-Pick: fix unhandled already seen tx error for gnosis chiado ([#14099](https://github.com/smartcontractkit/chainlink/pull/14099))

Requires:
“alreadyknown” is properly classified
Errors are classified to be Retryable