### PR TITLE
Stronger address book typing

### DIFF
--- a/integration-tests/deployment/address_book.go
+++ b/integration-tests/deployment/address_book.go
@@ -15,6 +15,7 @@ type ContractType string
 var (
 	Version1_0_0     = *semver.MustParse("1.0.0")
 	Version1_1_0     = *semver.MustParse("1.1.0")
+	Version1_2_0     = *semver.MustParse("1.2.0")
 	Version1_5_0     = *semver.MustParse("1.5.0")
 	Version1_6_0_dev = *semver.MustParse("1.6.0-dev")
 )

--- a/integration-tests/deployment/address_book.go
+++ b/integration-tests/deployment/address_book.go
@@ -1,25 +1,105 @@
 package deployment
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/ethereum/go-ethereum/common"
+	chainsel "github.com/smartcontractkit/chain-selectors"
+)
+
+// ContractType is a simple string type for identifying contract types.
+type ContractType string
+
+var (
+	Version1_0_0     = *semver.MustParse("1.0.0")
+	Version1_1_0     = *semver.MustParse("1.1.0")
+	Version1_5_0     = *semver.MustParse("1.5.0")
+	Version1_6_0_dev = *semver.MustParse("1.6.0-dev")
+)
+
+type TypeAndVersion struct {
+	Type    ContractType
+	Version semver.Version
+}
+
+func (tv TypeAndVersion) String() string {
+	return fmt.Sprintf("%s %s", tv.Type, tv.Version.String())
+}
+
+func (tv TypeAndVersion) Equal(other TypeAndVersion) bool {
+	return tv.String() == other.String()
+}
+
+func MustTypeAndVersionFromString(s string) TypeAndVersion {
+	tv, err := TypeAndVersionFromString(s)
+	if err != nil {
+		panic(err)
+	}
+	return tv
+}
+
+// Note this will become useful for validation. When we want
+// to assert an onchain call to typeAndVersion yields whats expected.
+func TypeAndVersionFromString(s string) (TypeAndVersion, error) {
+	parts := strings.Split(s, " ")
+	if len(parts) != 2 {
+		return TypeAndVersion{}, fmt.Errorf("invalid type and version string: %s", s)
+	}
+	v, err := semver.NewVersion(parts[1])
+	if err != nil {
+		return TypeAndVersion{}, err
+	}
+	return TypeAndVersion{
+		Type:    ContractType(parts[0]),
+		Version: *v,
+	}, nil
+}
+
+func NewTypeAndVersion(t ContractType, v semver.Version) TypeAndVersion {
+	return TypeAndVersion{
+		Type:    t,
+		Version: v,
+	}
+}
 
 // AddressBook is a simple interface for storing and retrieving contract addresses across
-// chains. It is family agnostic.
+// chains. It is family agnostic as the keys are chain selectors.
+// We store rather than derive typeAndVersion as some contracts do not support it.
+// For ethereum addresses are always stored in EIP55 format.
 type AddressBook interface {
-	Save(chainSelector uint64, address string, typeAndVersion string) error
-	Addresses() (map[uint64]map[string]string, error)
-	AddressesForChain(chain uint64) (map[string]string, error)
+	Save(chainSelector uint64, address string, tv TypeAndVersion) error
+	Addresses() (map[uint64]map[string]TypeAndVersion, error)
+	AddressesForChain(chain uint64) (map[string]TypeAndVersion, error)
 	// Allows for merging address books (e.g. new deployments with existing ones)
 	Merge(other AddressBook) error
 }
 
 type AddressBookMap struct {
-	AddressesByChain map[uint64]map[string]string
+	AddressesByChain map[uint64]map[string]TypeAndVersion
 }
 
