### PR TITLE
Updating MockRouter to align with EVM2EVMOffRamp.

### DIFF
--- a/contracts/src/v0.8/ccip/test/mocks/MockRouter.sol
+++ b/contracts/src/v0.8/ccip/test/mocks/MockRouter.sol
@@ -45,8 +45,11 @@ contract MockCCIPRouter is IRouter, IRouterClient {
     uint256 gasLimit,
     address receiver
   ) internal returns (bool success, bytes memory retData, uint256 gasUsed) {
-    // Only send through the router if the receiver is a contract and implements the IAny2EVMMessageReceiver interface.
-    if (receiver.code.length == 0 || !receiver.supportsInterface(type(IAny2EVMMessageReceiver).interfaceId)) {
+    // Receiver can be skipped in 3 cases referred to here: https://github.com/smartcontractkit/ccip/blob/ccip-develop/contracts/src/v0.8/ccip/offRamp/EVM2EVMOffRamp.sol#L512
+    if (
+      (message.data.length == 0 && gasLimit == 0) || receiver.code.length == 0
+        || !receiver.supportsInterface(type(IAny2EVMMessageReceiver).interfaceId)
+    ) {
       return (true, "", 0);
     }
 


### PR DESCRIPTION
Specifically, allow for empty message with zero gas.

## Motivation
EVM2EVMOffRamp checks the message for content and gaslimit and skips calling ccip receive if they're not present.  
Consequently the mock errors (ReceiverError) when sending only tokens to a smart contract.   This update will help chainlink-local correctly process fork-based tests too. 

## Solution
The MockRouter implementation of _routeMessage was last updated in https://github.com/smartcontractkit/ccip/pull/669/ and is out of sync with the logic in EVM2EVMOffRamp.