### PR TITLE
feat: Add support for parsing deployed 1.0 contracts which have no TypeAndVersion

### DIFF
--- a/core/services/ocr2/plugins/ccip/config/type_and_version.go
+++ b/core/services/ocr2/plugins/ccip/config/type_and_version.go
@@ -19,6 +19,7 @@ var (
 	EVM2EVMOffRamp ContractType = "EVM2EVMOffRamp"
 	CommitStore    ContractType = "CommitStore"
 	PriceRegistry  ContractType = "PriceRegistry"
+	Unknown        ContractType = "Unknown" // 1.0.0 Contracts which have no TypeAndVersion
 	ContractTypes               = mapset.NewSet[ContractType](
 		EVM2EVMOffRamp,
 		EVM2EVMOnRamp,
@@ -63,7 +64,13 @@ func TypeAndVersion(addr common.Address, client bind.ContractBackend) (ContractT
 	return ContractType(contractType), *v, nil
 }
 
+// default version to use when TypeAndVersion is missing.
+const defaultVersion = "1.0.0"
+
 func ParseTypeAndVersion(tvStr string) (string, string, error) {
+	if tvStr == "" {
+		tvStr = string(Unknown) + " " + defaultVersion
+	}
 	typeAndVersionValues := strings.Split(tvStr, " ")
 
 	if len(typeAndVersionValues) < 2 {

--- a/core/services/ocr2/plugins/ccip/config/type_and_version_test.go
+++ b/core/services/ocr2/plugins/ccip/config/type_and_version_test.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseTypeAndVersion(t *testing.T) {
+	tests := []struct {
+		name            string
+		input           string
+		expectedType    string
+		expectedVersion string
+		expectedError   string
+	}{
+		{
+			name:            "Valid input",
+			input:           string(EVM2EVMOnRamp) + " 1.2.0",
+			expectedType:    string(EVM2EVMOnRamp),
+			expectedVersion: "1.2.0",
+		},
+		{
+			name:            "Empty input",
+			input:           "",
+			expectedType:    string(Unknown),
+			expectedVersion: defaultVersion,
+		},
+		{
+			name:          "Invalid input",
+			input:         "InvalidInput",
+			expectedError: "invalid type and version InvalidInput",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actualType, actualVersion, err := ParseTypeAndVersion(tc.input)
+
+			if tc.expectedError != "" {
+				assert.EqualError(t, err, tc.expectedError)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedType, actualType)
+				assert.Equal(t, tc.expectedVersion, actualVersion)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

- 1.0.0 contracts have no TypeAndVersion however tooling validation expects a TypeAndVersion be set

## Solution

- Return `Unknown 1.0.0` for contracts with an empty type and version string, implying that they are 1.0.0 deployed contracts
