### PR TITLE
persistent chain with Seth

### DIFF
--- a/integration-tests/deployment/ccip/deploy.go
+++ b/integration-tests/deployment/ccip/deploy.go
@@ -87,7 +87,12 @@ func deployContract[C Contracts](
 		lggr.Errorw("Failed to deploy contract", "err", contractDeploy.Err)
 		return nil, contractDeploy.Err
 	}
-	err := chain.Confirm(contractDeploy.Tx.Hash())
+	err := chain.LoadAbi(contractDeploy.Contract)
+	if err != nil {
+		lggr.Errorw("Failed to load contract abi", "err", err)
+		return nil, err
+	}
+	err = chain.Confirm(contractDeploy.Tx.Hash())
 	if err != nil {
 		lggr.Errorw("Failed to confirm deployment", "err", err)
 		return nil, err

--- a/integration-tests/deployment/ccip/deploy_home_chain.go
+++ b/integration-tests/deployment/ccip/deploy_home_chain.go
@@ -81,6 +81,9 @@ func DeployCapReg(lggr logger.Logger, chains map[uint64]deployment.Chain, chainS
 				chain.Client,
 				capReg.Address,
 			)
+			if err2 != nil {
+				tx, err2 = chain.RetrySubmit(tx, err2)
+			}
 			return ContractDeploy[*ccip_config.CCIPConfig]{
 				Address: ccAddr, Tv: deployment.NewTypeAndVersion(CCIPConfig, deployment.Version1_6_0_dev), Tx: tx, Err: err2, Contract: cc,
 			}

--- a/integration-tests/deployment/ccip/deploy_home_chain.go
+++ b/integration-tests/deployment/ccip/deploy_home_chain.go
@@ -61,6 +61,9 @@ func DeployCapReg(lggr logger.Logger, chains map[uint64]deployment.Chain, chainS
 				chain.DeployerKey,
 				chain.Client,
 			)
+			if err2 != nil {
+				tx, err2 = chain.RetrySubmit(tx, err2)
+			}
 			return ContractDeploy[*capabilities_registry.CapabilitiesRegistry]{
 				Address: crAddr, Contract: cr, Tv: deployment.NewTypeAndVersion(CapabilitiesRegistry, deployment.Version1_0_0), Tx: tx, Err: err2,
 			}

--- a/integration-tests/deployment/environment.go
+++ b/integration-tests/deployment/environment.go
@@ -41,6 +41,7 @@ type Chain struct {
 	// Note the Sign function can be abstract supporting a variety of key storage mechanisms (e.g. KMS etc).
 	DeployerKey *bind.TransactOpts
 	Confirm     func(tx common.Hash) error
+	RetrySubmit func(tx *types.Transaction, err error) (*types.Transaction, error)
 }
 
 type Environment struct {

--- a/integration-tests/deployment/environment.go
+++ b/integration-tests/deployment/environment.go
@@ -41,7 +41,22 @@ type Chain struct {
 	// Note the Sign function can be abstract supporting a variety of key storage mechanisms (e.g. KMS etc).
 	DeployerKey *bind.TransactOpts
 	Confirm     func(tx common.Hash) error
+	// Function to execute if transaction submission fails.
 	RetrySubmit func(tx *types.Transaction, err error) (*types.Transaction, error)
+	// Seth-specific function that loads the ABI for a contract, so that we can decode it
+	// IMHO it would be better to add it to OnchainClient, as that it belongs there, but would mean we'd need a wrapper
+	// for bind.SimulatedBackend, which is a bit annoying.
+	LoadAbi func(contract interface{}) error
+}
+
+// NoOpRetrySubmit is a retry submit function that does nothing.
+func NoOpRetrySubmit(tx *types.Transaction, err error) (*types.Transaction, error) {
+	return nil, err
+}
+
+// NoOpLoadAbi is a load ABI function that does nothing.
+func NoOpLoadAbi(contract interface{}) error {
+	return nil
 }
 
 type Environment struct {

--- a/integration-tests/deployment/memory/environment.go
+++ b/integration-tests/deployment/memory/environment.go
@@ -53,6 +53,8 @@ func NewMemoryChains(t *testing.T, numChains int) map[uint64]deployment.Chain {
 					return nil
 				}
 			},
+			RetrySubmit: deployment.NoOpRetrySubmit,
+			LoadAbi:     deployment.NoOpLoadAbi,
 		}
 	}
 	return chains

