### PR TITLE
Fix RPCClient Deadlock on Unsubscribe and NewHead (#14236)

### DIFF
--- a/.changeset/curly-birds-guess.md
+++ b/.changeset/curly-birds-guess.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Fixed deadlock in RPCClient causing CL Node to stop performing RPC requests for the affected chain #bugfix

--- a/core/chains/evm/client/rpc_client_test.go
+++ b/core/chains/evm/client/rpc_client_test.go
@@ -156,7 +156,6 @@ func TestRPCClient_SubscribeNewHead(t *testing.T) {
 			}()
 			wg.Wait()
 		}
-
 	})
 	t.Run("Block's chain ID matched configured", func(t *testing.T) {
 		server := testutils.NewWSServer(t, chainId, serverCallBack)


### PR DESCRIPTION
Cherry-pick of https://github.com/smartcontractkit/chainlink/pull/14236