### PR TITLE
lowercase networkName

### DIFF
--- a/integration-tests/ccip-tests/load/helper.go
+++ b/integration-tests/ccip-tests/load/helper.go
@@ -112,7 +112,7 @@ func (l *LoadArgs) scheduleForDest(destNetworkName string) []*wasp.Segment {
 	// otherwise, use the default frequency
 	if l.TestCfg.TestGroupInput.LoadProfile.FrequencyByDestination != nil {
 		for networkName, freq := range l.TestCfg.TestGroupInput.LoadProfile.FrequencyByDestination {
-			if strings.Contains(destNetworkName, networkName) {
+			if strings.Contains(destNetworkName, strings.ToLower(networkName)) {
 				return WaspSchedule(
 					freq.RequestPerUnitTime,
 					l.TestCfg.TestGroupInput.LoadProfile.TestDuration,


### PR DESCRIPTION
## Motivation

Load tests with different load config per chain is not working properly.

## Solution

Debugged the issue and found that issue was with uppercase in network name.