-func (m *AddressBookMap) Save(chainSelector uint64, address string, typeAndVersion string) error {
+func (m *AddressBookMap) Save(chainSelector uint64, address string, typeAndVersion TypeAndVersion) error {
+	_, exists := chainsel.ChainBySelector(chainSelector)
+	if !exists {
+		return fmt.Errorf("chain selector %d not found", chainSelector)
+	}
+	if address == "" {
+		return fmt.Errorf("address cannot be empty")
+	}
+	if common.IsHexAddress(address) {
+		// IMPORTANT: WE ALWAYS STANDARDIZE ETHEREUM ADDRESS STRINGS TO EIP55
+		address = common.HexToAddress(address).Hex()
+	} else {
+		return fmt.Errorf("address %s is not a valid Ethereum address, only Ethereum addresses supported", address)
+	}
+	if typeAndVersion.Type == "" {
+		return fmt.Errorf("type cannot be empty")
+	}
 	if _, exists := m.AddressesByChain[chainSelector]; !exists {
 		// First time chain add, create map
-		m.AddressesByChain[chainSelector] = make(map[string]string)
+		m.AddressesByChain[chainSelector] = make(map[string]TypeAndVersion)
 	}
 	if _, exists := m.AddressesByChain[chainSelector][address]; exists {
 		return fmt.Errorf("address %s already exists for chain %d", address, chainSelector)
@@ -28,11 +108,11 @@ func (m *AddressBookMap) Save(chainSelector uint64, address string, typeAndVersi
 	return nil
 }
 
-func (m *AddressBookMap) Addresses() (map[uint64]map[string]string, error) {
+func (m *AddressBookMap) Addresses() (map[uint64]map[string]TypeAndVersion, error) {
 	return m.AddressesByChain, nil
 }
 
-func (m *AddressBookMap) AddressesForChain(chain uint64) (map[string]string, error) {
+func (m *AddressBookMap) AddressesForChain(chain uint64) (map[string]TypeAndVersion, error) {
 	if _, exists := m.AddressesByChain[chain]; !exists {
 		return nil, fmt.Errorf("chain %d not found", chain)
 	}
@@ -55,8 +135,11 @@ func (m *AddressBookMap) Merge(ab AddressBook) error {
 	return nil
 }
 
+// TODO: Maybe could add an environment argument
+// which would ensure only mainnet/testnet chain selectors are used
+// for further safety?
 func NewMemoryAddressBook() *AddressBookMap {
 	return &AddressBookMap{
-		AddressesByChain: make(map[uint64]map[string]string),
+		AddressesByChain: make(map[uint64]map[string]TypeAndVersion),
 	}
 }

--- a/integration-tests/deployment/address_book.go
+++ b/integration-tests/deployment/address_book.go
@@ -6,7 +6,13 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/pkg/errors"
 	chainsel "github.com/smartcontractkit/chain-selectors"
+)
+
+var (
+	ErrInvalidChainSelector = fmt.Errorf("invalid chain selector")
+	ErrInvalidAddress       = fmt.Errorf("invalid address")
 )
 
 // ContractType is a simple string type for identifying contract types.
@@ -84,16 +90,16 @@ type AddressBookMap struct {
 func (m *AddressBookMap) Save(chainSelector uint64, address string, typeAndVersion TypeAndVersion) error {
 	_, exists := chainsel.ChainBySelector(chainSelector)
 	if !exists {
-		return fmt.Errorf("chain selector %d not found", chainSelector)
+		return errors.Wrapf(ErrInvalidChainSelector, "chain selector %d not found", chainSelector)
 	}
-	if address == "" {
-		return fmt.Errorf("address cannot be empty")
+	if address == "" || address == common.HexToAddress("0x0").Hex() {
+		return errors.Wrap(ErrInvalidAddress, "address cannot be empty")
 	}
 	if common.IsHexAddress(address) {
 		// IMPORTANT: WE ALWAYS STANDARDIZE ETHEREUM ADDRESS STRINGS TO EIP55
 		address = common.HexToAddress(address).Hex()
 	} else {
-		return fmt.Errorf("address %s is not a valid Ethereum address, only Ethereum addresses supported", address)
+		return errors.Wrapf(ErrInvalidAddress, "address %s is not a valid Ethereum address, only Ethereum addresses supported", address)
 	}
 	if typeAndVersion.Type == "" {
 		return fmt.Errorf("type cannot be empty")

--- a/integration-tests/deployment/address_book_test.go
+++ b/integration-tests/deployment/address_book_test.go
@@ -3,69 +3,78 @@ package deployment
 import (
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 	"gotest.tools/v3/assert"
 )
 
-func TestAddressBook(t *testing.T) {
+func TestAddressBook_Save(t *testing.T) {
 	ab := NewMemoryAddressBook()
-	err := ab.Save(1, "0x1", "OnRamp 1.0.0")
+	onRamp100 := NewTypeAndVersion("OnRamp", Version1_0_0)
+	onRamp110 := NewTypeAndVersion("OnRamp", Version1_1_0)
+	offRamp100 := NewTypeAndVersion("OffRamp", Version1_0_0)
+	addr1 := common.HexToAddress("0x1").String()
+	addr2 := common.HexToAddress("0x2").String()
+	addr3 := common.HexToAddress("0x3").String()
+
+	err := ab.Save(chainsel.TEST_90000001.Selector, addr1, onRamp100)
 	require.NoError(t, err)
 	// Duplicate address will error
-	err = ab.Save(1, "0x1", "OnRamp 1.0.0")
+	err = ab.Save(chainsel.TEST_90000001.Selector, addr1, onRamp100)
 	require.Error(t, err)
 	// Distinct address same TV will not
-	err = ab.Save(1, "0x2", "OnRamp 1.0.0")
+	err = ab.Save(chainsel.TEST_90000001.Selector, addr2, onRamp100)
 	require.NoError(t, err)
 	// Same address different chain will not error
-	err = ab.Save(2, "0x1", "OnRamp 1.0.0")
+	err = ab.Save(chainsel.TEST_90000002.Selector, addr1, onRamp100)
 	require.NoError(t, err)
 	// We can save different versions of the same contract
-	err = ab.Save(2, "0x2", "OnRamp 1.2.0")
+	err = ab.Save(chainsel.TEST_90000002.Selector, addr2, onRamp110)
 	require.NoError(t, err)
 
 	addresses, err := ab.Addresses()
 	require.NoError(t, err)
-	assert.DeepEqual(t, addresses, map[uint64]map[string]string{
-		1: {
-			"0x1": "OnRamp 1.0.0",
-			"0x2": "OnRamp 1.0.0",
+	assert.DeepEqual(t, addresses, map[uint64]map[string]TypeAndVersion{
+		chainsel.TEST_90000001.Selector: {
+			addr1: onRamp100,
+			addr2: onRamp100,
 		},
-		2: {
-			"0x1": "OnRamp 1.0.0",
-			"0x2": "OnRamp 1.2.0",
+		chainsel.TEST_90000002.Selector: {
+			addr1: onRamp100,
+			addr2: onRamp110,
 		},
 	})
 
 	// Test merge
 	ab2 := NewMemoryAddressBook()
-	require.NoError(t, ab2.Save(3, "0x3", "OnRamp 1.0.0"))
+	require.NoError(t, ab2.Save(chainsel.TEST_90000003.Selector, addr3, onRamp100))
 	require.NoError(t, ab.Merge(ab2))
 	// Other address book should remain unchanged.
 	addresses, err = ab2.Addresses()
 	require.NoError(t, err)
-	assert.DeepEqual(t, addresses, map[uint64]map[string]string{
-		3: {
-			"0x3": "OnRamp 1.0.0",
+	assert.DeepEqual(t, addresses, map[uint64]map[string]TypeAndVersion{
+		chainsel.TEST_90000003.Selector: {
+			addr3: onRamp100,
 		},
 	})
 	// Existing addressbook should contain the new elements.
 	addresses, err = ab.Addresses()
 	require.NoError(t, err)
-	assert.DeepEqual(t, addresses, map[uint64]map[string]string{
-		1: {
-			"0x1": "OnRamp 1.0.0",
-			"0x2": "OnRamp 1.0.0",
+	assert.DeepEqual(t, addresses, map[uint64]map[string]TypeAndVersion{
+		chainsel.TEST_90000001.Selector: {
+			addr1: onRamp100,
+			addr2: onRamp100,
 		},
-		2: {
-			"0x1": "OnRamp 1.0.0",
-			"0x2": "OnRamp 1.2.0",
+		chainsel.TEST_90000002.Selector: {
+			addr1: onRamp100,
+			addr2: onRamp110,
 		},
-		3: {
-			"0x3": "OnRamp 1.0.0",
+		chainsel.TEST_90000003.Selector: {
+			addr3: onRamp100,
 		},
 	})
 
 	// Merge to an existing chain.
-	require.NoError(t, ab2.Save(2, "0x3", "OffRamp 1.0.0"))
+	require.NoError(t, ab2.Save(chainsel.TEST_90000002.Selector, addr3, offRamp100))
 }

--- a/integration-tests/deployment/address_book_test.go
+++ b/integration-tests/deployment/address_book_test.go
@@ -1,6 +1,7 @@
 package deployment
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -20,9 +21,21 @@ func TestAddressBook_Save(t *testing.T) {
 
 	err := ab.Save(chainsel.TEST_90000001.Selector, addr1, onRamp100)
 	require.NoError(t, err)
-	// Duplicate address will error
+
+	// Check input validation
+	err = ab.Save(chainsel.TEST_90000001.Selector, "asdlfkj", onRamp100)
+	require.Error(t, err)
+	assert.Equal(t, errors.Is(err, ErrInvalidAddress), true, "err %s", err)
+	err = ab.Save(0, addr1, onRamp100)
+	require.Error(t, err)
+	assert.Equal(t, errors.Is(err, ErrInvalidChainSelector), true)
+	// Duplicate
 	err = ab.Save(chainsel.TEST_90000001.Selector, addr1, onRamp100)
 	require.Error(t, err)
+	// Zero address
+	err = ab.Save(chainsel.TEST_90000001.Selector, common.HexToAddress("0x0").Hex(), onRamp100)
+	require.Error(t, err)
+
 	// Distinct address same TV will not
 	err = ab.Save(chainsel.TEST_90000001.Selector, addr2, onRamp100)
 	require.NoError(t, err)

--- a/integration-tests/deployment/ccip/deploy.go
+++ b/integration-tests/deployment/ccip/deploy.go
@@ -29,43 +29,21 @@ import (
 )
 
 var (
-	MockARM             deployment.ContractType = "MockARM"
-	LinkToken           deployment.ContractType = "LinkToken"
-	ARMProxy            deployment.ContractType = "ARMProxy"
-	WETH9               deployment.ContractType = "WETH9"
-	Router              deployment.ContractType = "Router"
-	TokenAdminRegistry  deployment.ContractType = "TokenAdminRegistry"
-	NonceManager        deployment.ContractType = "NonceManager"
-	PriceRegistry       deployment.ContractType = "PriceRegistry"
-	ManyChainMultisig   deployment.ContractType = "ManyChainMultiSig"
-	CCIPConfig          deployment.ContractType = "CCIPConfig"
-	RBACTimelock        deployment.ContractType = "RBACTimelock"
-	EVM2EVMMultiOnRamp  deployment.ContractType = "EVM2EVMMultiOnRamp"
-	EVM2EVMMultiOffRamp deployment.ContractType = "EVM2EVMMultiOffRamp"
-	CCIPReceiver        deployment.ContractType = "CCIPReceiver"
-)
-
-var (
-// // 1.0
-// ARMProxy_1_1_0      = "ARMProxy 1.0.0"
-// MockARM_1_0_0       = "MockARM 1.0.0"
-// LinkToken_1_0_0     = "LinkToken 1.0.0"
-// WETH9_1_0_0         = "WETH9 1.0.0"
-// MCMS_1_0_0          = "ManyChainMultiSig 1.0.0"
-// RBAC_Timelock_1_0_0 = "RBACTimelock 1.0.0"
-// CCIPReceiver_1_0_0  = "CCIPReceiver 1.0.0"
-//
-// // 1.2
-// Router_1_2_0 = "Router 1.2.0"
-// // 1.5
-// TokenAdminRegistry_1_5_0 = "TokenAdminRegistry 1.5.0-dev"
-// // 1.6
-// CapabilitiesRegistry_1_0_0 = "CapabilitiesRegistry 1.0.0"
-// CCIPConfig_1_6_0           = "CCIPConfig 1.6.0-dev"
-// EVM2EVMMultiOnRamp_1_6_0   = "EVM2EVMMultiOnRamp 1.6.0-dev"
-// EVM2EVMMultiOffRamp_1_6_0  = "EVM2EVMMultiOffRamp 1.6.0-dev"
-// NonceManager_1_6_0         = "NonceManager 1.6.0-dev"
-// PriceRegistry_1_6_0        = "PriceRegistry 1.6.0-dev"
+	MockARM              deployment.ContractType = "MockARM"
+	LinkToken            deployment.ContractType = "LinkToken"
+	ARMProxy             deployment.ContractType = "ARMProxy"
+	WETH9                deployment.ContractType = "WETH9"
+	Router               deployment.ContractType = "Router"
+	TokenAdminRegistry   deployment.ContractType = "TokenAdminRegistry"
+	NonceManager         deployment.ContractType = "NonceManager"
+	PriceRegistry        deployment.ContractType = "PriceRegistry"
+	ManyChainMultisig    deployment.ContractType = "ManyChainMultiSig"
+	CCIPConfig           deployment.ContractType = "CCIPConfig"
+	RBACTimelock         deployment.ContractType = "RBACTimelock"
+	EVM2EVMMultiOnRamp   deployment.ContractType = "EVM2EVMMultiOnRamp"
+	EVM2EVMMultiOffRamp  deployment.ContractType = "EVM2EVMMultiOffRamp"
+	CCIPReceiver         deployment.ContractType = "CCIPReceiver"
+	CapabilitiesRegistry deployment.ContractType = "CapabilitiesRegistry"
 )
 
 type Contracts interface {
@@ -113,7 +91,7 @@ func deployContract[C Contracts](
 		lggr.Errorw("Failed to confirm deployment", "err", err)
 		return nil, err
 	}
-	err = addressBook.Save(chain.Selector, contractDeploy.Address.String(), contractDeploy.TvStr)
+	err = addressBook.Save(chain.Selector, contractDeploy.Address.String(), contractDeploy.Tv)
 	if err != nil {
 		lggr.Errorw("Failed to save contract address", "err", err)
 		return nil, err
@@ -290,7 +268,7 @@ func DeployCCIPContracts(e deployment.Environment, c DeployCCIPContractConfig) (
 					armProxy.Address,
 				)
 				return ContractDeploy[*router.Router]{
-					routerAddr, routerC, tx, Router_1_2_0, err2,
+					routerAddr, routerC, tx, deployment.NewTypeAndVersion(Router, deployment.Version1_2_0), err2,
 				}
 			})
 		if err != nil {
@@ -305,7 +283,7 @@ func DeployCCIPContracts(e deployment.Environment, c DeployCCIPContractConfig) (
 					chain.DeployerKey,
 					chain.Client)
 				return ContractDeploy[*token_admin_registry.TokenAdminRegistry]{
-					tokenAdminRegistryAddr, tokenAdminRegistry, tx, TokenAdminRegistry_1_5_0, err2,
+					tokenAdminRegistryAddr, tokenAdminRegistry, tx, deployment.NewTypeAndVersion(TokenAdminRegistry, deployment.Version1_5_0), err2,
 				}
 			})
 		if err != nil {
@@ -322,7 +300,7 @@ func DeployCCIPContracts(e deployment.Environment, c DeployCCIPContractConfig) (
 					[]common.Address{}, // Need to add onRamp after
 				)
 				return ContractDeploy[*nonce_manager.NonceManager]{
-					nonceManagerAddr, nonceManager, tx, NonceManager_1_6_0, err2,
+					nonceManagerAddr, nonceManager, tx, deployment.NewTypeAndVersion(NonceManager, deployment.Version1_6_0_dev), err2,
 				}
 			})
 		if err != nil {
@@ -357,7 +335,7 @@ func DeployCCIPContracts(e deployment.Environment, c DeployCCIPContractConfig) (
 					[]price_registry.PriceRegistryDestChainConfigArgs{},
 				)
 				return ContractDeploy[*price_registry.PriceRegistry]{
-					prAddr, pr, tx, PriceRegistry_1_6_0, err2,
+					prAddr, pr, tx, deployment.NewTypeAndVersion(PriceRegistry, deployment.Version1_6_0_dev), err2,
 				}
 			})
 		if err != nil {
@@ -383,7 +361,7 @@ func DeployCCIPContracts(e deployment.Environment, c DeployCCIPContractConfig) (
 					[]evm_2_evm_multi_onramp.EVM2EVMMultiOnRampDestChainConfigArgs{},
 				)
 				return ContractDeploy[*evm_2_evm_multi_onramp.EVM2EVMMultiOnRamp]{
-					onRampAddr, onRamp, tx, EVM2EVMMultiOnRamp_1_6_0, err2,
+					onRampAddr, onRamp, tx, deployment.NewTypeAndVersion(EVM2EVMMultiOnRamp, deployment.Version1_6_0_dev), err2,
 				}
 			})
 		if err != nil {
@@ -412,7 +390,7 @@ func DeployCCIPContracts(e deployment.Environment, c DeployCCIPContractConfig) (
 					[]evm_2_evm_multi_offramp.EVM2EVMMultiOffRampSourceChainConfigArgs{},
 				)
 				return ContractDeploy[*evm_2_evm_multi_offramp.EVM2EVMMultiOffRamp]{
-					offRampAddr, offRamp, tx, EVM2EVMMultiOffRamp_1_6_0, err2,
+					offRampAddr, offRamp, tx, deployment.NewTypeAndVersion(EVM2EVMMultiOffRamp, deployment.Version1_6_0_dev), err2,
 				}
 			})
 		if err != nil {

--- a/integration-tests/deployment/ccip/deploy.go
+++ b/integration-tests/deployment/ccip/deploy.go
@@ -29,26 +29,43 @@ import (
 )
 
 var (
-	// 1.0
-	ARMProxy_1_1_0      = "ARMProxy 1.0.0"
-	MockARM_1_0_0       = "MockARM 1.0.0"
-	LinkToken_1_0_0     = "LinkToken 1.0.0"
-	WETH9_1_0_0         = "WETH9 1.0.0"
-	MCMS_1_0_0          = "ManyChainMultiSig 1.0.0"
-	RBAC_Timelock_1_0_0 = "RBACTimelock 1.0.0"
-	CCIPReceiver_1_0_0  = "CCIPReceiver 1.0.0"
+	MockARM             deployment.ContractType = "MockARM"
+	LinkToken           deployment.ContractType = "LinkToken"
+	ARMProxy            deployment.ContractType = "ARMProxy"
+	WETH9               deployment.ContractType = "WETH9"
+	Router              deployment.ContractType = "Router"
+	TokenAdminRegistry  deployment.ContractType = "TokenAdminRegistry"
+	NonceManager        deployment.ContractType = "NonceManager"
+	PriceRegistry       deployment.ContractType = "PriceRegistry"
+	ManyChainMultisig   deployment.ContractType = "ManyChainMultiSig"
+	CCIPConfig          deployment.ContractType = "CCIPConfig"
+	RBACTimelock        deployment.ContractType = "RBACTimelock"
+	EVM2EVMMultiOnRamp  deployment.ContractType = "EVM2EVMMultiOnRamp"
+	EVM2EVMMultiOffRamp deployment.ContractType = "EVM2EVMMultiOffRamp"
+	CCIPReceiver        deployment.ContractType = "CCIPReceiver"
+)
 
-	// 1.2
-	Router_1_2_0 = "Router 1.2.0"
-	// 1.5
-	TokenAdminRegistry_1_5_0 = "TokenAdminRegistry 1.5.0-dev"
-	// 1.6
-	CapabilitiesRegistry_1_0_0 = "CapabilitiesRegistry 1.0.0"
-	CCIPConfig_1_6_0           = "CCIPConfig 1.6.0-dev"
-	EVM2EVMMultiOnRamp_1_6_0   = "EVM2EVMMultiOnRamp 1.6.0-dev"
-	EVM2EVMMultiOffRamp_1_6_0  = "EVM2EVMMultiOffRamp 1.6.0-dev"
-	NonceManager_1_6_0         = "NonceManager 1.6.0-dev"
-	PriceRegistry_1_6_0        = "PriceRegistry 1.6.0-dev"
+var (
+// // 1.0
+// ARMProxy_1_1_0      = "ARMProxy 1.0.0"
+// MockARM_1_0_0       = "MockARM 1.0.0"
+// LinkToken_1_0_0     = "LinkToken 1.0.0"
+// WETH9_1_0_0         = "WETH9 1.0.0"
+// MCMS_1_0_0          = "ManyChainMultiSig 1.0.0"
+// RBAC_Timelock_1_0_0 = "RBACTimelock 1.0.0"
+// CCIPReceiver_1_0_0  = "CCIPReceiver 1.0.0"
+//
+// // 1.2
+// Router_1_2_0 = "Router 1.2.0"
+// // 1.5
+// TokenAdminRegistry_1_5_0 = "TokenAdminRegistry 1.5.0-dev"
+// // 1.6
+// CapabilitiesRegistry_1_0_0 = "CapabilitiesRegistry 1.0.0"
+// CCIPConfig_1_6_0           = "CCIPConfig 1.6.0-dev"
+// EVM2EVMMultiOnRamp_1_6_0   = "EVM2EVMMultiOnRamp 1.6.0-dev"
+// EVM2EVMMultiOffRamp_1_6_0  = "EVM2EVMMultiOffRamp 1.6.0-dev"
+// NonceManager_1_6_0         = "NonceManager 1.6.0-dev"
+// PriceRegistry_1_6_0        = "PriceRegistry 1.6.0-dev"
 )
 
 type Contracts interface {
@@ -75,7 +92,7 @@ type ContractDeploy[C Contracts] struct {
 	Address  common.Address
 	Contract C
 	Tx       *types.Transaction
-	TvStr    string
+	Tv       deployment.TypeAndVersion
 	Err      error
 }
 
@@ -148,7 +165,7 @@ func DeployCCIPContracts(e deployment.Environment, c DeployCCIPContractConfig) (
 					false,
 				)
 				return ContractDeploy[*maybe_revert_message_receiver.MaybeRevertMessageReceiver]{
-					receiverAddr, receiver, tx, CCIPReceiver_1_0_0, err2,
+					receiverAddr, receiver, tx, deployment.NewTypeAndVersion(CCIPReceiver, deployment.Version1_0_0), err2,
 				}
 			})
 		if err != nil {
@@ -165,7 +182,7 @@ func DeployCCIPContracts(e deployment.Environment, c DeployCCIPContractConfig) (
 					chain.Client,
 				)
 				return ContractDeploy[*mock_arm_contract.MockARMContract]{
-					mockARMAddr, mockARM, tx, MockARM_1_0_0, err2,
+					mockARMAddr, mockARM, tx, deployment.NewTypeAndVersion(MockARM, deployment.Version1_0_0), err2,
 				}
 			})
 		if err != nil {
@@ -181,7 +198,7 @@ func DeployCCIPContracts(e deployment.Environment, c DeployCCIPContractConfig) (
 					chain.Client,
 				)
 				return ContractDeploy[*owner_helpers.ManyChainMultiSig]{
-					mcmAddr, mcm, tx, MCMS_1_0_0, err2,
+					mcmAddr, mcm, tx, deployment.NewTypeAndVersion(ManyChainMultisig, deployment.Version1_0_0), err2,
 				}
 			})
 		if err != nil {
@@ -204,7 +221,7 @@ func DeployCCIPContracts(e deployment.Environment, c DeployCCIPContractConfig) (
 					[]common.Address{mcm.Address},            // bypassers
 				)
 				return ContractDeploy[*owner_helpers.RBACTimelock]{
-					timelock, cc, tx, RBAC_Timelock_1_0_0, err2,
+					timelock, cc, tx, deployment.NewTypeAndVersion(RBACTimelock, deployment.Version1_0_0), err2,
 				}
 			})
 		if err != nil {
@@ -221,7 +238,7 @@ func DeployCCIPContracts(e deployment.Environment, c DeployCCIPContractConfig) (
 					mockARM.Address,
 				)
 				return ContractDeploy[*arm_proxy_contract.ARMProxyContract]{
-					armProxyAddr, armProxy, tx, ARMProxy_1_1_0, err2,
+					armProxyAddr, armProxy, tx, deployment.NewTypeAndVersion(ARMProxy, deployment.Version1_0_0), err2,
 				}
 			})
 		if err != nil {
@@ -237,7 +254,7 @@ func DeployCCIPContracts(e deployment.Environment, c DeployCCIPContractConfig) (
 					chain.Client,
 				)
 				return ContractDeploy[*weth9.WETH9]{
-					weth9Addr, weth9c, tx, WETH9_1_0_0, err2,
+					weth9Addr, weth9c, tx, deployment.NewTypeAndVersion(WETH9, deployment.Version1_0_0), err2,
 				}
 			})
 		if err != nil {
@@ -256,7 +273,7 @@ func DeployCCIPContracts(e deployment.Environment, c DeployCCIPContractConfig) (
 					big.NewInt(0).Mul(big.NewInt(1e9), big.NewInt(1e18)),
 				)
 				return ContractDeploy[*burn_mint_erc677.BurnMintERC677]{
-					linkTokenAddr, linkToken, tx, LinkToken_1_0_0, err2,
+					linkTokenAddr, linkToken, tx, deployment.NewTypeAndVersion(LinkToken, deployment.Version1_0_0), err2,
 				}
 			})
 		if err != nil {

--- a/integration-tests/deployment/ccip/deploy_home_chain.go
+++ b/integration-tests/deployment/ccip/deploy_home_chain.go
@@ -182,12 +182,10 @@ func AddChainConfig(
 		chainConfig,
 	}
 	tx, err := ccipConfig.ApplyChainConfigUpdates(h.DeployerKey, nil, inputConfig)
-	if err != nil {
+	if err := deployment.ConfirmIfNoError(h, tx, err); err != nil {
 		return ccip_config.CCIPConfigTypesChainConfigInfo{}, err
 	}
-	if err := h.Confirm(tx.Hash()); err != nil {
-		return ccip_config.CCIPConfigTypesChainConfigInfo{}, err
-	}
+	lggr.Infow("Applied chain config updates", "chainConfig", chainConfig)
 	return chainConfig, nil
 }
 
@@ -309,10 +307,6 @@ func AddDON(
 	// Trim first four bytes to remove function selector.
 	encodedConfigs := encodedCall[4:]
 
-	// commit so that we have an empty block to filter events from
-	// TODO: required?
-	//h.backend.Commit()
-
 	tx, err := capReg.AddDON(home.DeployerKey, p2pIDs, []capabilities_registry.CapabilitiesRegistryCapabilityConfiguration{
 		{
 			CapabilityId: ccipCapabilityID,
@@ -377,8 +371,6 @@ func AddDON(
 		})
 	}
 
-	//uni.backend.Commit()
-
 	tx, err = offRamp.SetOCR3Configs(dest.DeployerKey, offrampOCR3Configs)
 	if err := deployment.ConfirmIfNoError(dest, tx, err); err != nil {
 		return err
@@ -392,7 +384,8 @@ func AddDON(
 			//return err
 			return deployment.MaybeDataErr(err)
 		}
-		// TODO: assertions
+		// TODO: assertions to be done as part of full state
+		// resprentation validation CCIP-3047
 		//require.Equalf(t, offrampOCR3Configs[pluginType].ConfigDigest, ocrConfig.ConfigInfo.ConfigDigest, "%s OCR3 config digest mismatch", pluginType.String())
 		//require.Equalf(t, offrampOCR3Configs[pluginType].F, ocrConfig.ConfigInfo.F, "%s OCR3 config F mismatch", pluginType.String())
 		//require.Equalf(t, offrampOCR3Configs[pluginType].IsSignatureVerificationEnabled, ocrConfig.ConfigInfo.IsSignatureVerificationEnabled, "%s OCR3 config signature verification mismatch", pluginType.String())

--- a/integration-tests/deployment/ccip/deploy_home_chain.go
+++ b/integration-tests/deployment/ccip/deploy_home_chain.go
@@ -62,7 +62,7 @@ func DeployCapReg(lggr logger.Logger, chains map[uint64]deployment.Chain, chainS
 				chain.Client,
 			)
 			return ContractDeploy[*capabilities_registry.CapabilitiesRegistry]{
-				Address: crAddr, Contract: cr, TvStr: CapabilitiesRegistry_1_0_0, Tx: tx, Err: err2,
+				Address: crAddr, Contract: cr, Tv: deployment.NewTypeAndVersion(CapabilitiesRegistry, deployment.Version1_0_0), Tx: tx, Err: err2,
 			}
 		})
 	if err != nil {
@@ -79,7 +79,7 @@ func DeployCapReg(lggr logger.Logger, chains map[uint64]deployment.Chain, chainS
 				capReg.Address,
 			)
 			return ContractDeploy[*ccip_config.CCIPConfig]{
-				Address: ccAddr, TvStr: CCIPConfig_1_6_0, Tx: tx, Err: err2, Contract: cc,
+				Address: ccAddr, Tv: deployment.NewTypeAndVersion(CCIPConfig, deployment.Version1_6_0_dev), Tx: tx, Err: err2, Contract: cc,
 			}
 		})
 	if err != nil {

--- a/integration-tests/deployment/ccip/deploy_test.go
+++ b/integration-tests/deployment/ccip/deploy_test.go
@@ -23,6 +23,7 @@ func TestDeployCCIPContracts(t *testing.T) {
 	// Deploy all the CCIP contracts.
 	homeChain := e.AllChainSelectors()[0]
 	capRegAddresses, err := DeployCapReg(lggr, e.Chains, homeChain)
+	require.NoError(t, err)
 	s, err := GenerateOnchainState(e, capRegAddresses)
 	require.NoError(t, err)
 	ab, err := DeployCCIPContracts(e, DeployCCIPContractConfig{

--- a/integration-tests/deployment/ccip/deploy_test.go
+++ b/integration-tests/deployment/ccip/deploy_test.go
@@ -16,11 +16,19 @@ import (
 func TestDeployCCIPContracts(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	e := memory.NewMemoryEnvironment(t, lggr, zapcore.InfoLevel, memory.MemoryEnvironmentConfig{
-		Chains: 1,
-		Nodes:  1,
+		Bootstraps: 1,
+		Chains:     1,
+		Nodes:      4,
 	})
 	// Deploy all the CCIP contracts.
-	ab, err := DeployCCIPContracts(e, DeployCCIPContractConfig{})
+	homeChain := e.AllChainSelectors()[0]
+	capRegAddresses, err := DeployCapReg(lggr, e.Chains, homeChain)
+	s, err := GenerateOnchainState(e, capRegAddresses)
+	require.NoError(t, err)
+	ab, err := DeployCCIPContracts(e, DeployCCIPContractConfig{
+		HomeChainSel:     homeChain,
+		CCIPOnChainState: s,
+	})
 	require.NoError(t, err)
 	state, err := GenerateOnchainState(e, ab)
 	require.NoError(t, err)
@@ -28,7 +36,7 @@ func TestDeployCCIPContracts(t *testing.T) {
 	require.NoError(t, err)
 
 	// Assert expect every deployed address to be in the address book.
-	// TODO: Add the rest of CCIPv2 representation
+	// TODO (CCIP-3047): Add the rest of CCIPv2 representation
 	b, err := json.MarshalIndent(snap, "", "	")
 	require.NoError(t, err)
 	fmt.Println(string(b))

--- a/integration-tests/deployment/ccip/migrations/1_initial_deploy_test.go
+++ b/integration-tests/deployment/ccip/migrations/1_initial_deploy_test.go
@@ -2,7 +2,6 @@ package migrations
 
 import (
 	"context"
-	"math/big"
 	"sync"
 	"testing"
 	"time"
@@ -197,10 +196,10 @@ func Test0001_InitialDeploy(t *testing.T) {
 			srcChain := srcChain
 			dstChain := dstChain
 			wg.Add(1)
-			go func(src, dest uint64) {
+			go func(src, dest deployment.Chain) {
 				defer wg.Done()
-				waitForExecWithSeqNr(t, srcChain, dstChain, state.EvmOffRampsV160[dest], 1)
-			}(src, dest)
+				waitForExecWithSeqNr(t, src, dest, state.EvmOffRampsV160[dest.Selector], 1)
+			}(srcChain, dstChain)
 		}
 	}
 	wg.Wait()
@@ -211,8 +210,7 @@ func Test0001_InitialDeploy(t *testing.T) {
 func ReplayAllLogs(nodes map[string]memory.Node, chains map[uint64]deployment.Chain) error {
 	for _, node := range nodes {
 		for sel := range chains {
-			chainID, _ := chainsel.ChainIdFromSelector(sel)
-			if err := node.App.ReplayFromBlock(big.NewInt(int64(chainID)), 1, false); err != nil {
+			if err := node.ReplayLogs(map[uint64]uint64{sel: 1}); err != nil {
 				return err
 			}
 		}

--- a/integration-tests/deployment/ccip/state.go
+++ b/integration-tests/deployment/ccip/state.go
@@ -202,7 +202,7 @@ func GenerateOnchainState(e deployment.Environment, ab deployment.AddressBook) (
 					return state, err
 				}
 				state.EvmOffRampsV160[chainSelector] = offRamp
-			case deployment.NewTypeAndVersion(ARMProxy, deployment.Version1_1_0).String():
+			case deployment.NewTypeAndVersion(ARMProxy, deployment.Version1_0_0).String():
 				armProxy, err := arm_proxy_contract.NewARMProxyContract(common.HexToAddress(address), e.Chains[chainSelector].Client)
 				if err != nil {
 					return state, err

--- a/integration-tests/deployment/ccip/state.go
+++ b/integration-tests/deployment/ccip/state.go
@@ -177,86 +177,86 @@ func GenerateOnchainState(e deployment.Environment, ab deployment.AddressBook) (
 					return state, err
 				}
 				state.Timelocks[chainSelector] = tl
-			case MCMS_1_0_0:
+			case deployment.NewTypeAndVersion(ManyChainMultisig, deployment.Version1_0_0).String():
 				mcms, err := owner_wrappers.NewManyChainMultiSig(common.HexToAddress(address), e.Chains[chainSelector].Client)
 				if err != nil {
 					return state, err
 				}
 				state.Mcms[chainSelector] = mcms
 				state.McmsAddrs[chainSelector] = common.HexToAddress(address)
-			case CapabilitiesRegistry_1_0_0:
+			case deployment.NewTypeAndVersion(CapabilitiesRegistry, deployment.Version1_0_0).String():
 				cr, err := capabilities_registry.NewCapabilitiesRegistry(common.HexToAddress(address), e.Chains[chainSelector].Client)
 				if err != nil {
 					return state, err
 				}
 				state.CapabilityRegistry[chainSelector] = cr
-			case EVM2EVMMultiOnRamp_1_6_0:
+			case deployment.NewTypeAndVersion(EVM2EVMMultiOnRamp, deployment.Version1_6_0_dev).String():
 				onRamp, err := evm_2_evm_multi_onramp.NewEVM2EVMMultiOnRamp(common.HexToAddress(address), e.Chains[chainSelector].Client)
 				if err != nil {
 					return state, err
 				}
 				state.EvmOnRampsV160[chainSelector] = onRamp
-			case EVM2EVMMultiOffRamp_1_6_0:
+			case deployment.NewTypeAndVersion(EVM2EVMMultiOffRamp, deployment.Version1_6_0_dev).String():
 				offRamp, err := evm_2_evm_multi_offramp.NewEVM2EVMMultiOffRamp(common.HexToAddress(address), e.Chains[chainSelector].Client)
 				if err != nil {
 					return state, err
 				}
 				state.EvmOffRampsV160[chainSelector] = offRamp
-			case ARMProxy_1_1_0:
+			case deployment.NewTypeAndVersion(ARMProxy, deployment.Version1_1_0).String():
 				armProxy, err := arm_proxy_contract.NewARMProxyContract(common.HexToAddress(address), e.Chains[chainSelector].Client)
 				if err != nil {
 					return state, err
 				}
 				state.ArmProxies[chainSelector] = armProxy
-			case MockARM_1_0_0:
+			case deployment.NewTypeAndVersion(MockARM, deployment.Version1_0_0).String():
 				mockARM, err := mock_arm_contract.NewMockARMContract(common.HexToAddress(address), e.Chains[chainSelector].Client)
 				if err != nil {
 					return state, err
 				}
 				state.MockArms[chainSelector] = mockARM
-			case WETH9_1_0_0:
+			case deployment.NewTypeAndVersion(WETH9, deployment.Version1_0_0).String():
 				weth9, err := weth9.NewWETH9(common.HexToAddress(address), e.Chains[chainSelector].Client)
 				if err != nil {
 					return state, err
 				}
 				state.Weth9s[chainSelector] = weth9
-			case NonceManager_1_6_0:
+			case deployment.NewTypeAndVersion(NonceManager, deployment.Version1_6_0_dev).String():
 				nm, err := nonce_manager.NewNonceManager(common.HexToAddress(address), e.Chains[chainSelector].Client)
 				if err != nil {
 					return state, err
 				}
 				state.NonceManagers[chainSelector] = nm
-			case TokenAdminRegistry_1_5_0:
+			case deployment.NewTypeAndVersion(TokenAdminRegistry, deployment.Version1_5_0).String():
 				tm, err := token_admin_registry.NewTokenAdminRegistry(common.HexToAddress(address), e.Chains[chainSelector].Client)
 				if err != nil {
 					return state, err
 				}
 				state.TokenAdminRegistries[chainSelector] = tm
-			case Router_1_2_0:
+			case deployment.NewTypeAndVersion(Router, deployment.Version1_2_0).String():
 				r, err := router.NewRouter(common.HexToAddress(address), e.Chains[chainSelector].Client)
 				if err != nil {
 					return state, err
 				}
 				state.Routers[chainSelector] = r
-			case PriceRegistry_1_6_0:
+			case deployment.NewTypeAndVersion(PriceRegistry, deployment.Version1_6_0_dev).String():
 				pr, err := price_registry.NewPriceRegistry(common.HexToAddress(address), e.Chains[chainSelector].Client)
 				if err != nil {
 					return state, err
 				}
 				state.PriceRegistries[chainSelector] = pr
-			case LinkToken_1_0_0:
+			case deployment.NewTypeAndVersion(LinkToken, deployment.Version1_0_0).String():
 				lt, err := burn_mint_erc677.NewBurnMintERC677(common.HexToAddress(address), e.Chains[chainSelector].Client)
 				if err != nil {
 					return state, err
 				}
 				state.LinkTokens[chainSelector] = lt
-			case CCIPConfig_1_6_0:
+			case deployment.NewTypeAndVersion(CCIPConfig, deployment.Version1_6_0_dev).String():
 				cc, err := ccip_config.NewCCIPConfig(common.HexToAddress(address), e.Chains[chainSelector].Client)
 				if err != nil {
 					return state, err
 				}
 				state.CCIPConfig[chainSelector] = cc
-			case CCIPReceiver_1_0_0:
+			case deployment.NewTypeAndVersion(CCIPReceiver, deployment.Version1_0_0).String():
 				mr, err := maybe_revert_message_receiver.NewMaybeRevertMessageReceiver(common.HexToAddress(address), e.Chains[chainSelector].Client)
 				if err != nil {
 					return state, err

--- a/integration-tests/deployment/ccip/state.go
+++ b/integration-tests/deployment/ccip/state.go
@@ -65,20 +65,20 @@ type Contract struct {
 	Address        common.Address `json:"address"`
 }
 
-type TokenAdminRegistry struct {
+type TokenAdminRegistryView struct {
 	Contract
 	Tokens []common.Address `json:"tokens"`
 }
 
-type NonceManager struct {
+type NonceManagerView struct {
 	Contract
 	AuthorizedCallers []common.Address `json:"authorizedCallers"`
 }
 
 type Chain struct {
 	// TODO: this will have to be versioned for getting state during upgrades.
-	TokenAdminRegistry TokenAdminRegistry `json:"tokenAdminRegistry"`
-	NonceManager       NonceManager       `json:"nonceManager"`
+	TokenAdminRegistry TokenAdminRegistryView `json:"tokenAdminRegistry"`
+	NonceManager       NonceManagerView       `json:"nonceManager"`
 }
 
 func (s CCIPOnChainState) Snapshot(chains []uint64) (CCIPSnapShot, error) {
@@ -105,7 +105,7 @@ func (s CCIPOnChainState) Snapshot(chains []uint64) (CCIPSnapShot, error) {
 			if err != nil {
 				return snapshot, err
 			}
-			c.TokenAdminRegistry = TokenAdminRegistry{
+			c.TokenAdminRegistry = TokenAdminRegistryView{
 				Contract: Contract{
 					TypeAndVersion: tv,
 					Address:        ta.Address(),
@@ -122,7 +122,7 @@ func (s CCIPOnChainState) Snapshot(chains []uint64) (CCIPSnapShot, error) {
 			if err != nil {
 				return snapshot, err
 			}
-			c.NonceManager = NonceManager{
+			c.NonceManager = NonceManagerView{
 				Contract: Contract{
 					TypeAndVersion: tv,
 					Address:        nm.Address(),
@@ -170,8 +170,8 @@ func GenerateOnchainState(e deployment.Environment, ab deployment.AddressBook) (
 	}
 	for chainSelector, addresses := range addresses {
 		for address, tvStr := range addresses {
-			switch tvStr {
-			case RBAC_Timelock_1_0_0:
+			switch tvStr.String() {
+			case deployment.NewTypeAndVersion(RBACTimelock, deployment.Version1_0_0).String():
 				tl, err := owner_wrappers.NewRBACTimelock(common.HexToAddress(address), e.Chains[chainSelector].Client)
 				if err != nil {
 					return state, err

--- a/integration-tests/deployment/memory/node.go
+++ b/integration-tests/deployment/memory/node.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
@@ -59,6 +60,16 @@ type Node struct {
 	Keys       Keys
 	Addr       net.TCPAddr
 	IsBoostrap bool
+}
+
+func (n Node) ReplayLogs(chains map[uint64]uint64) error {
+	for sel, block := range chains {
+		chainID, _ := chainsel.ChainIdFromSelector(sel)
+		if err := n.App.ReplayFromBlock(big.NewInt(int64(chainID)), block, false); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 type RegistryConfig struct {


### PR DESCRIPTION
## Motivation
Want to be maximally defensive for the address book to prevent corruption. 

## Solution
- Type contract and version
- Let products compose type and version at deploy/state gen time to avoid a combinatorial number of strings 

