### PR TITLE
Create dummy RMN contract for testing w/o RMN verification

### DIFF
--- a/contracts/src/v0.8/ccip/rmn/DummyRMN.sol
+++ b/contracts/src/v0.8/ccip/rmn/DummyRMN.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.24;
+
+import {IRMNV2} from "../interfaces/IRMNV2.sol";
+import {Internal} from "../libraries/Internal.sol";
+
+/// @dev XXX DO NOT USE THIS CONTRACT, FOR TESTING ONLY XXX
+contract DummyRMN is IRMNV2 {
+  /// @inheritdoc IRMNV2
+  function verify(Internal.MerkleRoot[] memory destLaneUpdates, Signature[] memory signatures) external view {
+    return;
+  }
+
+  /// @inheritdoc IRMNV2
+  function isCursed() external view returns (bool) {
+    return false;
+  }
+
+  /// @inheritdoc IRMNV2
+  function isCursed(bytes16 subject) external view returns (bool) {
+    return false;
+  }
+}


### PR DESCRIPTION
## Motivation
Unblock E2E testing

## Solution
Create a dummy RMN contract that doesn't verify RMN sigs or curse