### PR TITLE
Add id column as PRIMARY KEY for evm.logs & evm.log_poller_blocks

### DIFF
--- a/.changeset/brown-geese-boil.md
+++ b/.changeset/brown-geese-boil.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+FilteredLogs receive Expression instead of whole KeyFilter. #internal

--- a/.changeset/sweet-pumas-refuse.md
+++ b/.changeset/sweet-pumas-refuse.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+#bugfix Addresses 2 minor issues with the pruning of LogPoller's db tables: logs not matching any filter will now be pruned, and rows deleted are now properly reported for observability

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.22.5
+golang 1.22.7
 mockery 2.43.2
 nodejs 20.13.1
 pnpm 9.4.0

--- a/core/chains/evm/logpoller/disabled.go
+++ b/core/chains/evm/logpoller/disabled.go
@@ -118,7 +118,7 @@ func (d disabled) LogsDataWordBetween(ctx context.Context, eventSig common.Hash,
 	return nil, ErrDisabled
 }
 
-func (d disabled) FilteredLogs(_ context.Context, _ query.KeyFilter, _ query.LimitAndSort, _ string) ([]Log, error) {
+func (d disabled) FilteredLogs(_ context.Context, _ []query.Expression, _ query.LimitAndSort, _ string) ([]Log, error) {
 	return nil, ErrDisabled
 }
 

--- a/core/chains/evm/logpoller/log_poller.go
+++ b/core/chains/evm/logpoller/log_poller.go
@@ -1116,11 +1116,11 @@ func (lp *logPoller) PruneExpiredLogs(ctx context.Context) (bool, error) {
 }
 
 func (lp *logPoller) PruneUnmatchedLogs(ctx context.Context) (bool, error) {
-	ids, err := lp.orm.SelectUnmatchedLogIds(ctx, lp.logPrunePageSize)
+	ids, err := lp.orm.SelectUnmatchedLogIDs(ctx, lp.logPrunePageSize)
 	if err != nil {
 		return false, err
 	}
-	rowsRemoved, err := lp.orm.DeleteLogsByRowId(ctx, ids)
+	rowsRemoved, err := lp.orm.DeleteLogsByRowID(ctx, ids)
 
 	return lp.logPrunePageSize == 0 || rowsRemoved < lp.logPrunePageSize, err
 }

--- a/core/chains/evm/logpoller/log_poller.go
+++ b/core/chains/evm/logpoller/log_poller.go
@@ -68,7 +68,7 @@ type LogPoller interface {
 	LogsDataWordBetween(ctx context.Context, eventSig common.Hash, address common.Address, wordIndexMin, wordIndexMax int, wordValue common.Hash, confs evmtypes.Confirmations) ([]Log, error)
 
 	// chainlink-common query filtering
-	FilteredLogs(ctx context.Context, filter query.KeyFilter, limitAndSort query.LimitAndSort, queryName string) ([]Log, error)
+	FilteredLogs(ctx context.Context, filter []query.Expression, limitAndSort query.LimitAndSort, queryName string) ([]Log, error)
 }
 
 type LogPollerTest interface {
@@ -1518,6 +1518,25 @@ func EvmWord(i uint64) common.Hash {
 	return common.BytesToHash(b)
 }
 
-func (lp *logPoller) FilteredLogs(ctx context.Context, queryFilter query.KeyFilter, limitAndSort query.LimitAndSort, queryName string) ([]Log, error) {
+func (lp *logPoller) FilteredLogs(ctx context.Context, queryFilter []query.Expression, limitAndSort query.LimitAndSort, queryName string) ([]Log, error) {
 	return lp.orm.FilteredLogs(ctx, queryFilter, limitAndSort, queryName)
+}
+
+// Where is a query.Where wrapper that ignores the Key and returns a slice of query.Expression rather than query.KeyFilter.
+// If no expressions are provided, or an error occurs, an empty slice is returned.
+func Where(expressions ...query.Expression) ([]query.Expression, error) {
+	filter, err := query.Where(
+		"",
+		expressions...,
+	)
+
+	if err != nil {
+		return []query.Expression{}, err
+	}
+
+	if filter.Expressions == nil {
+		return []query.Expression{}, nil
+	}
+
+	return filter.Expressions, nil
 }

--- a/core/chains/evm/logpoller/log_poller.go
+++ b/core/chains/evm/logpoller/log_poller.go
@@ -24,8 +24,8 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink-common/pkg/timeutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query"
-	"github.com/smartcontractkit/chainlink-common/pkg/utils"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/mathutil"
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/client"
@@ -638,31 +638,36 @@ func (lp *logPoller) backgroundWorkerRun() {
 	ctx, cancel := lp.stopCh.NewCtx()
 	defer cancel()
 
+	blockPruneShortInterval := lp.pollPeriod * 100
+	blockPruneInterval := blockPruneShortInterval * 10
+	logPruneShortInterval := lp.pollPeriod * 241 // no common factors with 100
+	logPruneInterval := logPruneShortInterval * 10
+
 	// Avoid putting too much pressure on the database by staggering the pruning of old blocks and logs.
 	// Usually, node after restart will have some work to boot the plugins and other services.
-	// Deferring first prune by minutes reduces risk of putting too much pressure on the database.
-	blockPruneTick := time.After(5 * time.Minute)
-	logPruneTick := time.After(10 * time.Minute)
+	// Deferring first prune by at least 5 mins reduces risk of putting too much pressure on the database.
+	blockPruneTick := time.After((5 * time.Minute) + timeutil.JitterPct(1.0).Apply(blockPruneInterval/2))
+	logPruneTick := time.After((5 * time.Minute) + timeutil.JitterPct(1.0).Apply(logPruneInterval/2))
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-blockPruneTick:
-			blockPruneTick = time.After(utils.WithJitter(lp.pollPeriod * 1000))
+			blockPruneTick = time.After(timeutil.JitterPct(0.1).Apply(blockPruneInterval))
 			if allRemoved, err := lp.PruneOldBlocks(ctx); err != nil {
 				lp.lggr.Errorw("Unable to prune old blocks", "err", err)
 			} else if !allRemoved {
 				// Tick faster when cleanup can't keep up with the pace of new blocks
-				blockPruneTick = time.After(utils.WithJitter(lp.pollPeriod * 100))
+				blockPruneTick = time.After(timeutil.JitterPct(0.1).Apply(blockPruneShortInterval))
 			}
 		case <-logPruneTick:
-			logPruneTick = time.After(utils.WithJitter(lp.pollPeriod * 2401)) // = 7^5 avoids common factors with 1000
+			logPruneTick = time.After(timeutil.JitterPct(0.1).Apply(logPruneInterval))
 			if allRemoved, err := lp.PruneExpiredLogs(ctx); err != nil {
 				lp.lggr.Errorw("Unable to prune expired logs", "err", err)
 			} else if !allRemoved {
 				// Tick faster when cleanup can't keep up with the pace of new logs
-				logPruneTick = time.After(utils.WithJitter(lp.pollPeriod * 241))
+				logPruneTick = time.After(timeutil.JitterPct(0.1).Apply(logPruneShortInterval))
 			}
 		}
 	}

--- a/core/chains/evm/logpoller/log_poller.go
+++ b/core/chains/evm/logpoller/log_poller.go
@@ -649,6 +649,8 @@ func (lp *logPoller) backgroundWorkerRun() {
 	blockPruneTick := time.After((5 * time.Minute) + timeutil.JitterPct(1.0).Apply(blockPruneInterval/2))
 	logPruneTick := time.After((5 * time.Minute) + timeutil.JitterPct(1.0).Apply(logPruneInterval/2))
 
+	successfulExpiredLogPrunes := 0
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -668,6 +670,18 @@ func (lp *logPoller) backgroundWorkerRun() {
 			} else if !allRemoved {
 				// Tick faster when cleanup can't keep up with the pace of new logs
 				logPruneTick = time.After(timeutil.JitterPct(0.1).Apply(logPruneShortInterval))
+			} else if successfulExpiredLogPrunes == 20 {
+				// Only prune unmatched logs if we've successfully pruned all expired logs at least 20 times
+				// since the last time unmatched logs were pruned
+				if allRemoved, err := lp.PruneUnmatchedLogs(ctx); err != nil {
+					lp.lggr.Errorw("Unable to prune unmatched logs", "err", err)
+				} else if !allRemoved {
+					logPruneTick = time.After(timeutil.JitterPct(0.1).Apply(logPruneShortInterval))
+				} else {
+					successfulExpiredLogPrunes = 0
+				}
+			} else {
+				successfulExpiredLogPrunes++
 			}
 		}
 	}
@@ -1098,6 +1112,16 @@ func (lp *logPoller) PruneOldBlocks(ctx context.Context) (bool, error) {
 // Returns whether all logs eligible for pruning were removed. If logPrunePageSize is set to 0, it will always return true.
 func (lp *logPoller) PruneExpiredLogs(ctx context.Context) (bool, error) {
 	rowsRemoved, err := lp.orm.DeleteExpiredLogs(ctx, lp.logPrunePageSize)
+	return lp.logPrunePageSize == 0 || rowsRemoved < lp.logPrunePageSize, err
+}
+
+func (lp *logPoller) PruneUnmatchedLogs(ctx context.Context) (bool, error) {
+	ids, err := lp.orm.SelectUnmatchedLogIds(ctx, lp.logPrunePageSize)
+	if err != nil {
+		return false, err
+	}
+	rowsRemoved, err := lp.orm.DeleteLogsByRowId(ctx, ids)
+
 	return lp.logPrunePageSize == 0 || rowsRemoved < lp.logPrunePageSize, err
 }
 

--- a/core/chains/evm/logpoller/log_poller.go
+++ b/core/chains/evm/logpoller/log_poller.go
@@ -670,7 +670,7 @@ func (lp *logPoller) backgroundWorkerRun() {
 			} else if !allRemoved {
 				// Tick faster when cleanup can't keep up with the pace of new logs
 				logPruneTick = time.After(timeutil.JitterPct(0.1).Apply(logPruneShortInterval))
-			} else if successfulExpiredLogPrunes == 20 {
+			} else if successfulExpiredLogPrunes == 5 {
 				// Only prune unmatched logs if we've successfully pruned all expired logs at least 20 times
 				// since the last time unmatched logs were pruned
 				if allRemoved, err := lp.PruneUnmatchedLogs(ctx); err != nil {

--- a/core/chains/evm/logpoller/log_poller.go
+++ b/core/chains/evm/logpoller/log_poller.go
@@ -1094,6 +1094,7 @@ func (lp *logPoller) PruneOldBlocks(ctx context.Context) (bool, error) {
 		// No blocks saved yet.
 		return true, nil
 	}
+	lp.lggr.Errorw("Calling DeleteBlocksBefore")
 	if latestBlock.FinalizedBlockNumber <= lp.keepFinalizedBlocksDepth {
 		// No-op, keep all blocks
 		return true, nil
@@ -1105,6 +1106,7 @@ func (lp *logPoller) PruneOldBlocks(ctx context.Context) (bool, error) {
 		latestBlock.FinalizedBlockNumber-lp.keepFinalizedBlocksDepth,
 		lp.logPrunePageSize,
 	)
+	lp.lggr.Errorw("DeleteBlocksBefore returned", "logPrunePageSize", lp.logPrunePageSize, "rowsRemoved", rowsRemoved, "allRemoved", rowsRemoved < lp.logPrunePageSize)
 	return lp.logPrunePageSize == 0 || rowsRemoved < lp.logPrunePageSize, err
 }
 

--- a/core/chains/evm/logpoller/log_poller_test.go
+++ b/core/chains/evm/logpoller/log_poller_test.go
@@ -26,6 +26,8 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/query"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives"
 	commonutils "github.com/smartcontractkit/chainlink-common/pkg/utils"
 
 	htMocks "github.com/smartcontractkit/chainlink/v2/common/headtracker/mocks"
@@ -2051,4 +2053,40 @@ func TestFindLCA(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWhere(t *testing.T) {
+	address := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
+	eventSig := common.HexToHash("0xabcdef1234567890abcdef1234567890abcdef1234")
+	ts := time.Now()
+
+	expr1 := logpoller.NewAddressFilter(address)
+	expr2 := logpoller.NewEventSigFilter(eventSig)
+	expr3 := query.Timestamp(uint64(ts.Unix()), primitives.Gte)
+	expr4 := logpoller.NewConfirmationsFilter(evmtypes.Confirmations(0))
+
+	t.Run("Valid combination of filters", func(t *testing.T) {
+		result, err := logpoller.Where(expr1, expr2, expr3, expr4)
+		assert.NoError(t, err)
+		assert.Equal(t, []query.Expression{expr1, expr2, expr3, expr4}, result)
+	})
+
+	t.Run("No expressions (should return empty slice)", func(t *testing.T) {
+		result, err := logpoller.Where()
+		assert.NoError(t, err)
+		assert.Equal(t, []query.Expression{}, result)
+	})
+
+	t.Run("Invalid boolean expression", func(t *testing.T) {
+		invalidExpr := query.Expression{
+			BoolExpression: query.BoolExpression{
+				Expressions: []query.Expression{},
+			},
+		}
+
+		result, err := logpoller.Where(invalidExpr)
+		assert.Error(t, err)
+		assert.EqualError(t, err, "all boolean expressions should have at least 2 expressions")
+		assert.Equal(t, []query.Expression{}, result)
+	})
 }

--- a/core/chains/evm/logpoller/mocks/log_poller.go
+++ b/core/chains/evm/logpoller/mocks/log_poller.go
@@ -124,7 +124,7 @@ func (_c *LogPoller_DeleteLogsAndBlocksAfter_Call) RunAndReturn(run func(context
 }
 
 // FilteredLogs provides a mock function with given fields: ctx, filter, limitAndSort, queryName
-func (_m *LogPoller) FilteredLogs(ctx context.Context, filter query.KeyFilter, limitAndSort query.LimitAndSort, queryName string) ([]logpoller.Log, error) {
+func (_m *LogPoller) FilteredLogs(ctx context.Context, filter []query.Expression, limitAndSort query.LimitAndSort, queryName string) ([]logpoller.Log, error) {
 	ret := _m.Called(ctx, filter, limitAndSort, queryName)
 
 	if len(ret) == 0 {
@@ -133,10 +133,10 @@ func (_m *LogPoller) FilteredLogs(ctx context.Context, filter query.KeyFilter, l
 
 	var r0 []logpoller.Log
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, query.KeyFilter, query.LimitAndSort, string) ([]logpoller.Log, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, []query.Expression, query.LimitAndSort, string) ([]logpoller.Log, error)); ok {
 		return rf(ctx, filter, limitAndSort, queryName)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, query.KeyFilter, query.LimitAndSort, string) []logpoller.Log); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, []query.Expression, query.LimitAndSort, string) []logpoller.Log); ok {
 		r0 = rf(ctx, filter, limitAndSort, queryName)
 	} else {
 		if ret.Get(0) != nil {
@@ -144,7 +144,7 @@ func (_m *LogPoller) FilteredLogs(ctx context.Context, filter query.KeyFilter, l
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, query.KeyFilter, query.LimitAndSort, string) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, []query.Expression, query.LimitAndSort, string) error); ok {
 		r1 = rf(ctx, filter, limitAndSort, queryName)
 	} else {
 		r1 = ret.Error(1)
@@ -160,16 +160,16 @@ type LogPoller_FilteredLogs_Call struct {
 
 // FilteredLogs is a helper method to define mock.On call
 //   - ctx context.Context
-//   - filter query.KeyFilter
+//   - filter []query.Expression
 //   - limitAndSort query.LimitAndSort
 //   - queryName string
 func (_e *LogPoller_Expecter) FilteredLogs(ctx interface{}, filter interface{}, limitAndSort interface{}, queryName interface{}) *LogPoller_FilteredLogs_Call {
 	return &LogPoller_FilteredLogs_Call{Call: _e.mock.On("FilteredLogs", ctx, filter, limitAndSort, queryName)}
 }
 
-func (_c *LogPoller_FilteredLogs_Call) Run(run func(ctx context.Context, filter query.KeyFilter, limitAndSort query.LimitAndSort, queryName string)) *LogPoller_FilteredLogs_Call {
+func (_c *LogPoller_FilteredLogs_Call) Run(run func(ctx context.Context, filter []query.Expression, limitAndSort query.LimitAndSort, queryName string)) *LogPoller_FilteredLogs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(query.KeyFilter), args[2].(query.LimitAndSort), args[3].(string))
+		run(args[0].(context.Context), args[1].([]query.Expression), args[2].(query.LimitAndSort), args[3].(string))
 	})
 	return _c
 }
@@ -179,7 +179,7 @@ func (_c *LogPoller_FilteredLogs_Call) Return(_a0 []logpoller.Log, _a1 error) *L
 	return _c
 }
 
-func (_c *LogPoller_FilteredLogs_Call) RunAndReturn(run func(context.Context, query.KeyFilter, query.LimitAndSort, string) ([]logpoller.Log, error)) *LogPoller_FilteredLogs_Call {
+func (_c *LogPoller_FilteredLogs_Call) RunAndReturn(run func(context.Context, []query.Expression, query.LimitAndSort, string) ([]logpoller.Log, error)) *LogPoller_FilteredLogs_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/chains/evm/logpoller/observability.go
+++ b/core/chains/evm/logpoller/observability.go
@@ -262,7 +262,7 @@ func (o *ObservedORM) SelectIndexedLogsTopicRange(ctx context.Context, address c
 	})
 }
 
-func (o *ObservedORM) FilteredLogs(ctx context.Context, filter query.KeyFilter, limitAndSort query.LimitAndSort, queryName string) ([]Log, error) {
+func (o *ObservedORM) FilteredLogs(ctx context.Context, filter []query.Expression, limitAndSort query.LimitAndSort, queryName string) ([]Log, error) {
 	return withObservedQueryAndResults(o, queryName, func() ([]Log, error) {
 		return o.ORM.FilteredLogs(ctx, filter, limitAndSort, queryName)
 	})

--- a/core/chains/evm/logpoller/observability.go
+++ b/core/chains/evm/logpoller/observability.go
@@ -136,6 +136,18 @@ func (o *ObservedORM) DeleteLogsAndBlocksAfter(ctx context.Context, start int64)
 	})
 }
 
+func (o *ObservedORM) DeleteLogsByRowId(ctx context.Context, rowIds []uint64) (int64, error) {
+	return withObservedExecAndRowsAffected(o, "DeleteLogsByRowId", del, func() (int64, error) {
+		return o.ORM.DeleteLogsByRowId(ctx, rowIds)
+	})
+}
+
+func (o *ObservedORM) SelectUnmatchedLogIds(ctx context.Context, limit int64) (ids []uint64, err error) {
+	return withObservedQueryAndResults[uint64](o, "SelectUnmatchedLogIds", func() ([]uint64, error) {
+		return o.ORM.SelectUnmatchedLogIds(ctx, limit)
+	})
+}
+
 func (o *ObservedORM) DeleteExpiredLogs(ctx context.Context, limit int64) (int64, error) {
 	return withObservedExecAndRowsAffected(o, "DeleteExpiredLogs", del, func() (int64, error) {
 		return o.ORM.DeleteExpiredLogs(ctx, limit)

--- a/core/chains/evm/logpoller/observability.go
+++ b/core/chains/evm/logpoller/observability.go
@@ -136,15 +136,15 @@ func (o *ObservedORM) DeleteLogsAndBlocksAfter(ctx context.Context, start int64)
 	})
 }
 
-func (o *ObservedORM) DeleteLogsByRowId(ctx context.Context, rowIds []uint64) (int64, error) {
-	return withObservedExecAndRowsAffected(o, "DeleteLogsByRowId", del, func() (int64, error) {
-		return o.ORM.DeleteLogsByRowId(ctx, rowIds)
+func (o *ObservedORM) DeleteLogsByRowID(ctx context.Context, rowIDs []uint64) (int64, error) {
+	return withObservedExecAndRowsAffected(o, "DeleteLogsByRowID", del, func() (int64, error) {
+		return o.ORM.DeleteLogsByRowID(ctx, rowIDs)
 	})
 }
 
-func (o *ObservedORM) SelectUnmatchedLogIds(ctx context.Context, limit int64) (ids []uint64, err error) {
-	return withObservedQueryAndResults[uint64](o, "SelectUnmatchedLogIds", func() ([]uint64, error) {
-		return o.ORM.SelectUnmatchedLogIds(ctx, limit)
+func (o *ObservedORM) SelectUnmatchedLogIDs(ctx context.Context, limit int64) (ids []uint64, err error) {
+	return withObservedQueryAndResults[uint64](o, "SelectUnmatchedLogIDs", func() ([]uint64, error) {
+		return o.ORM.SelectUnmatchedLogIDs(ctx, limit)
 	})
 }
 

--- a/core/chains/evm/logpoller/observability_test.go
+++ b/core/chains/evm/logpoller/observability_test.go
@@ -119,6 +119,16 @@ func TestCountersAreProperlyPopulatedForWrites(t *testing.T) {
 	assert.Equal(t, float64(20), testutil.ToFloat64(orm.logsInserted.WithLabelValues("420")))
 	assert.Equal(t, float64(2), testutil.ToFloat64(orm.blocksInserted.WithLabelValues("420")))
 
+	rowsAffected, err := orm.DeleteExpiredLogs(ctx, 3)
+	require.NoError(t, err)
+	require.Equal(t, int64(3), rowsAffected)
+	assert.Equal(t, 3, counterFromGaugeByLabels(orm.datasetSize, "420", "DeleteExpiredLogs", "delete"))
+
+	rowsAffected, err = orm.DeleteBlocksBefore(ctx, 30, 0)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), rowsAffected)
+	assert.Equal(t, 2, counterFromGaugeByLabels(orm.datasetSize, "420", "DeleteBlocksBefore", "delete"))
+
 	// Don't update counters in case of an error
 	require.Error(t, orm.InsertLogsWithBlock(ctx, logs, NewLogPollerBlock(utils.RandomBytes32(), 0, time.Now(), 0)))
 	assert.Equal(t, float64(20), testutil.ToFloat64(orm.logsInserted.WithLabelValues("420")))

--- a/core/chains/evm/logpoller/observability_test.go
+++ b/core/chains/evm/logpoller/observability_test.go
@@ -121,8 +121,8 @@ func TestCountersAreProperlyPopulatedForWrites(t *testing.T) {
 
 	rowsAffected, err := orm.DeleteExpiredLogs(ctx, 3)
 	require.NoError(t, err)
-	require.Equal(t, int64(3), rowsAffected)
-	assert.Equal(t, 3, counterFromGaugeByLabels(orm.datasetSize, "420", "DeleteExpiredLogs", "delete"))
+	require.Equal(t, int64(0), rowsAffected)
+	assert.Equal(t, 0, counterFromGaugeByLabels(orm.datasetSize, "420", "DeleteExpiredLogs", "delete"))
 
 	rowsAffected, err = orm.DeleteBlocksBefore(ctx, 30, 0)
 	require.NoError(t, err)

--- a/core/chains/evm/logpoller/orm.go
+++ b/core/chains/evm/logpoller/orm.go
@@ -33,11 +33,11 @@ type ORM interface {
 	LoadFilters(ctx context.Context) (map[string]Filter, error)
 	DeleteFilter(ctx context.Context, name string) error
 
-	DeleteLogsByRowId(ctx context.Context, rowIds []uint64) (int64, error)
+	DeleteLogsByRowID(ctx context.Context, rowIDs []uint64) (int64, error)
 	InsertBlock(ctx context.Context, blockHash common.Hash, blockNumber int64, blockTimestamp time.Time, finalizedBlock int64) error
 	DeleteBlocksBefore(ctx context.Context, end int64, limit int64) (int64, error)
 	DeleteLogsAndBlocksAfter(ctx context.Context, start int64) error
-	SelectUnmatchedLogIds(ctx context.Context, limit int64) (ids []uint64, err error)
+	SelectUnmatchedLogIDs(ctx context.Context, limit int64) (ids []uint64, err error)
 	DeleteExpiredLogs(ctx context.Context, limit int64) (int64, error)
 
 	GetBlocksRange(ctx context.Context, start int64, end int64) ([]LogPollerBlock, error)
@@ -380,7 +380,7 @@ type Exp struct {
 	ShouldDelete bool
 }
 
-func (o *DSORM) SelectUnmatchedLogIds(ctx context.Context, limit int64) (ids []uint64, err error) {
+func (o *DSORM) SelectUnmatchedLogIDs(ctx context.Context, limit int64) (ids []uint64, err error) {
 	query := `
 		SELECT l.id FROM evm.logs l JOIN (
 			SELECT evm_chain_id, address, event
@@ -1050,9 +1050,9 @@ func (o *DSORM) FilteredLogs(ctx context.Context, filter []query.Expression, lim
 	return logs, nil
 }
 
-// DeleteLogsByRowId accepts a list of log row id's to delete
-func (o *DSORM) DeleteLogsByRowId(ctx context.Context, rowIds []uint64) (int64, error) {
-	result, err := o.ds.ExecContext(ctx, `DELETE FROM evm.logs WHERE id = ANY($1)`, rowIds)
+// DeleteLogsByRowID accepts a list of log row id's to delete
+func (o *DSORM) DeleteLogsByRowID(ctx context.Context, rowIDs []uint64) (int64, error) {
+	result, err := o.ds.ExecContext(ctx, `DELETE FROM evm.logs WHERE id = ANY($1)`, rowIDs)
 	if err != nil {
 		return 0, err
 	}

--- a/core/chains/evm/logpoller/orm.go
+++ b/core/chains/evm/logpoller/orm.go
@@ -15,6 +15,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
+
 	evmtypes "github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
@@ -313,34 +314,29 @@ type Exp struct {
 	ShouldDelete bool
 }
 
+// DeleteExpiredLogs removes any logs which either:
+//   - don't match any currently registered filters, or
+//   - have a timestamp older than any matching filter's retention, UNLESS there is at
+//     least one matching filter with retention=0
 func (o *DSORM) DeleteExpiredLogs(ctx context.Context, limit int64) (int64, error) {
 	var err error
 	var result sql.Result
-	if limit > 0 {
-		result, err = o.ds.ExecContext(ctx, `
-		DELETE FROM evm.logs
+	query := `DELETE FROM evm.logs
 		WHERE (evm_chain_id, address, event_sig, block_number) IN (
 			SELECT l.evm_chain_id, l.address, l.event_sig, l.block_number
 			FROM evm.logs l
-			INNER JOIN (
-				SELECT address, event, MAX(retention) AS retention
+			LEFT JOIN (
+				SELECT address, event, CASE WHEN MIN(retention) = 0 THEN 0 ELSE MAX(retention) END AS retention
 				FROM evm.log_poller_filters
 				WHERE evm_chain_id = $1
 				GROUP BY evm_chain_id, address, event
-				HAVING NOT 0 = ANY(ARRAY_AGG(retention))
 			) r ON l.evm_chain_id = $1 AND l.address = r.address AND l.event_sig = r.event
-			AND l.block_timestamp <= STATEMENT_TIMESTAMP() - (r.retention / 10^9 * interval '1 second')
-			LIMIT $2
-		)`, ubig.New(o.chainID), limit)
+			WHERE r.retention IS NULL OR (r.retention != 0 AND l.block_timestamp <= STATEMENT_TIMESTAMP() - (r.retention / 10^9 * interval '1 second')) %s)`
+
+	if limit > 0 {
+		result, err = o.ds.ExecContext(ctx, fmt.Sprintf(query, "LIMIT $2"), ubig.New(o.chainID), limit)
 	} else {
-		result, err = o.ds.ExecContext(ctx, `WITH r AS
-		( SELECT address, event, MAX(retention) AS retention
-			FROM evm.log_poller_filters WHERE evm_chain_id=$1
-			GROUP BY evm_chain_id,address, event HAVING NOT 0 = ANY(ARRAY_AGG(retention))
-		) DELETE FROM evm.logs l USING r
-			WHERE l.evm_chain_id = $1 AND l.address=r.address AND l.event_sig=r.event
-			AND l.block_timestamp <= STATEMENT_TIMESTAMP() - (r.retention / 10^9 * interval '1 second')`, // retention is in nanoseconds (time.Duration aka BIGINT)
-			ubig.New(o.chainID))
+		result, err = o.ds.ExecContext(ctx, fmt.Sprintf(query, ""), ubig.New(o.chainID))
 	}
 
 	if err != nil {

--- a/core/chains/evm/logpoller/orm.go
+++ b/core/chains/evm/logpoller/orm.go
@@ -373,12 +373,13 @@ func (o *DSORM) DeleteExpiredLogs(ctx context.Context, limit int64) (int64, erro
 		WITH rows_to_delete AS (
 			SELECT l.id
 			FROM evm.logs l LEFT JOIN (
-				SELECT address, event, CASE WHEN MIN(retention) = 0 THEN 0 ELSE MAX(retention) END AS retention
+				SELECT evm_chain_id, address, event, CASE WHEN MIN(retention) = 0 THEN 0 ELSE MAX(retention) END AS retention
 				FROM evm.log_poller_filters
 				WHERE evm_chain_id = $1
 				GROUP BY evm_chain_id, address, event
-			) r ON l.evm_chain_id = $1 AND l.address = r.address AND l.event_sig = r.event
-			WHERE r.retention IS NULL OR (r.retention != 0 AND l.block_timestamp <= STATEMENT_TIMESTAMP() - (r.retention / 10^9 * interval '1 second''
+			) r ON l.evm_chain_id = r.evm_chain_id AND l.address = r.address AND l.event_sig = r.event
+			WHERE l.evm_chain_id = $1 AND -- needed because of LEFT JOIN
+				  r.retention IS NULL OR (r.retention != 0 AND l.block_timestamp <= STATEMENT_TIMESTAMP() - (r.retention / 10^9 * interval '1 second'))
 			%s
 		) DELETE FROM evm.logs WHERE id IN (SELECT id FROM rows_to_delete)`, limitClause)
 	result, err := o.ds.ExecContext(ctx, query, ubig.New(o.chainID))

--- a/core/chains/evm/logpoller/orm.go
+++ b/core/chains/evm/logpoller/orm.go
@@ -389,7 +389,7 @@ func (o *DSORM) insertLogsWithinTx(ctx context.Context, logs []Log, tx sqlutil.D
 					(:evm_chain_id, :log_index, :block_hash, :block_number, :block_timestamp, :address, :event_sig, :topics, :tx_hash, :data, NOW())
 				ON CONFLICT DO NOTHING`
 
-		_, err := o.ds.NamedExecContext(ctx, query, logs[start:end])
+		_, err := tx.NamedExecContext(ctx, query, logs[start:end])
 		if err != nil {
 			if pkgerrors.Is(err, context.DeadlineExceeded) && batchInsertSize > 500 {
 				// In case of DB timeouts, try to insert again with a smaller batch upto a limit

--- a/core/chains/evm/logpoller/orm.go
+++ b/core/chains/evm/logpoller/orm.go
@@ -64,7 +64,7 @@ type ORM interface {
 	SelectLogsDataWordBetween(ctx context.Context, address common.Address, eventSig common.Hash, wordIndexMin int, wordIndexMax int, wordValue common.Hash, confs evmtypes.Confirmations) ([]Log, error)
 
 	// FilteredLogs accepts chainlink-common filtering DSL.
-	FilteredLogs(ctx context.Context, filter query.KeyFilter, limitAndSort query.LimitAndSort, queryName string) ([]Log, error)
+	FilteredLogs(ctx context.Context, filter []query.Expression, limitAndSort query.LimitAndSort, queryName string) ([]Log, error)
 }
 
 type DSORM struct {
@@ -964,9 +964,8 @@ func (o *DSORM) SelectIndexedLogsWithSigsExcluding(ctx context.Context, sigA, si
 	return logs, nil
 }
 
-// TODO flaky BCF-3258
-func (o *DSORM) FilteredLogs(ctx context.Context, filter query.KeyFilter, limitAndSort query.LimitAndSort, _ string) ([]Log, error) {
-	qs, args, err := (&pgDSLParser{}).buildQuery(o.chainID, filter.Expressions, limitAndSort)
+func (o *DSORM) FilteredLogs(ctx context.Context, filter []query.Expression, limitAndSort query.LimitAndSort, _ string) ([]Log, error) {
+	qs, args, err := (&pgDSLParser{}).buildQuery(o.chainID, filter, limitAndSort)
 	if err != nil {
 		return nil, err
 	}

--- a/core/chains/evm/logpoller/orm.go
+++ b/core/chains/evm/logpoller/orm.go
@@ -364,26 +364,24 @@ type Exp struct {
 //   - have a timestamp older than any matching filter's retention, UNLESS there is at
 //     least one matching filter with retention=0
 func (o *DSORM) DeleteExpiredLogs(ctx context.Context, limit int64) (int64, error) {
-	var err error
-	var result sql.Result
-	query := `DELETE FROM evm.logs
-		WHERE (evm_chain_id, address, event_sig, block_number) IN (
-			SELECT l.evm_chain_id, l.address, l.event_sig, l.block_number
-			FROM evm.logs l
-			LEFT JOIN (
+	limitClause := ""
+	if limit > 0 {
+		limitClause = fmt.Sprintf("LIMIT %d", limit)
+	}
+
+	query := fmt.Sprintf(`
+		WITH rows_to_delete AS (
+			SELECT l.id
+			FROM evm.logs l LEFT JOIN (
 				SELECT address, event, CASE WHEN MIN(retention) = 0 THEN 0 ELSE MAX(retention) END AS retention
 				FROM evm.log_poller_filters
 				WHERE evm_chain_id = $1
 				GROUP BY evm_chain_id, address, event
 			) r ON l.evm_chain_id = $1 AND l.address = r.address AND l.event_sig = r.event
-			WHERE r.retention IS NULL OR (r.retention != 0 AND l.block_timestamp <= STATEMENT_TIMESTAMP() - (r.retention / 10^9 * interval '1 second')) %s)`
-
-	if limit > 0 {
-		result, err = o.ds.ExecContext(ctx, fmt.Sprintf(query, "LIMIT $2"), ubig.New(o.chainID), limit)
-	} else {
-		result, err = o.ds.ExecContext(ctx, fmt.Sprintf(query, ""), ubig.New(o.chainID))
-	}
-
+			WHERE r.retention IS NULL OR (r.retention != 0 AND l.block_timestamp <= STATEMENT_TIMESTAMP() - (r.retention / 10^9 * interval '1 second''
+			%s
+		) DELETE FROM evm.logs WHERE id IN (SELECT id FROM rows_to_delete)`, limitClause)
+	result, err := o.ds.ExecContext(ctx, query, ubig.New(o.chainID))
 	if err != nil {
 		return 0, err
 	}

--- a/core/chains/evm/logpoller/orm.go
+++ b/core/chains/evm/logpoller/orm.go
@@ -185,9 +185,52 @@ func (o *DSORM) LoadFilters(ctx context.Context) (map[string]Filter, error) {
 	return filters, err
 }
 
+func blocksQuery(clause string) string {
+	return fmt.Sprintf(`SELECT %s FROM evm.log_poller_blocks %s`, strings.Join(blocksFields[:], ", "), clause)
+}
+func logsQuery(clause string) string {
+	return fmt.Sprintf(`SELECT %s FROM evm.logs %s`, strings.Join(logsFields[:], ", "), clause)
+}
+
+func logsQueryWithTablePrefix(tableAlias string, clause string) string {
+	var s strings.Builder
+	for i, field := range logsFields {
+		if i > 0 {
+			s.WriteString(", ")
+		}
+		s.WriteString(fmt.Sprintf("%s.%s", tableAlias, field))
+	}
+	return fmt.Sprintf(`SELECT %s FROM evm.logs AS %s %s`, s.String(), tableAlias, clause)
+}
+
+func withConfs(query string, tableAlias string, confs evmtypes.Confirmations) string {
+	var lastConfirmedBlock string
+
+	var tablePrefix string
+	if tableAlias != "" {
+		tablePrefix = tableAlias + "."
+	}
+	if confs == evmtypes.Finalized {
+		lastConfirmedBlock = `finalized_block_number`
+	} else {
+		lastConfirmedBlock = `block_number - :confs`
+	}
+	return fmt.Sprintf(`%s %sblock_number <= (
+			SELECT %s
+			FROM evm.log_poller_blocks
+			WHERE evm_chain_id = :evm_chain_id
+			ORDER BY block_number DESC LIMIT 1)`, query, tablePrefix, lastConfirmedBlock)
+}
+
+func logsQueryWithConfs(clause string, confs evmtypes.Confirmations) string {
+	return withConfs(logsQuery(clause), "", confs)
+}
+
 func (o *DSORM) SelectBlockByHash(ctx context.Context, hash common.Hash) (*LogPollerBlock, error) {
 	var b LogPollerBlock
-	if err := o.ds.GetContext(ctx, &b, `SELECT * FROM evm.log_poller_blocks WHERE block_hash = $1 AND evm_chain_id = $2`, hash.Bytes(), ubig.New(o.chainID)); err != nil {
+	if err := o.ds.GetContext(ctx, &b,
+		blocksQuery(`WHERE block_hash = $1 AND evm_chain_id = $2`),
+		hash.Bytes(), ubig.New(o.chainID)); err != nil {
 		return nil, err
 	}
 	return &b, nil
@@ -195,7 +238,9 @@ func (o *DSORM) SelectBlockByHash(ctx context.Context, hash common.Hash) (*LogPo
 
 func (o *DSORM) SelectBlockByNumber(ctx context.Context, n int64) (*LogPollerBlock, error) {
 	var b LogPollerBlock
-	if err := o.ds.GetContext(ctx, &b, `SELECT * FROM evm.log_poller_blocks WHERE block_number = $1 AND evm_chain_id = $2`, n, ubig.New(o.chainID)); err != nil {
+	if err := o.ds.GetContext(ctx, &b,
+		blocksQuery(`WHERE block_number = $1 AND evm_chain_id = $2`), n, ubig.New(o.chainID),
+	); err != nil {
 		return nil, err
 	}
 	return &b, nil
@@ -203,7 +248,9 @@ func (o *DSORM) SelectBlockByNumber(ctx context.Context, n int64) (*LogPollerBlo
 
 func (o *DSORM) SelectLatestBlock(ctx context.Context) (*LogPollerBlock, error) {
 	var b LogPollerBlock
-	if err := o.ds.GetContext(ctx, &b, `SELECT * FROM evm.log_poller_blocks WHERE evm_chain_id = $1 ORDER BY block_number DESC LIMIT 1`, ubig.New(o.chainID)); err != nil {
+	if err := o.ds.GetContext(ctx, &b,
+		blocksQuery(`WHERE evm_chain_id = $1 ORDER BY block_number DESC LIMIT 1`), ubig.New(o.chainID),
+	); err != nil {
 		return nil, err
 	}
 	return &b, nil
@@ -211,7 +258,10 @@ func (o *DSORM) SelectLatestBlock(ctx context.Context) (*LogPollerBlock, error) 
 
 func (o *DSORM) SelectOldestBlock(ctx context.Context, minAllowedBlockNumber int64) (*LogPollerBlock, error) {
 	var b LogPollerBlock
-	if err := o.ds.GetContext(ctx, &b, `SELECT * FROM evm.log_poller_blocks WHERE evm_chain_id = $1 AND block_number >= $2 ORDER BY block_number ASC LIMIT 1`, ubig.New(o.chainID), minAllowedBlockNumber); err != nil {
+	if err := o.ds.GetContext(ctx, &b,
+		blocksQuery(`WHERE evm_chain_id = $1 AND block_number >= $2 ORDER BY block_number ASC LIMIT 1`),
+		ubig.New(o.chainID), minAllowedBlockNumber,
+	); err != nil {
 		return nil, err
 	}
 	return &b, nil
@@ -224,15 +274,11 @@ func (o *DSORM) SelectLatestLogByEventSigWithConfs(ctx context.Context, eventSig
 	if err != nil {
 		return nil, err
 	}
-	query := fmt.Sprintf(`
-		SELECT * FROM evm.logs
-			WHERE evm_chain_id = :evm_chain_id
+	query := logsQueryWithConfs(
+		`WHERE evm_chain_id = :evm_chain_id
 			AND event_sig = :event_sig
-			AND address = :address
-			AND block_number <= %s
-			ORDER BY block_number desc, log_index DESC
-			LIMIT 1
-		`, nestedBlockNumberQuery(confs))
+			AND address = :address AND `, confs) +
+		` ORDER BY block_number desc, log_index DESC LIMIT 1`
 	var l Log
 
 	query, sqlArgs, err := o.ds.BindNamed(query, args)
@@ -256,8 +302,7 @@ func (o *DSORM) DeleteBlocksBefore(ctx context.Context, end int64, limit int64) 
             				WHERE block_number <= $1
             				AND evm_chain_id = $2
 							LIMIT $3
-						)
-						AND evm_chain_id = $2`,
+						) AND evm_chain_id = $2`,
 			end, ubig.New(o.chainID), limit)
 		if err != nil {
 			return 0, err
@@ -421,11 +466,11 @@ func (o *DSORM) SelectLogsByBlockRange(ctx context.Context, start, end int64) ([
 		return nil, err
 	}
 
-	query := `SELECT * FROM evm.logs
-        	WHERE evm_chain_id = :evm_chain_id
-        	AND block_number >= :start_block
-        	AND block_number <= :end_block
-        	ORDER BY block_number, log_index`
+	query := logsQuery(`
+        WHERE evm_chain_id = :evm_chain_id
+        AND block_number >= :start_block
+        AND block_number <= :end_block
+		ORDER BY block_number, log_index`)
 
 	var logs []Log
 	query, sqlArgs, err := o.ds.BindNamed(query, args)
@@ -450,13 +495,13 @@ func (o *DSORM) SelectLogs(ctx context.Context, start, end int64, address common
 		return nil, err
 	}
 
-	query := `SELECT * FROM evm.logs
-			WHERE evm_chain_id = :evm_chain_id
-			AND address = :address
-			AND event_sig = :event_sig
-			AND block_number >= :start_block
-			AND block_number <= :end_block
-			ORDER BY block_number, log_index`
+	query := logsQuery(`
+		WHERE evm_chain_id = :evm_chain_id
+		AND address = :address
+		AND event_sig = :event_sig
+		AND block_number >= :start_block
+		AND block_number <= :end_block
+		ORDER BY block_number, log_index`)
 
 	var logs []Log
 	query, sqlArgs, err := o.ds.BindNamed(query, args)
@@ -481,14 +526,12 @@ func (o *DSORM) SelectLogsCreatedAfter(ctx context.Context, address common.Addre
 		return nil, err
 	}
 
-	query := fmt.Sprintf(`
-		SELECT * FROM evm.logs
-				WHERE evm_chain_id = :evm_chain_id
-				AND address = :address
-				AND event_sig = :event_sig
-				AND block_timestamp > :block_timestamp_after
-				AND block_number <= %s
-				ORDER BY block_number, log_index`, nestedBlockNumberQuery(confs))
+	query := logsQueryWithConfs(
+		`WHERE evm_chain_id = :evm_chain_id
+			AND address = :address
+			AND event_sig = :event_sig
+			AND block_timestamp > :block_timestamp_after AND `, confs) +
+		`ORDER BY block_number, log_index`
 
 	var logs []Log
 	query, sqlArgs, err := o.ds.BindNamed(query, args)
@@ -515,12 +558,12 @@ func (o *DSORM) SelectLogsWithSigs(ctx context.Context, start, end int64, addres
 		return nil, err
 	}
 
-	query := `SELECT * FROM evm.logs
-				WHERE evm_chain_id = :evm_chain_id
-				AND address = :address
-				AND event_sig = ANY(:event_sig_array)
-				AND block_number BETWEEN :start_block AND :end_block
-				ORDER BY block_number, log_index`
+	query := logsQuery(`
+		WHERE evm_chain_id = :evm_chain_id
+		AND address = :address
+		AND event_sig = ANY(:event_sig_array)
+		AND block_number BETWEEN :start_block AND :end_block
+		ORDER BY block_number, log_index`)
 
 	query, sqlArgs, err := o.ds.BindNamed(query, args)
 	if err != nil {
@@ -543,11 +586,11 @@ func (o *DSORM) GetBlocksRange(ctx context.Context, start int64, end int64) ([]L
 		return nil, err
 	}
 
-	query := `SELECT * FROM evm.log_poller_blocks
+	query := blocksQuery(`
 			WHERE block_number >= :start_block
 			AND block_number <= :end_block
 			AND evm_chain_id = :evm_chain_id
-			ORDER BY block_number ASC`
+			ORDER BY block_number ASC`)
 
 	var blocks []LogPollerBlock
 	query, sqlArgs, err := o.ds.BindNamed(query, args)
@@ -574,17 +617,14 @@ func (o *DSORM) SelectLatestLogEventSigsAddrsWithConfs(ctx context.Context, from
 		return nil, err
 	}
 
-	query := fmt.Sprintf(`
-		SELECT * FROM evm.logs WHERE (block_number, address, event_sig) IN (
+	query := logsQueryWithConfs(`WHERE (block_number, address, event_sig) IN (
 			SELECT MAX(block_number), address, event_sig FROM evm.logs
 				WHERE evm_chain_id = :evm_chain_id
 				AND event_sig = ANY(:event_sig_array)
 				AND address = ANY(:address_array)
-				AND block_number > :start_block
-				AND block_number <= %s
-			GROUP BY event_sig, address
-		)
-		ORDER BY block_number ASC`, nestedBlockNumberQuery(confs))
+				AND block_number > :start_block AND `, confs) +
+		`GROUP BY event_sig, address)
+			ORDER BY block_number ASC`
 
 	var logs []Log
 	query, sqlArgs, err := o.ds.BindNamed(query, args)
@@ -609,13 +649,11 @@ func (o *DSORM) SelectLatestBlockByEventSigsAddrsWithConfs(ctx context.Context, 
 	if err != nil {
 		return 0, err
 	}
-	query := fmt.Sprintf(`
-		SELECT COALESCE(MAX(block_number), 0) FROM evm.logs
-			WHERE evm_chain_id = :evm_chain_id
-			AND event_sig = ANY(:event_sig_array)
-			AND address = ANY(:address_array)
-			AND block_number > :start_block
-			AND block_number <= %s`, nestedBlockNumberQuery(confs))
+	query := withConfs(`SELECT COALESCE(MAX(block_number), 0) FROM evm.logs
+		WHERE evm_chain_id = :evm_chain_id
+		AND event_sig = ANY(:event_sig_array)
+		AND address = ANY(:address_array)
+		AND block_number > :start_block AND `, "", confs)
 
 	var blockNumber int64
 	query, sqlArgs, err := o.ds.BindNamed(query, args)
@@ -640,14 +678,12 @@ func (o *DSORM) SelectLogsDataWordRange(ctx context.Context, address common.Addr
 		return nil, err
 	}
 
-	query := fmt.Sprintf(`SELECT * FROM evm.logs
-			WHERE evm_chain_id = :evm_chain_id
-			AND address = :address
-			AND event_sig = :event_sig
-			AND substring(data from 32*:word_index+1 for 32) >= :word_value_min
-			AND substring(data from 32*:word_index+1 for 32) <= :word_value_max
-			AND block_number <= %s
-			ORDER BY block_number, log_index`, nestedBlockNumberQuery(confs))
+	query := logsQueryWithConfs(`WHERE evm_chain_id = :evm_chain_id
+		AND address = :address
+		AND event_sig = :event_sig
+		AND substring(data from 32*:word_index+1 for 32) >= :word_value_min
+		AND substring(data from 32*:word_index+1 for 32) <= :word_value_max AND `, confs) +
+		`ORDER BY block_number, log_index`
 
 	var logs []Log
 	query, sqlArgs, err := o.ds.BindNamed(query, args)
@@ -671,14 +707,11 @@ func (o *DSORM) SelectLogsDataWordGreaterThan(ctx context.Context, address commo
 		return nil, err
 	}
 
-	query := fmt.Sprintf(`
-		SELECT * FROM evm.logs
-			WHERE evm_chain_id = :evm_chain_id
-			AND address = :address
-			AND event_sig = :event_sig
-			AND substring(data from 32*:word_index+1 for 32) >= :word_value_min
-			AND block_number <= %s
-			ORDER BY block_number, log_index`, nestedBlockNumberQuery(confs))
+	query := logsQueryWithConfs(`WHERE evm_chain_id = :evm_chain_id
+		AND address = :address
+		AND event_sig = :event_sig
+		AND substring(data from 32*:word_index+1 for 32) >= :word_value_min AND `, confs) +
+		`ORDER BY block_number, log_index`
 
 	var logs []Log
 	query, sqlArgs, err := o.ds.BindNamed(query, args)
@@ -702,15 +735,12 @@ func (o *DSORM) SelectLogsDataWordBetween(ctx context.Context, address common.Ad
 	if err != nil {
 		return nil, err
 	}
-	query := fmt.Sprintf(`
-		SELECT * FROM evm.logs
-			WHERE evm_chain_id = :evm_chain_id
-			AND address = :address
-			AND event_sig = :event_sig
-			AND substring(data from 32*:word_index_min+1 for 32) <= :word_value
-			AND substring(data from 32*:word_index_max+1 for 32) >= :word_value
-			AND block_number <= %s
-			ORDER BY block_number, log_index`, nestedBlockNumberQuery(confs))
+	query := logsQueryWithConfs(`WHERE evm_chain_id = :evm_chain_id
+		AND address = :address
+		AND event_sig = :event_sig
+		AND substring(data from 32*:word_index_min+1 for 32) <= :word_value
+		AND substring(data from 32*:word_index_max+1 for 32) >= :word_value AND `, confs) +
+		`ORDER BY block_number, log_index`
 
 	var logs []Log
 	query, sqlArgs, err := o.ds.BindNamed(query, args)
@@ -734,14 +764,11 @@ func (o *DSORM) SelectIndexedLogsTopicGreaterThan(ctx context.Context, address c
 		return nil, err
 	}
 
-	query := fmt.Sprintf(`
-		SELECT * FROM evm.logs
-			WHERE evm_chain_id = :evm_chain_id
-			AND address = :address
-			AND event_sig = :event_sig
-			AND topics[:topic_index] >= :topic_value_min
-			AND block_number <= %s
-			ORDER BY block_number, log_index`, nestedBlockNumberQuery(confs))
+	query := logsQueryWithConfs(`WHERE evm_chain_id = :evm_chain_id
+		AND address = :address
+		AND event_sig = :event_sig
+		AND topics[:topic_index] >= :topic_value_min AND `, confs) +
+		`ORDER BY block_number, log_index`
 
 	var logs []Log
 	query, sqlArgs, err := o.ds.BindNamed(query, args)
@@ -766,15 +793,12 @@ func (o *DSORM) SelectIndexedLogsTopicRange(ctx context.Context, address common.
 		return nil, err
 	}
 
-	query := fmt.Sprintf(`
-			SELECT * FROM evm.logs
-				WHERE evm_chain_id = :evm_chain_id
-				AND address = :address
-				AND event_sig = :event_sig
-				AND topics[:topic_index] >= :topic_value_min
-				AND topics[:topic_index] <= :topic_value_max
-				AND block_number <= %s
-			ORDER BY block_number, log_index`, nestedBlockNumberQuery(confs))
+	query := logsQueryWithConfs(`WHERE evm_chain_id = :evm_chain_id
+		AND address = :address
+		AND event_sig = :event_sig
+		AND topics[:topic_index] >= :topic_value_min
+		AND topics[:topic_index] <= :topic_value_max AND `, confs) +
+		`ORDER BY block_number, log_index`
 
 	var logs []Log
 	query, sqlArgs, err := o.ds.BindNamed(query, args)
@@ -798,14 +822,12 @@ func (o *DSORM) SelectIndexedLogs(ctx context.Context, address common.Address, e
 		return nil, err
 	}
 
-	query := fmt.Sprintf(`
-		SELECT * FROM evm.logs
-			WHERE evm_chain_id = :evm_chain_id
-			AND address = :address
-			AND event_sig = :event_sig
-			AND topics[:topic_index] = ANY(:topic_values)
-			AND block_number <= %s
-			ORDER BY block_number, log_index`, nestedBlockNumberQuery(confs))
+	query := logsQueryWithConfs(`
+		WHERE evm_chain_id = :evm_chain_id
+		AND address = :address
+		AND event_sig = :event_sig
+		AND topics[:topic_index] = ANY(:topic_values) AND `, confs) +
+		`ORDER BY block_number, log_index`
 
 	var logs []Log
 	query, sqlArgs, err := o.ds.BindNamed(query, args)
@@ -831,14 +853,14 @@ func (o *DSORM) SelectIndexedLogsByBlockRange(ctx context.Context, start, end in
 		return nil, err
 	}
 
-	query := `SELECT * FROM evm.logs
+	query := logsQuery(`
 				WHERE evm_chain_id = :evm_chain_id
 				AND address = :address
 				AND event_sig = :event_sig
 				AND topics[:topic_index] = ANY(:topic_values)
 				AND block_number >= :start_block
 				AND block_number <= :end_block
-				ORDER BY block_number, log_index`
+				ORDER BY block_number, log_index`)
 
 	var logs []Log
 	query, sqlArgs, err := o.ds.BindNamed(query, args)
@@ -864,16 +886,13 @@ func (o *DSORM) SelectIndexedLogsCreatedAfter(ctx context.Context, address commo
 		return nil, err
 	}
 
-	query := fmt.Sprintf(`
-		SELECT * FROM evm.logs
-			WHERE evm_chain_id = :evm_chain_id
-			AND address = :address
-			AND event_sig = :event_sig
-			AND topics[:topic_index] = ANY(:topic_values)
-			AND block_timestamp > :block_timestamp_after
-			AND block_number <= %s
-			ORDER BY block_number, log_index
-		`, nestedBlockNumberQuery(confs))
+	query := logsQueryWithConfs(`
+		WHERE evm_chain_id = :evm_chain_id
+		AND address = :address
+		AND event_sig = :event_sig
+		AND topics[:topic_index] = ANY(:topic_values)
+		AND block_timestamp > :block_timestamp_after AND `, confs) +
+		`ORDER BY block_number, log_index`
 
 	var logs []Log
 	query, sqlArgs, err := o.ds.BindNamed(query, args)
@@ -897,12 +916,12 @@ func (o *DSORM) SelectIndexedLogsByTxHash(ctx context.Context, address common.Ad
 		return nil, err
 	}
 
-	query := `SELECT * FROM evm.logs
+	query := logsQuery(`
 			WHERE evm_chain_id = :evm_chain_id
 			AND address = :address
 			AND event_sig = :event_sig
 			AND tx_hash = :tx_hash
-			ORDER BY block_number, log_index`
+			ORDER BY block_number, log_index`)
 
 	var logs []Log
 	query, sqlArgs, err := o.ds.BindNamed(query, args)
@@ -932,25 +951,22 @@ func (o *DSORM) SelectIndexedLogsWithSigsExcluding(ctx context.Context, sigA, si
 		return nil, err
 	}
 
-	nestedQuery := nestedBlockNumberQuery(confs)
-	query := fmt.Sprintf(`
-		SELECT * FROM   evm.logs
-		WHERE   evm_chain_id = :evm_chain_id
-		AND     address = :address
-		AND     event_sig = :sigA
-		AND 	block_number BETWEEN :start_block AND :end_block
-		AND 	block_number <= %s
-		EXCEPT
-		SELECT     a.* FROM       evm.logs AS a
-		INNER JOIN evm.logs B
-		ON         a.evm_chain_id = b.evm_chain_id
-		AND        a.address = b.address
-		AND        a.topics[:topic_index] = b.topics[:topic_index]
-		AND        a.event_sig = :sigA
-		AND        b.event_sig = :sigB
-	    AND 	   b.block_number BETWEEN :start_block AND :end_block
-		AND		   b.block_number <= %s
-		ORDER BY block_number, log_index`, nestedQuery, nestedQuery)
+	query := logsQueryWithConfs(`
+			WHERE      evm_chain_id = :evm_chain_id
+			AND        address = :address
+			AND        event_sig = :sigA
+			AND        block_number BETWEEN :start_block AND :end_block AND `, confs) +
+		` EXCEPT ` +
+		withConfs(logsQueryWithTablePrefix("a", `
+			INNER JOIN evm.logs AS b
+			ON         a.evm_chain_id = b.evm_chain_id
+			AND        a.address = b.address
+			AND        a.topics[:topic_index] = b.topics[:topic_index]
+			AND        a.event_sig = :sigA
+			AND        b.event_sig = :sigB
+			AND        b.block_number BETWEEN :start_block AND :end_block
+			AND `), "b", confs) +
+		` ORDER BY block_number, log_index`
 
 	var logs []Log
 	query, sqlArgs, err := o.ds.BindNamed(query, args)
@@ -986,21 +1002,4 @@ func (o *DSORM) FilteredLogs(ctx context.Context, filter []query.Expression, lim
 	}
 
 	return logs, nil
-}
-
-func nestedBlockNumberQuery(confs evmtypes.Confirmations) string {
-	if confs == evmtypes.Finalized {
-		return `
-				(SELECT finalized_block_number
-				FROM evm.log_poller_blocks
-				WHERE evm_chain_id = :evm_chain_id
-				ORDER BY block_number DESC LIMIT 1) `
-	}
-	// Intentionally wrap with greatest() function and don't return negative block numbers when :confs > :block_number
-	// It doesn't impact logic of the outer query, because block numbers are never less or equal to 0 (guarded by log_poller_blocks_block_number_check)
-	return `
-			(SELECT greatest(block_number - :confs, 0)
-			FROM evm.log_poller_blocks
-			WHERE evm_chain_id = :evm_chain_id
-			ORDER BY block_number DESC LIMIT 1) `
 }

--- a/core/chains/evm/logpoller/orm.go
+++ b/core/chains/evm/logpoller/orm.go
@@ -617,14 +617,17 @@ func (o *DSORM) SelectLatestLogEventSigsAddrsWithConfs(ctx context.Context, from
 		return nil, err
 	}
 
-	query := logsQueryWithConfs(`WHERE (block_number, address, event_sig) IN (
-			SELECT MAX(block_number), address, event_sig FROM evm.logs
+	query := logsQueryWithConfs(`WHERE id IN (
+			SELECT LAST_VALUE(id) OVER(
+				PARTITION BY evm_chain_id, address, event_sig
+				ORDER BY block_number, log_index
+				ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+			) FROM evm.logs
 				WHERE evm_chain_id = :evm_chain_id
-				AND event_sig = ANY(:event_sig_array)
-				AND address = ANY(:address_array)
-				AND block_number > :start_block AND `, confs) +
-		`GROUP BY event_sig, address)
-			ORDER BY block_number ASC`
+					AND event_sig = ANY(:event_sig_array)
+					AND address = ANY(:address_array)
+					AND block_number >= :start_block AND `, confs) + `
+			)`
 
 	var logs []Log
 	query, sqlArgs, err := o.ds.BindNamed(query, args)
@@ -653,7 +656,7 @@ func (o *DSORM) SelectLatestBlockByEventSigsAddrsWithConfs(ctx context.Context, 
 		WHERE evm_chain_id = :evm_chain_id
 		AND event_sig = ANY(:event_sig_array)
 		AND address = ANY(:address_array)
-		AND block_number > :start_block AND `, "", confs)
+		AND block_number >= :start_block AND `, "", confs)
 
 	var blockNumber int64
 	query, sqlArgs, err := o.ds.BindNamed(query, args)

--- a/core/chains/evm/logpoller/orm_test.go
+++ b/core/chains/evm/logpoller/orm_test.go
@@ -1556,7 +1556,7 @@ func TestSelectLatestBlockNumberEventSigsAddrsWithConfs(t *testing.T) {
 			events:              []common.Hash{event1, event2},
 			addrs:               []common.Address{address1, address2},
 			confs:               0,
-			fromBlock:           3,
+			fromBlock:           4,
 			expectedBlockNumber: 0,
 		},
 		{

--- a/core/chains/evm/logpoller/orm_test.go
+++ b/core/chains/evm/logpoller/orm_test.go
@@ -494,7 +494,17 @@ func TestORM(t *testing.T) {
 	// Delete expired logs without page limit
 	deleted, err = o1.DeleteExpiredLogs(ctx, 0)
 	require.NoError(t, err)
-	assert.Equal(t, int64(2), deleted)
+	assert.Equal(t, int64(1), deleted)
+
+	// Delete unmatched logs with page limit
+	ids, err := o1.SelectUnmatchedLogIDs(ctx, 2)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), ids)
+
+	// Delete unmatched logs without page limit
+	ids, err = o1.SelectUnmatchedLogIDs(ctx, 0)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), ids)
 
 	// Ensure that both of the logs from the second chain are still there
 	logs, err = o2.SelectLogs(ctx, 0, 100, common.HexToAddress("0x1236"), topic2)

--- a/core/chains/evm/logpoller/orm_test.go
+++ b/core/chains/evm/logpoller/orm_test.go
@@ -506,10 +506,10 @@ func TestORM(t *testing.T) {
 
 	logs, err = o1.SelectLogsByBlockRange(ctx, 1, latest.BlockNumber)
 	require.NoError(t, err)
-	// It should have retained the log matching filter0 (due to ret=0 meaning permanent retention) as well as all
-	// 3 logs matching filter12 (ret=1 hour). It should have deleted 3 logs not matching any filter, as well as 1
-	// of the 2 logs matching filter1 (ret=1ms)--the one that doesn't also match filter12.
-	assert.Len(t, logs, 4)
+	// The only log which should be deleted is the one which matches filter1 (ret=1ms) but not filter12 (ret=1 hour)
+	// Importantly, it shouldn't delete any logs matching only filter0 (ret=0 meaning permanent retention).  Anything
+	// matching filter12 should be kept regardless of what other filters it matches.
+	assert.Len(t, logs, 7)
 
 	// Delete logs after should delete all logs.
 	err = o1.DeleteLogsAndBlocksAfter(ctx, 1)

--- a/core/chains/evm/logpoller/orm_test.go
+++ b/core/chains/evm/logpoller/orm_test.go
@@ -457,20 +457,21 @@ func TestORM(t *testing.T) {
 	time.Sleep(2 * time.Millisecond) // just in case we haven't reached the end of the 1ms retention period
 	deleted, err := o1.DeleteExpiredLogs(ctx, 0)
 	require.NoError(t, err)
-	assert.Equal(t, int64(1), deleted)
+	assert.Equal(t, int64(4), deleted)
+
 	logs, err = o1.SelectLogsByBlockRange(ctx, 1, latest.BlockNumber)
 	require.NoError(t, err)
-	// The only log which should be deleted is the one which matches filter1 (ret=1ms) but not filter12 (ret=1 hour)
-	// Importantly, it shouldn't delete any logs matching only filter0 (ret=0 meaning permanent retention).  Anything
-	// matching filter12 should be kept regardless of what other filters it matches.
-	assert.Len(t, logs, 7)
+	// It should have retained the log matching filter0 (due to ret=0 meaning permanent retention) as well as all
+	// 3 logs matching filter12 (ret=1 hour). It should have deleted 3 logs not matching any filter, as well as 1
+	// of the 2 logs matching filter1 (ret=1ms)--the one that doesn't also match filter12.
+	assert.Len(t, logs, 4)
 
 	// Delete logs after should delete all logs.
 	err = o1.DeleteLogsAndBlocksAfter(ctx, 1)
 	require.NoError(t, err)
 	logs, err = o1.SelectLogsByBlockRange(ctx, 1, latest.BlockNumber)
 	require.NoError(t, err)
-	require.Zero(t, len(logs))
+	assert.Zero(t, len(logs))
 }
 
 type PgxLogger struct {

--- a/core/chains/evm/logpoller/orm_test.go
+++ b/core/chains/evm/logpoller/orm_test.go
@@ -187,6 +187,7 @@ func TestORM_GetBlocks_From_Range_Recent_Blocks(t *testing.T) {
 }
 
 func TestORM(t *testing.T) {
+	t.Parallel()
 	th := SetupTH(t, lpOpts)
 	o1 := th.ORM
 	o2 := th.ORM2
@@ -334,6 +335,36 @@ func TestORM(t *testing.T) {
 		},
 	}))
 
+	// Insert a couple logs on a different chain, to make sure
+	// these aren't affected by any operations on the chain LogPoller
+	// is managing.
+	require.NoError(t, o2.InsertLogs(ctx, []logpoller.Log{
+		{
+			EvmChainId:     ubig.New(th.ChainID2),
+			LogIndex:       8,
+			BlockHash:      common.HexToHash("0x1238"),
+			BlockNumber:    int64(17),
+			EventSig:       topic2,
+			Topics:         [][]byte{topic2[:]},
+			Address:        common.HexToAddress("0x1236"),
+			TxHash:         common.HexToHash("0x1888"),
+			Data:           []byte("same log on unrelated chain"),
+			BlockTimestamp: time.Now(),
+		},
+		{
+			EvmChainId:     ubig.New(th.ChainID2),
+			LogIndex:       9,
+			BlockHash:      common.HexToHash("0x1999"),
+			BlockNumber:    int64(18),
+			EventSig:       topic,
+			Topics:         [][]byte{topic[:], topic2[:]},
+			Address:        common.HexToAddress("0x5555"),
+			TxHash:         common.HexToHash("0x1543"),
+			Data:           []byte("different log on unrelated chain"),
+			BlockTimestamp: time.Now(),
+		},
+	}))
+
 	t.Log(latest.BlockNumber)
 	logs, err := o1.SelectLogsByBlockRange(ctx, 1, 17)
 	require.NoError(t, err)
@@ -454,18 +485,31 @@ func TestORM(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, logs, 8)
 
-	// Delete expired logs
+	// Delete expired logs with page limit
 	time.Sleep(2 * time.Millisecond) // just in case we haven't reached the end of the 1ms retention period
-	deleted, err := o1.DeleteExpiredLogs(ctx, 0)
+	deleted, err := o1.DeleteExpiredLogs(ctx, 2)
 	require.NoError(t, err)
-	assert.Equal(t, int64(1), deleted)
+	assert.Equal(t, int64(2), deleted)
+
+	// Delete expired logs without page limit
+	deleted, err = o1.DeleteExpiredLogs(ctx, 0)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), deleted)
+
+	// Ensure that both of the logs from the second chain are still there
+	logs, err = o2.SelectLogs(ctx, 0, 100, common.HexToAddress("0x1236"), topic2)
+	require.NoError(t, err)
+	assert.Len(t, logs, 1)
+	logs, err = o2.SelectLogs(ctx, 0, 100, common.HexToAddress("0x5555"), topic)
+	require.NoError(t, err)
+	assert.Len(t, logs, 1)
 
 	logs, err = o1.SelectLogsByBlockRange(ctx, 1, latest.BlockNumber)
 	require.NoError(t, err)
-	// The only log which should be deleted is the one which matches filter1 (ret=1ms) but not filter12 (ret=1 hour)
-	// Importantly, it shouldn't delete any logs matching only filter0 (ret=0 meaning permanent retention).  Anything
-	// matching filter12 should be kept regardless of what other filters it matches.
-	assert.Len(t, logs, 7)
+	// It should have retained the log matching filter0 (due to ret=0 meaning permanent retention) as well as all
+	// 3 logs matching filter12 (ret=1 hour). It should have deleted 3 logs not matching any filter, as well as 1
+	// of the 2 logs matching filter1 (ret=1ms)--the one that doesn't also match filter12.
+	assert.Len(t, logs, 4)
 
 	// Delete logs after should delete all logs.
 	err = o1.DeleteLogsAndBlocksAfter(ctx, 1)
@@ -606,8 +650,8 @@ func TestORM_IndexedLogs(t *testing.T) {
 		}
 
 		for idx, value := range topicValues {
-			topicFilters.Expressions[idx] = logpoller.NewEventByTopicFilter(topicIdx, []primitives.ValueComparator{
-				{Value: logpoller.EvmWord(value).Hex(), Operator: primitives.Eq},
+			topicFilters.Expressions[idx] = logpoller.NewEventByTopicFilter(topicIdx, []logpoller.HashedValueComparator{
+				{Value: logpoller.EvmWord(value), Operator: primitives.Eq},
 			})
 		}
 
@@ -658,7 +702,7 @@ func TestORM_IndexedLogs(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(lgs))
 
-	lgs, err = o1.FilteredLogs(ctx, blockRangeFilter(1, 1, 1, []uint64{1}), limiter, "")
+	lgs, err = o1.FilteredLogs(ctx, blockRangeFilter("1", "1", 1, []uint64{1}), limiter, "")
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(lgs))
 
@@ -666,7 +710,7 @@ func TestORM_IndexedLogs(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(lgs))
 
-	lgs, err = o1.FilteredLogs(ctx, blockRangeFilter(1, 2, 1, []uint64{2}), limiter, "")
+	lgs, err = o1.FilteredLogs(ctx, blockRangeFilter("1", "2", 1, []uint64{2}), limiter, "")
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(lgs))
 
@@ -674,7 +718,7 @@ func TestORM_IndexedLogs(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(lgs))
 
-	lgs, err = o1.FilteredLogs(ctx, blockRangeFilter(1, 2, 1, []uint64{1}), limiter, "")
+	lgs, err = o1.FilteredLogs(ctx, blockRangeFilter("1", "2", 1, []uint64{1}), limiter, "")
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(lgs))
 
@@ -682,7 +726,7 @@ func TestORM_IndexedLogs(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid index for topic: 0")
 
-	_, err = o1.FilteredLogs(ctx, blockRangeFilter(1, 2, 0, []uint64{1}), limiter, "")
+	_, err = o1.FilteredLogs(ctx, blockRangeFilter("1", "2", 0, []uint64{1}), limiter, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid index for topic: 0")
 
@@ -690,7 +734,7 @@ func TestORM_IndexedLogs(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid index for topic: 4")
 
-	_, err = o1.FilteredLogs(ctx, blockRangeFilter(1, 2, 4, []uint64{1}), limiter, "")
+	_, err = o1.FilteredLogs(ctx, blockRangeFilter("1", "2", 4, []uint64{1}), limiter, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid index for topic: 4")
 
@@ -702,8 +746,8 @@ func TestORM_IndexedLogs(t *testing.T) {
 		Expressions: []query.Expression{
 			logpoller.NewAddressFilter(addr),
 			logpoller.NewEventSigFilter(eventSig),
-			logpoller.NewEventByTopicFilter(1, []primitives.ValueComparator{
-				{Value: logpoller.EvmWord(2).Hex(), Operator: primitives.Gte},
+			logpoller.NewEventByTopicFilter(1, []logpoller.HashedValueComparator{
+				{Value: logpoller.EvmWord(2), Operator: primitives.Gte},
 			}),
 			query.Confidence(primitives.Unconfirmed),
 		},
@@ -717,11 +761,11 @@ func TestORM_IndexedLogs(t *testing.T) {
 		return []query.Expression{
 			logpoller.NewAddressFilter(addr),
 			logpoller.NewEventSigFilter(eventSig),
-			logpoller.NewEventByTopicFilter(topicIdx, []primitives.ValueComparator{
-				{Value: logpoller.EvmWord(min).Hex(), Operator: primitives.Gte},
+			logpoller.NewEventByTopicFilter(topicIdx, []logpoller.HashedValueComparator{
+				{Value: logpoller.EvmWord(min), Operator: primitives.Gte},
 			}),
-			logpoller.NewEventByTopicFilter(topicIdx, []primitives.ValueComparator{
-				{Value: logpoller.EvmWord(max).Hex(), Operator: primitives.Lte},
+			logpoller.NewEventByTopicFilter(topicIdx, []logpoller.HashedValueComparator{
+				{Value: logpoller.EvmWord(max), Operator: primitives.Lte},
 			}),
 			query.Confidence(primitives.Unconfirmed),
 		}
@@ -876,11 +920,11 @@ func TestORM_DataWords(t *testing.T) {
 		return []query.Expression{
 			logpoller.NewAddressFilter(addr),
 			logpoller.NewEventSigFilter(eventSig),
-			logpoller.NewEventByWordFilter(eventSig, wordIdx, []primitives.ValueComparator{
-				{Value: logpoller.EvmWord(word1).Hex(), Operator: primitives.Gte},
+			logpoller.NewEventByWordFilter(wordIdx, []logpoller.HashedValueComparator{
+				{Value: logpoller.EvmWord(word1), Operator: primitives.Gte},
 			}),
-			logpoller.NewEventByWordFilter(eventSig, wordIdx, []primitives.ValueComparator{
-				{Value: logpoller.EvmWord(word2).Hex(), Operator: primitives.Lte},
+			logpoller.NewEventByWordFilter(wordIdx, []logpoller.HashedValueComparator{
+				{Value: logpoller.EvmWord(word2), Operator: primitives.Lte},
 			}),
 			query.Confidence(primitives.Unconfirmed),
 		}
@@ -944,8 +988,8 @@ func TestORM_DataWords(t *testing.T) {
 	filter := []query.Expression{
 		logpoller.NewAddressFilter(addr),
 		logpoller.NewEventSigFilter(eventSig),
-		logpoller.NewEventByWordFilter(eventSig, 0, []primitives.ValueComparator{
-			{Value: logpoller.EvmWord(1).Hex(), Operator: primitives.Gte},
+		logpoller.NewEventByWordFilter(0, []logpoller.HashedValueComparator{
+			{Value: logpoller.EvmWord(1), Operator: primitives.Gte},
 		}),
 		query.Confidence(primitives.Unconfirmed),
 	}
@@ -1036,7 +1080,7 @@ func TestORM_SelectLogsWithSigsByBlockRangeFilter(t *testing.T) {
 	}
 	require.NoError(t, o1.InsertLogs(ctx, inputLogs))
 
-	filter := func(sigs []common.Hash, startBlock, endBlock int64) query.KeyFilter {
+	filter := func(sigs []common.Hash, startBlock, endBlock string) query.KeyFilter {
 		filters := []query.Expression{
 			logpoller.NewAddressFilter(sourceAddr),
 		}
@@ -1058,8 +1102,8 @@ func TestORM_SelectLogsWithSigsByBlockRangeFilter(t *testing.T) {
 		filters = append(filters, query.Expression{
 			BoolExpression: query.BoolExpression{
 				Expressions: []query.Expression{
-					query.Block(uint64(startBlock), primitives.Gte),
-					query.Block(uint64(endBlock), primitives.Lte),
+					query.Block(startBlock, primitives.Gte),
+					query.Block(endBlock, primitives.Lte),
 				},
 				BoolOperator: query.AND,
 			},
@@ -1172,7 +1216,7 @@ func TestLogPoller_Logs(t *testing.T) {
 	assert.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000005", lgs[1].BlockHash.String())
 	assert.Equal(t, address1, lgs[1].Address)
 
-	lgs, err = th.ORM.FilteredLogs(ctx, logFilter(1, 3, address1), query.LimitAndSort{
+	lgs, err = th.ORM.FilteredLogs(ctx, logFilter("1", "3", address1), query.LimitAndSort{
 		SortBy: []query.SortBy{query.NewSortBySequence(query.Asc)},
 	}, "")
 	require.NoError(t, err)
@@ -1192,7 +1236,7 @@ func TestLogPoller_Logs(t *testing.T) {
 	assert.Equal(t, address2, lgs[0].Address)
 	assert.Equal(t, event1.Bytes(), lgs[0].Topics[0])
 
-	lgs, err = th.ORM.FilteredLogs(ctx, logFilter(2, 2, address2), query.LimitAndSort{
+	lgs, err = th.ORM.FilteredLogs(ctx, logFilter("2", "2", address2), query.LimitAndSort{
 		SortBy: []query.SortBy{query.NewSortBySequence(query.Asc)},
 	}, "")
 	require.NoError(t, err)
@@ -1667,8 +1711,8 @@ func TestSelectLogsCreatedAfter(t *testing.T) {
 		if len(topicVals) > 0 {
 			exp := make([]query.Expression, len(topicVals))
 			for idx, val := range topicVals {
-				exp[idx] = logpoller.NewEventByTopicFilter(uint64(topicIdx), []primitives.ValueComparator{
-					{Value: val.String(), Operator: primitives.Eq},
+				exp[idx] = logpoller.NewEventByTopicFilter(uint64(topicIdx), []logpoller.HashedValueComparator{
+					{Value: val, Operator: primitives.Eq},
 				})
 			}
 
@@ -1955,11 +1999,11 @@ func TestSelectLogsDataWordBetween(t *testing.T) {
 			Expressions: []query.Expression{
 				logpoller.NewAddressFilter(address),
 				logpoller.NewEventSigFilter(eventSig),
-				logpoller.NewEventByWordFilter(eventSig, 0, []primitives.ValueComparator{
-					{Value: logpoller.EvmWord(word).Hex(), Operator: primitives.Lte},
+				logpoller.NewEventByWordFilter(0, []logpoller.HashedValueComparator{
+					{Value: logpoller.EvmWord(word), Operator: primitives.Lte},
 				}),
-				logpoller.NewEventByWordFilter(eventSig, 1, []primitives.ValueComparator{
-					{Value: logpoller.EvmWord(word).Hex(), Operator: primitives.Gte},
+				logpoller.NewEventByWordFilter(1, []logpoller.HashedValueComparator{
+					{Value: logpoller.EvmWord(word), Operator: primitives.Gte},
 				}),
 				query.Confidence(primitives.Unconfirmed),
 			},

--- a/core/chains/evm/logpoller/orm_test.go
+++ b/core/chains/evm/logpoller/orm_test.go
@@ -458,14 +458,14 @@ func TestORM(t *testing.T) {
 	time.Sleep(2 * time.Millisecond) // just in case we haven't reached the end of the 1ms retention period
 	deleted, err := o1.DeleteExpiredLogs(ctx, 0)
 	require.NoError(t, err)
-	assert.Equal(t, int64(4), deleted)
+	assert.Equal(t, int64(1), deleted)
 
 	logs, err = o1.SelectLogsByBlockRange(ctx, 1, latest.BlockNumber)
 	require.NoError(t, err)
-	// It should have retained the log matching filter0 (due to ret=0 meaning permanent retention) as well as all
-	// 3 logs matching filter12 (ret=1 hour). It should have deleted 3 logs not matching any filter, as well as 1
-	// of the 2 logs matching filter1 (ret=1ms)--the one that doesn't also match filter12.
-	assert.Len(t, logs, 4)
+	// The only log which should be deleted is the one which matches filter1 (ret=1ms) but not filter12 (ret=1 hour)
+	// Importantly, it shouldn't delete any logs matching only filter0 (ret=0 meaning permanent retention).  Anything
+	// matching filter12 should be kept regardless of what other filters it matches.
+	assert.Len(t, logs, 7)
 
 	// Delete logs after should delete all logs.
 	err = o1.DeleteLogsAndBlocksAfter(ctx, 1)

--- a/core/chains/evm/logpoller/orm_test.go
+++ b/core/chains/evm/logpoller/orm_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"strconv"
 	"testing"
 	"time"
 
@@ -630,7 +631,7 @@ func TestORM_IndexedLogs(t *testing.T) {
 	require.Equal(t, 1, len(lgs))
 	assert.Equal(t, logpoller.EvmWord(1).Bytes(), lgs[0].GetTopics()[1].Bytes())
 
-	lgs, err = o1.FilteredLogs(ctx, standardFilter(1, []uint64{1}), limiter, "")
+	lgs, err = o1.FilteredLogs(ctx, standardFilter(1, []uint64{1}).Expressions, limiter, "")
 	require.NoError(t, err)
 	require.Equal(t, 1, len(lgs))
 	assert.Equal(t, logpoller.EvmWord(1).Bytes(), lgs[0].GetTopics()[1].Bytes())
@@ -639,19 +640,17 @@ func TestORM_IndexedLogs(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(lgs))
 
-	lgs, err = o1.FilteredLogs(ctx, standardFilter(1, []uint64{1, 2}), limiter, "")
+	lgs, err = o1.FilteredLogs(ctx, standardFilter(1, []uint64{1, 2}).Expressions, limiter, "")
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(lgs))
 
-	blockRangeFilter := func(start, end uint64, topicIdx uint64, topicValues []uint64) query.KeyFilter {
-		return query.KeyFilter{
-			Expressions: []query.Expression{
-				logpoller.NewAddressFilter(addr),
-				logpoller.NewEventSigFilter(eventSig),
-				filtersForTopics(topicIdx, topicValues),
-				query.Block(start, primitives.Gte),
-				query.Block(end, primitives.Lte),
-			},
+	blockRangeFilter := func(start, end string, topicIdx uint64, topicValues []uint64) []query.Expression {
+		return []query.Expression{
+			logpoller.NewAddressFilter(addr),
+			logpoller.NewEventSigFilter(eventSig),
+			filtersForTopics(topicIdx, topicValues),
+			query.Block(start, primitives.Gte),
+			query.Block(end, primitives.Lte),
 		}
 	}
 
@@ -710,23 +709,21 @@ func TestORM_IndexedLogs(t *testing.T) {
 		},
 	}
 
-	lgs, err = o1.FilteredLogs(ctx, filter, limiter, "")
+	lgs, err = o1.FilteredLogs(ctx, filter.Expressions, limiter, "")
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(lgs))
 
-	rangeFilter := func(topicIdx uint64, min, max uint64) query.KeyFilter {
-		return query.KeyFilter{
-			Expressions: []query.Expression{
-				logpoller.NewAddressFilter(addr),
-				logpoller.NewEventSigFilter(eventSig),
-				logpoller.NewEventByTopicFilter(topicIdx, []primitives.ValueComparator{
-					{Value: logpoller.EvmWord(min).Hex(), Operator: primitives.Gte},
-				}),
-				logpoller.NewEventByTopicFilter(topicIdx, []primitives.ValueComparator{
-					{Value: logpoller.EvmWord(max).Hex(), Operator: primitives.Lte},
-				}),
-				query.Confidence(primitives.Unconfirmed),
-			},
+	rangeFilter := func(topicIdx uint64, min, max uint64) []query.Expression {
+		return []query.Expression{
+			logpoller.NewAddressFilter(addr),
+			logpoller.NewEventSigFilter(eventSig),
+			logpoller.NewEventByTopicFilter(topicIdx, []primitives.ValueComparator{
+				{Value: logpoller.EvmWord(min).Hex(), Operator: primitives.Gte},
+			}),
+			logpoller.NewEventByTopicFilter(topicIdx, []primitives.ValueComparator{
+				{Value: logpoller.EvmWord(max).Hex(), Operator: primitives.Lte},
+			}),
+			query.Confidence(primitives.Unconfirmed),
 		}
 	}
 
@@ -834,7 +831,7 @@ func TestORM_SelectIndexedLogsByTxHash(t *testing.T) {
 		},
 	}
 
-	retrievedLogs, err = o1.FilteredLogs(ctx, filter, limiter, "")
+	retrievedLogs, err = o1.FilteredLogs(ctx, filter.Expressions, limiter, "")
 	require.NoError(t, err)
 
 	require.Equal(t, 2, len(retrievedLogs))
@@ -875,19 +872,17 @@ func TestORM_DataWords(t *testing.T) {
 		},
 	}))
 
-	wordFilter := func(wordIdx uint8, word1, word2 uint64) query.KeyFilter {
-		return query.KeyFilter{
-			Expressions: []query.Expression{
-				logpoller.NewAddressFilter(addr),
-				logpoller.NewEventSigFilter(eventSig),
-				logpoller.NewEventByWordFilter(eventSig, wordIdx, []primitives.ValueComparator{
-					{Value: logpoller.EvmWord(word1).Hex(), Operator: primitives.Gte},
-				}),
-				logpoller.NewEventByWordFilter(eventSig, wordIdx, []primitives.ValueComparator{
-					{Value: logpoller.EvmWord(word2).Hex(), Operator: primitives.Lte},
-				}),
-				query.Confidence(primitives.Unconfirmed),
-			},
+	wordFilter := func(wordIdx uint8, word1, word2 uint64) []query.Expression {
+		return []query.Expression{
+			logpoller.NewAddressFilter(addr),
+			logpoller.NewEventSigFilter(eventSig),
+			logpoller.NewEventByWordFilter(eventSig, wordIdx, []primitives.ValueComparator{
+				{Value: logpoller.EvmWord(word1).Hex(), Operator: primitives.Gte},
+			}),
+			logpoller.NewEventByWordFilter(eventSig, wordIdx, []primitives.ValueComparator{
+				{Value: logpoller.EvmWord(word2).Hex(), Operator: primitives.Lte},
+			}),
+			query.Confidence(primitives.Unconfirmed),
 		}
 	}
 
@@ -946,15 +941,13 @@ func TestORM_DataWords(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(lgs))
 
-	filter := query.KeyFilter{
-		Expressions: []query.Expression{
-			logpoller.NewAddressFilter(addr),
-			logpoller.NewEventSigFilter(eventSig),
-			logpoller.NewEventByWordFilter(eventSig, 0, []primitives.ValueComparator{
-				{Value: logpoller.EvmWord(1).Hex(), Operator: primitives.Gte},
-			}),
-			query.Confidence(primitives.Unconfirmed),
-		},
+	filter := []query.Expression{
+		logpoller.NewAddressFilter(addr),
+		logpoller.NewEventSigFilter(eventSig),
+		logpoller.NewEventByWordFilter(eventSig, 0, []primitives.ValueComparator{
+			{Value: logpoller.EvmWord(1).Hex(), Operator: primitives.Gte},
+		}),
+		query.Confidence(primitives.Unconfirmed),
 	}
 
 	lgs, err = o1.FilteredLogs(ctx, filter, limiter, "")
@@ -1098,8 +1091,7 @@ func TestORM_SelectLogsWithSigsByBlockRangeFilter(t *testing.T) {
 	})
 
 	assertion(t, logs, err, startBlock, endBlock)
-
-	logs, err = th.ORM.FilteredLogs(ctx, filter([]common.Hash{topic, topic2}, startBlock, endBlock), limiter, "")
+	logs, err = th.ORM.FilteredLogs(ctx, filter([]common.Hash{topic, topic2}, strconv.Itoa(int(startBlock)), strconv.Itoa(int(endBlock))).Expressions, limiter, "")
 
 	assertion(t, logs, err, startBlock, endBlock)
 }
@@ -1161,14 +1153,12 @@ func TestLogPoller_Logs(t *testing.T) {
 	assert.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000005", lgs[4].BlockHash.String())
 	assert.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000005", lgs[5].BlockHash.String())
 
-	logFilter := func(start, end uint64, address common.Address) query.KeyFilter {
-		return query.KeyFilter{
-			Expressions: []query.Expression{
-				logpoller.NewAddressFilter(address),
-				logpoller.NewEventSigFilter(event1),
-				query.Block(start, primitives.Gte),
-				query.Block(end, primitives.Lte),
-			},
+	logFilter := func(start, end string, address common.Address) []query.Expression {
+		return []query.Expression{
+			logpoller.NewAddressFilter(address),
+			logpoller.NewEventSigFilter(event1),
+			query.Block(start, primitives.Gte),
+			query.Block(end, primitives.Lte),
 		}
 	}
 
@@ -1722,7 +1712,7 @@ func TestSelectLogsCreatedAfter(t *testing.T) {
 
 			assertion(t, logs, err, tt.expectedLogs)
 
-			logs, err = th.ORM.FilteredLogs(ctx, filter(tt.after, tt.confs, 0, nil), limiter, "")
+			logs, err = th.ORM.FilteredLogs(ctx, filter(tt.after, tt.confs, 0, nil).Expressions, limiter, "")
 
 			assertion(t, logs, err, tt.expectedLogs)
 		})
@@ -1735,7 +1725,7 @@ func TestSelectLogsCreatedAfter(t *testing.T) {
 
 				assertion(t, logs, err, tt.expectedLogs)
 
-				logs, err = th.ORM.FilteredLogs(ctx, filter(tt.after, tt.confs, 1, []common.Hash{event}), limiter, "")
+				logs, err = th.ORM.FilteredLogs(ctx, filter(tt.after, tt.confs, 1, []common.Hash{event}).Expressions, limiter, "")
 
 				assertion(t, logs, err, tt.expectedLogs)
 			})
@@ -1991,7 +1981,7 @@ func TestSelectLogsDataWordBetween(t *testing.T) {
 
 			assertion(t, logs, err, tt.expectedLogs)
 
-			logs, err = th.ORM.FilteredLogs(ctx, wordFilter(tt.wordValue), limiter, "")
+			logs, err = th.ORM.FilteredLogs(ctx, wordFilter(tt.wordValue).Expressions, limiter, "")
 
 			assertion(t, logs, err, tt.expectedLogs)
 		})

--- a/core/chains/evm/logpoller/parser.go
+++ b/core/chains/evm/logpoller/parser.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives"
+
 	evmtypes "github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
 )
 
@@ -26,6 +27,10 @@ const (
 
 var (
 	ErrUnexpectedCursorFormat = errors.New("unexpected cursor format")
+	logsFields                = [...]string{"evm_chain_id", "log_index", "block_hash", "block_number",
+		"address", "event_sig", "topics", "tx_hash", "data", "created_at", "block_timestamp"}
+	blocksFields = [...]string{"evm_chain_id", "block_hash", "block_number", "block_timestamp",
+		"finalized_block_number", "created_at"}
 )
 
 // The parser builds SQL expressions piece by piece for each Accept function call and resets the error and expression
@@ -220,7 +225,7 @@ func (v *pgDSLParser) buildQuery(chainID *big.Int, expressions []query.Expressio
 	v.err = nil
 
 	// build the query string
-	clauses := []string{"SELECT evm.logs.* FROM evm.logs"}
+	clauses := []string{logsQuery("")}
 
 	where, err := v.whereClause(expressions, limiter)
 	if err != nil {

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/reader.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/reader.go
@@ -29,14 +29,18 @@ const (
 	// be able to bring back processing without replaying any logs from chain. You can read that param as
 	// "how long CCIP can be down and still be able to process all the messages after getting back to life".
 	// Breaching this threshold would require replaying chain using LogPoller from the beginning of the outage.
-	CommitExecLogsRetention = 30 * 24 * time.Hour // 30 days
+
+	CommitExecLogsRetention = 3 * time.Hour // 3 hours for testing TODO: REMOVE FOR PRODUCTION!
+
 	// CacheEvictionLogsRetention defines the duration for which logs used for caching on-chain data are kept.
 	// Restarting node clears the cache entirely and rebuilds it from scratch by fetching data from chain,
 	// so we don't need to keep these logs for very long. All events relying on cache.NewLogpollerEventsBased should use this retention.
-	CacheEvictionLogsRetention = 7 * 24 * time.Hour // 7 days
+
+	CacheEvictionLogsRetention = 1 * time.Hour // 1 hour for testing TODO: REMOVE FOR PRODUCTION!
+
 	// PriceUpdatesLogsRetention defines the duration for which logs with price updates are kept.
 	// These logs are emitted whenever the token price or gas price is updated and Commit scans very small time windows (e.g. 2 hours)
-	PriceUpdatesLogsRetention = 1 * 24 * time.Hour // 1 day
+	PriceUpdatesLogsRetention = 5 * time.Minute // 5 minutes for testing TODO: REMOVE FOR PRODUCTION!
 )
 
 type Event[T any] struct {

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/reader.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/reader.go
@@ -29,18 +29,14 @@ const (
 	// be able to bring back processing without replaying any logs from chain. You can read that param as
 	// "how long CCIP can be down and still be able to process all the messages after getting back to life".
 	// Breaching this threshold would require replaying chain using LogPoller from the beginning of the outage.
-
-	CommitExecLogsRetention = 3 * time.Hour // 3 hours for testing TODO: REMOVE FOR PRODUCTION!
-
+	CommitExecLogsRetention = 30 * 24 * time.Hour // 30 days
 	// CacheEvictionLogsRetention defines the duration for which logs used for caching on-chain data are kept.
 	// Restarting node clears the cache entirely and rebuilds it from scratch by fetching data from chain,
 	// so we don't need to keep these logs for very long. All events relying on cache.NewLogpollerEventsBased should use this retention.
-
-	CacheEvictionLogsRetention = 1 * time.Hour // 1 hour for testing TODO: REMOVE FOR PRODUCTION!
-
+	CacheEvictionLogsRetention = 7 * 24 * time.Hour // 7 days
 	// PriceUpdatesLogsRetention defines the duration for which logs with price updates are kept.
 	// These logs are emitted whenever the token price or gas price is updated and Commit scans very small time windows (e.g. 2 hours)
-	PriceUpdatesLogsRetention = 5 * time.Minute // 5 minutes for testing TODO: REMOVE FOR PRODUCTION!
+	PriceUpdatesLogsRetention = 1 * 24 * time.Hour // 1 day
 )
 
 type Event[T any] struct {

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_0_0/commit_store.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_0_0/commit_store.go
@@ -336,8 +336,7 @@ func (c *CommitStore) GetAcceptedCommitReportsGteTimestamp(ctx context.Context, 
 		return nil, err
 	}
 
-	reportsQuery, err := query.Where(
-		c.address.String(),
+	reportsQuery, err := logpoller.Where(
 		logpoller.NewAddressFilter(c.address),
 		logpoller.NewEventSigFilter(c.reportAcceptedSig),
 		query.Timestamp(uint64(ts.Unix()), primitives.Gte),

--- a/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_2_0/commit_store.go
+++ b/core/services/ocr2/plugins/ccip/internal/ccipdata/v1_2_0/commit_store.go
@@ -351,8 +351,7 @@ func (c *CommitStore) GetAcceptedCommitReportsGteTimestamp(ctx context.Context, 
 		return nil, err
 	}
 
-	reportsQuery, err := query.Where(
-		c.address.String(),
+	reportsQuery, err := logpoller.Where(
 		logpoller.NewAddressFilter(c.address),
 		logpoller.NewEventSigFilter(c.reportAcceptedSig),
 		query.Timestamp(uint64(ts.Unix()), primitives.Gte),

--- a/core/services/relay/evm/event_binding.go
+++ b/core/services/relay/evm/event_binding.go
@@ -168,7 +168,7 @@ func (e *eventBinding) QueryKey(ctx context.Context, filter query.KeyFilter, lim
 	}
 	remapped.Expressions = append(defaultExpressions, remapped.Expressions...)
 
-	logs, err := e.lp.FilteredLogs(ctx, remapped, limitAndSort, e.contractName+"-"+e.eventName)
+	logs, err := e.lp.FilteredLogs(ctx, remapped.Expressions, limitAndSort, e.contractName+"-"+e.address.String()+"-"+e.eventName)
 	if err != nil {
 		return nil, err
 	}
@@ -224,13 +224,7 @@ func (e *eventBinding) getLatestValueWithFilters(
 		return err
 	}
 
-	fai := filtersAndIndices[0]
 	remainingFilters := filtersAndIndices[1:]
-
-	logs, err := e.lp.IndexedLogs(ctx, e.hash, e.address, 1, []common.Hash{fai}, confs)
-	if err != nil {
-		return wrapInternalErr(err)
-	}
 
 	// TODO Use filtered logs here BCF-3316
 	// TODO: there should be a better way to ask log poller to filter these

--- a/core/services/relay/evm/event_binding.go
+++ b/core/services/relay/evm/event_binding.go
@@ -224,7 +224,13 @@ func (e *eventBinding) getLatestValueWithFilters(
 		return err
 	}
 
+	fai := filtersAndIndices[0]
 	remainingFilters := filtersAndIndices[1:]
+
+	logs, err := e.lp.IndexedLogs(ctx, e.hash, e.address, 1, []common.Hash{fai}, confs)
+	if err != nil {
+		return wrapInternalErr(err)
+	}
 
 	// TODO Use filtered logs here BCF-3316
 	// TODO: there should be a better way to ask log poller to filter these

--- a/core/store/migrate/migrations/0248_log_poller_primary_keys.sql
+++ b/core/store/migrate/migrations/0248_log_poller_primary_keys.sql
@@ -1,0 +1,18 @@
+-- +goose Up
+
+ALTER TABLE evm.logs DROP CONSTRAINT logs_pkey;
+ALTER TABLE evm.logs ADD COLUMN id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY;
+CREATE UNIQUE INDEX idx_evm_logs_block_hash_log_index_evm_chain_id ON evm.logs (block_hash, log_index, evm_chain_id);
+ALTER TABLE evm.log_poller_blocks  DROP CONSTRAINT log_poller_blocks_pkey;
+ALTER TABLE evm.log_poller_blocks ADD COLUMN id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY;
+CREATE UNIQUE INDEX idx_evm_log_poller_blocks_block_number_evm_chain_id ON evm.log_poller_blocks (block_number, evm_chain_id);
+
+-- +goose Down
+
+DROP INDEX IF EXISTS evm.idx_evm_log_poller_blocks_block_number_evm_chain_id;
+ALTER TABLE evm.log_poller_blocks DROP COLUMN id;
+ALTER TABLE evm.log_poller_blocks ADD PRIMARY KEY (block_number, evm_chain_id);
+DROP INDEX IF EXISTS evm.idx_evm_logs_block_hash_log_index_evm_chain_id;
+ALTER TABLE evm.logs DROP COLUMN id;
+ALTER TABLE evm.logs ADD PRIMARY KEY (block_hash, log_index, evm_chain_id);
+

--- a/core/store/migrate/migrations/0248_log_poller_primary_keys.sql
+++ b/core/store/migrate/migrations/0248_log_poller_primary_keys.sql
@@ -2,17 +2,25 @@
 
 ALTER TABLE evm.logs DROP CONSTRAINT logs_pkey;
 ALTER TABLE evm.logs ADD COLUMN id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY;
-CREATE UNIQUE INDEX idx_evm_logs_block_hash_log_index_evm_chain_id ON evm.logs (block_hash, log_index, evm_chain_id);
-ALTER TABLE evm.log_poller_blocks  DROP CONSTRAINT log_poller_blocks_pkey;
+CREATE UNIQUE INDEX idx_logs_chain_block_logindex ON evm.logs (evm_chain_id, block_number, log_index);
+ALTER TABLE evm.log_poller_blocks DROP CONSTRAINT log_poller_blocks_pkey;
 ALTER TABLE evm.log_poller_blocks ADD COLUMN id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY;
-CREATE UNIQUE INDEX idx_evm_log_poller_blocks_block_number_evm_chain_id ON evm.log_poller_blocks (block_number, evm_chain_id);
+DROP INDEX IF EXISTS evm.idx_evm_log_poller_blocks_order_by_block;
+DROP INDEX IF EXISTS evm.idx_evm_log_poller_blocks_block_number_evm_chain_id;
+CREATE UNIQUE INDEX idx_log_poller_blocks_chain_block ON evm.log_poller_blocks (evm_chain_id, block_number DESC);
+DROP INDEX IF EXISTS evm.idx_evm_logs_ordered_by_block_and_created_at;
+CREATE INDEX idx_logs_chain_address_event_block_logindex ON evm.logs (evm_chain_id, address, event_sig, block_number, log_index);
 
 -- +goose Down
 
-DROP INDEX IF EXISTS evm.idx_evm_log_poller_blocks_block_number_evm_chain_id;
+DROP INDEX IF EXISTS evm.idx_logs_chain_address_event_block_logindex;
+CREATE INDEX idx_evm_logs_ordered_by_block_and_created_at ON evm.logs (evm_chain_id, address, event_sig, block_number, created_at);
+DROP INDEX IF EXISTS evm.idx_log_poller_blocks_chain_block;
+CREATE INDEX idx_evm_log_poller_blocks_order_by_block ON evm.log_poller_blocks (evm_chain_id, block_number DESC);
+CREATE INDEX idx_evm_log_poller_blocks_block_number_evm_chain_id ON evm.log_poller_blocks (block_number, evm_chain_id);
 ALTER TABLE evm.log_poller_blocks DROP COLUMN id;
 ALTER TABLE evm.log_poller_blocks ADD PRIMARY KEY (block_number, evm_chain_id);
-DROP INDEX IF EXISTS evm.idx_evm_logs_block_hash_log_index_evm_chain_id;
+DROP INDEX IF EXISTS evm.idx_logs_chain_block_logindex;
 ALTER TABLE evm.logs DROP COLUMN id;
 ALTER TABLE evm.logs ADD PRIMARY KEY (block_hash, log_index, evm_chain_id);
 

--- a/integration-tests/.tool-versions
+++ b/integration-tests/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.22.5
+golang 1.22.7
 k3d 5.4.6
 kubectl 1.25.5
 nodejs 20.13.1

--- a/integration-tests/ccip-tests/testconfig/tomls/ccip1.4-stress/baseline.toml
+++ b/integration-tests/ccip-tests/testconfig/tomls/ccip1.4-stress/baseline.toml
@@ -132,6 +132,7 @@ DeltaReconcile = '5s'
 
 CommonChainConfigTOML = """
 LogPollInterval = '1s'
+LogPrunePageSize = 2001
 
 [HeadTracker]
 HistoryDepth = 200

--- a/integration-tests/ccip-tests/testconfig/tomls/ccip1.4-stress/baseline.toml
+++ b/integration-tests/ccip-tests/testconfig/tomls/ccip1.4-stress/baseline.toml
@@ -15,7 +15,7 @@
 # If you want to use a specific commit or a branch you need to switch to the internal ECR in `~/.testsecrets`
 # E2E_TEST_CHAINLINK_IMAGE="<aws account number>.dkr.ecr.<aws region>.amazonaws.com/chainlink-ccip"
 [CCIP.Env.NewCLCluster.Common.ChainlinkImage]
-version = "2.14.0-ccip1.5.0"
+version = "log_poller_id_columns"
 
 [CCIP]
 [CCIP.ContractVersions]
@@ -132,7 +132,8 @@ DeltaReconcile = '5s'
 
 CommonChainConfigTOML = """
 LogPollInterval = '1s'
-LogPrunePageSize = 2001
+LogPrunePageSize = 5001
+LogKeepBlocksDepth = 1000
 
 [HeadTracker]
 HistoryDepth = 200


### PR DESCRIPTION
Problem:

The query for pruning expired logs with a max limit set was taking longer than it should. This was part due to needing to join on an awkward combination combination of columns due to their being no single primary key.

Solution:
- Add id column as PRIMARY KEY for evm.logs & evm.log_poller_blocks
- Join on id column instead of previous primary keys
- Replace all SELECT *'s with helper functions for selecting all columns
- Refactor nestedBlockQuery into withConfs, and make a bit more use of it## Motivation

While adding the id column, we can't just remove the old primary key because the index on it was helping to accelerate some queries.
Instead of just resurrecting it as-is, I took the opportunity to clean up several of the indices on the logs & blocks table. Some indexed columns (eg created_at) were never actually being used,
while others were not ordered in the most optimal way for accelerating the queries we have. Also, at least one of them was redundant with the primary key just in a different order.