--- a/integration-tests/deployment/persistent/chain.go
+++ b/integration-tests/deployment/persistent/chain.go
@@ -2,37 +2,104 @@ package persistent
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"reflect"
+	"testing"
+	"unsafe"
+
 	"github.com/avast/retry-go/v4"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/smartcontractkit/ccip/integration-tests/deployment"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/seth"
+
+	ctf_config "github.com/smartcontractkit/chainlink-testing-framework/config"
+	ctf_test_env "github.com/smartcontractkit/chainlink-testing-framework/docker/test_env"
+	seth_utils "github.com/smartcontractkit/chainlink-testing-framework/utils/seth"
+
+	"github.com/smartcontractkit/chainlink/integration-tests/deployment"
+	"github.com/smartcontractkit/chainlink/integration-tests/docker/test_env"
+	tc "github.com/smartcontractkit/chainlink/integration-tests/testconfig"
 )
 
-func NewPersistentChain(selector uint64) (deployment.Chain, error) {
-	cfg, err := seth.ReadConfig()
-	if err != nil {
-		return deployment.Chain{}, err
-	}
-	sethClient, err := seth.NewClientWithConfig(cfg)
-	if err != nil {
-		return deployment.Chain{}, err
+func NewPersistentChains(t *testing.T, testConfig tc.TestConfig) (map[uint64]deployment.Chain, error) {
+	chains := make(map[uint64]deployment.Chain)
+	var networks []*ctf_config.EthereumNetworkConfig
+
+	for _, evmNetwork := range testConfig.Network.EVMNetworks {
+		chainConfig := ctf_config.GetDefaultChainConfig()
+		chainConfig.ChainID = int(evmNetwork.ChainID)
+
+		ethBuilder := ctf_test_env.NewEthereumNetworkBuilder()
+		network, err := ethBuilder.
+			WithEthereumVersion(ctf_config.EthereumVersion_Eth1).
+			WithExecutionLayer(ctf_config.ExecutionLayer_Geth).
+			WithEthereumChainConfig(chainConfig).
+			Build()
+
+		if err != nil {
+			return chains, err
+		}
+
+		networks = append(networks, &network.EthereumNetworkConfig)
 	}
 
+	env, err := test_env.NewCLTestEnvBuilder().
+		WithTestInstance(t).
+		WithTestConfig(&testConfig).
+		WithPrivateEthereumNetworks(networks).
+		WithStandardCleanup().
+		Build()
+	if err != nil {
+		return chains, err
+	}
+
+	for _, evmNetwork := range env.EVMNetworks {
+		sethClient, err := seth_utils.GetChainClient(testConfig, *evmNetwork)
+		if err != nil {
+			return chains, err
+		}
+
+		asUint := uint64(evmNetwork.ChainID)
+		chain, err := buildChain(sethClient, asUint)
+		if err != nil {
+			return make(map[uint64]deployment.Chain), nil
+		}
+		chains[asUint] = chain
+	}
+
+	return chains, nil
+}
+
+func buildChain(sethClient *seth.Client, chainId uint64) (deployment.Chain, error) {
 	shouldRetryOnErrFn := func(err error) bool {
-		// some more complex logic here
+		// some retry logic here
 		return true
 	}
 
 	prepareReplacementTransactionFn := func(sethClient *seth.Client, tx *types.Transaction) (*types.Transaction, error) {
-		// some more complex logic here
+		// some replacement tx creation logic here
+		// maybe adjusting base fee aggressively if it's too low for transaction to even be included in the block
 		return tx, nil
 	}
 
+	sel, err := chainsel.SelectorFromChainId(chainId)
+	if err != nil {
+		return deployment.Chain{}, err
+	}
+
 	return deployment.Chain{
-		Selector:    selector,
-		Client:      sethClient.Client,
-		DeployerKey: sethClient.NewTXOpts(),
+		Selector: sel,
+		Client:   sethClient.Client,
+		DeployerKey: func() *bind.TransactOpts {
+			opts := sethClient.NewTXOpts()
+			opts.Nonce = nil
+			return opts
+		}(),
 		Confirm: func(txHash common.Hash) error {
 			ctx, cancelFn := context.WithTimeout(context.Background(), sethClient.Cfg.Network.TxnTimeout.Duration())
 			tx, _, err := sethClient.Client.TransactionByHash(ctx, txHash)
@@ -40,6 +107,8 @@ func NewPersistentChain(selector uint64) (deployment.Chain, error) {
 			if err != nil {
 				return err
 			}
+			// we pass `nil` as the second argument, because we do not have transaction submission error here
+			// Decode() can also bump gas if transaction takes too much time to confirm
 			_, decodedErr := sethClient.Decode(tx, nil)
 			if decodedErr != nil {
 				return decodedErr
@@ -69,8 +138,31 @@ func NewPersistentChain(selector uint64) (deployment.Chain, error) {
 				retry.RetryIf(shouldRetryOnErrFn),
 			)
 
+			// we pass `nil` as the first argument, because otherwise `Decode()` would wait for transaction to be mined (and we prefer to do that in Confirm() function),
+			// and we don't want that, we are only interested in decoding submission error, if any
 			_, decodeErr := sethClient.Decode(nil, retryErr)
 			return tx, decodeErr
+		},
+		LoadAbi: func(contract interface{}) error {
+			val := reflect.ValueOf(contract).Elem()
+			abiField := val.FieldByName("abi")
+
+			if abiField.IsValid() && abiField.CanSet() {
+				return errors.New("abi field is not settable")
+			} else {
+				// Make the field accessible by using reflection
+				abiField = reflect.NewAt(abiField.Type(), unsafe.Pointer(abiField.UnsafeAddr())).Elem()
+				contractName := fmt.Sprintf("%T", contract)
+
+				switch abiField.Interface().(type) {
+				case abi.ABI:
+					sethClient.ContractStore.AddABI(contractName, abiField.Interface().(abi.ABI))
+				default:
+					return fmt.Errorf("abi field is not the expected abi.ABI, but %T", abiField.Interface())
+				}
+			}
+
+			return nil
 		},
 	}, nil
 }

--- a/integration-tests/deployment/persistent/chain.go
+++ b/integration-tests/deployment/persistent/chain.go
@@ -1,0 +1,76 @@
+package persistent
+
+import (
+	"context"
+	"github.com/avast/retry-go/v4"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/smartcontractkit/ccip/integration-tests/deployment"
+	"github.com/smartcontractkit/seth"
+)
+
+func NewPersistentChain(selector uint64) (deployment.Chain, error) {
+	cfg, err := seth.ReadConfig()
+	if err != nil {
+		return deployment.Chain{}, err
+	}
+	sethClient, err := seth.NewClientWithConfig(cfg)
+	if err != nil {
+		return deployment.Chain{}, err
+	}
+
+	shouldRetryOnErrFn := func(err error) bool {
+		// some more complex logic here
+		return true
+	}
+
+	prepareReplacementTransactionFn := func(sethClient *seth.Client, tx *types.Transaction) (*types.Transaction, error) {
+		// some more complex logic here
+		return tx, nil
+	}
+
+	return deployment.Chain{
+		Selector:    selector,
+		Client:      sethClient.Client,
+		DeployerKey: sethClient.NewTXOpts(),
+		Confirm: func(txHash common.Hash) error {
+			ctx, cancelFn := context.WithTimeout(context.Background(), sethClient.Cfg.Network.TxnTimeout.Duration())
+			tx, _, err := sethClient.Client.TransactionByHash(ctx, txHash)
+			cancelFn()
+			if err != nil {
+				return err
+			}
+			_, decodedErr := sethClient.Decode(tx, nil)
+			if decodedErr != nil {
+				return decodedErr
+			}
+			return nil
+		},
+		RetrySubmit: func(tx *types.Transaction, err error) (*types.Transaction, error) {
+			if err == nil {
+				return tx, nil
+			}
+
+			retryErr := retry.Do(
+				func() error {
+					ctx, cancel := context.WithTimeout(context.Background(), sethClient.Cfg.Network.TxnTimeout.Duration())
+					defer cancel()
+
+					return sethClient.Client.SendTransaction(ctx, tx)
+				}, retry.OnRetry(func(i uint, retryErr error) {
+					replacementTx, replacementErr := prepareReplacementTransactionFn(sethClient, tx)
+					if replacementErr != nil {
+						return
+					}
+					tx = replacementTx
+				}),
+				retry.DelayType(retry.FixedDelay),
+				retry.Attempts(10),
+				retry.RetryIf(shouldRetryOnErrFn),
+			)
+
+			_, decodeErr := sethClient.Decode(nil, retryErr)
+			return tx, decodeErr
+		},
+	}, nil
+}

--- a/integration-tests/deployment/persistent/environment.go
+++ b/integration-tests/deployment/persistent/environment.go
@@ -1,0 +1,34 @@
+package persistent
+
+import (
+	"fmt"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"strings"
+	"testing"
+
+	"github.com/smartcontractkit/chainlink/integration-tests/deployment"
+	tc "github.com/smartcontractkit/chainlink/integration-tests/testconfig"
+	"github.com/stretchr/testify/require"
+)
+
+func NewPersistentEnvironment(t *testing.T, lggr logger.Logger) deployment.Environment {
+	config, err := tc.GetConfig([]string{"Smoke"}, tc.OCR)
+	require.NoError(t, err, "Error getting config")
+
+	chains, err := NewPersistentChains(t, config)
+	require.NoError(t, err, "Error getting chain")
+
+	return deployment.Environment{
+		Name: fmt.Sprintf("eth-persistent-%s", strings.Join(func() []string {
+			var chainIds []string
+			for id := range chains {
+				chainIds = append(chainIds, fmt.Sprintf("%d", id))
+			}
+
+			return chainIds
+		}(), "-")),
+		Chains:  chains,
+		NodeIDs: []string{}, //TODO add nodes!
+		Logger:  lggr,
+	}
+}

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/havoc/k8schaos v0.0.0-20240409145249-e78d20847e37
 	github.com/smartcontractkit/libocr v0.0.0-20240717100443-f6226e09bee7
-	github.com/smartcontractkit/seth v1.0.12
+	github.com/smartcontractkit/seth v1.2.0
 	github.com/smartcontractkit/wasp v0.4.5
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.9.0
@@ -108,6 +108,7 @@ require (
 	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/avast/retry-go v3.0.0+incompatible // indirect
+	github.com/awalterschulze/gographviz v2.0.3+incompatible // indirect
 	github.com/aws/aws-sdk-go v1.45.25 // indirect
 	github.com/aws/constructs-go/constructs/v10 v10.1.255 // indirect
 	github.com/aws/jsii-runtime-go v1.75.0 // indirect
@@ -467,7 +468,7 @@ require (
 	golang.org/x/oauth2 v0.21.0 // indirect
 	golang.org/x/sys v0.23.0 // indirect
 	golang.org/x/term v0.23.0 // indirect
-	golang.org/x/time v0.5.0 // indirect
+	golang.org/x/time v0.6.0 // indirect
 	golang.org/x/tools v0.23.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	gonum.org/v1/gonum v0.15.0 // indirect

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -204,6 +204,8 @@ github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHS
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/avast/retry-go/v4 v4.6.0 h1:K9xNA+KeB8HHc2aWFuLb25Offp+0iVRXEvFx8IinRJA=
 github.com/avast/retry-go/v4 v4.6.0/go.mod h1:gvWlPhBVsvBbLkVGDg/KwvBv0bEkCOLRRSHKIr2PyOE=
+github.com/awalterschulze/gographviz v2.0.3+incompatible h1:9sVEXJBJLwGX7EQVhLm2elIKCm7P2YHFC8v6096G09E=
+github.com/awalterschulze/gographviz v2.0.3+incompatible/go.mod h1:GEV5wmg4YquNw7v1kkyoX9etIk8yVmXj+AkDHuuETHs=
 github.com/aws/aws-sdk-go v1.22.1/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.23.20/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.38.35/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
@@ -1422,6 +1424,8 @@ github.com/smartcontractkit/libocr v0.0.0-20240717100443-f6226e09bee7 h1:e38V5FY
 github.com/smartcontractkit/libocr v0.0.0-20240717100443-f6226e09bee7/go.mod h1:fb1ZDVXACvu4frX3APHZaEBp0xi1DIm34DcA0CwTsZM=
 github.com/smartcontractkit/seth v1.0.12 h1:iVdgMx42XWanPPnBaM5StR4c1XsTr/0/B/kKRZL5BsY=
 github.com/smartcontractkit/seth v1.0.12/go.mod h1:thWtbLyW4nRHJGzC5heknQDORoJPErE15sF34LHkorg=
+github.com/smartcontractkit/seth v1.2.0 h1:2BzO5siO7Ehuqsig/SB4szx+/2hZpOjZNFU9vFPmSM8=
+github.com/smartcontractkit/seth v1.2.0/go.mod h1:+h2QvWqOQFBacL+w0KBMyJmVYbmXXTBkPbnR45JCfYQ=
 github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20230906073235-9e478e5e19f1 h1:yiKnypAqP8l0OX0P3klzZ7SCcBUxy5KqTAKZmQOvSQE=
 github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20230906073235-9e478e5e19f1/go.mod h1:q6f4fe39oZPdsh1i57WznEZgxd8siidMaSFq3wdPmVg=
 github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20230906073235-9e478e5e19f1 h1:Dai1bn+Q5cpeGMQwRdjOdVjG8mmFFROVkSKuUgBErRQ=
@@ -1956,6 +1960,8 @@ golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.3.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.5.0 h1:o7cqy6amK/52YcAKIPlM3a+Fpj35zvRj2TP+e1xFSfk=
 golang.org/x/time v0.5.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
+golang.org/x/time v0.6.0 h1:eTDhh4ZXt5Qf0augr54TN6suAUudPcawVZeIAPU7D4U=
+golang.org/x/time v0.6.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=

--- a/integration-tests/testconfig/default.toml
+++ b/integration-tests/testconfig/default.toml
@@ -99,16 +99,17 @@ FeeCapDefault = '200 gwei'
 # if transaction level doesn't match, then calling Decode() does nothing. It's advised to keep it set
 # to 'reverted' to limit noise. If you combine it with 'trace_to_json' it will save all possible data
 # in JSON files for reverted transactions.
-tracing_level = "reverted"
+tracing_level = "all"
 # saves each decoding/tracing results to JSON files; what exactly is saved depends on what we
 # were able te decode, we try to save maximum information possible. It can either be:
 # just tx hash, decoded transaction or call trace. Which transactions traces are saved depends
 # on 'tracing_level'.
+trace_outputs = ["console"]
 
 # number of addresses to be generated and runtime, if set to 0, no addresses will be generated
 # each generated address will receive a proportion of native tokens from root private key's balance
 # with the value equal to (root_balance / ephemeral_addresses_number) - transfer_fee * ephemeral_addresses_number
-ephemeral_addresses_number = 10
+ephemeral_addresses_number = 0
 
 # If enabled we will panic when getting transaction options if current key/address has a pending transaction
 # That's because the one we are about to send would get queued, possibly for a very long time


### PR DESCRIPTION
How we can use Seth with deployer, without rebuilding it too much?

Change that it would need probably:
* having 2 `Decode()` functions.. one for failed tx submission (that would only decode the submission error), another decoding submitted transaction:
`DecodeErr(err error)` and `DecodeTx(tx *types.Transaction)`

Why?
Otherwise in current implementation, in `RetrySubmit()` we would also wait for it to be mined (unless we call `Decode()` with `nil` transaction, as there we will only decode the error).