### PR TITLE
Update pragma to most restrictive dependency or feature

### DIFF
--- a/contracts/src/v0.8/ccip/applications/CCIPClientExample.sol
+++ b/contracts/src/v0.8/ccip/applications/CCIPClientExample.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 import {IRouterClient} from "../interfaces/IRouterClient.sol";
 

--- a/contracts/src/v0.8/ccip/applications/CCIPReceiver.sol
+++ b/contracts/src/v0.8/ccip/applications/CCIPReceiver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 import {IAny2EVMMessageReceiver} from "../interfaces/IAny2EVMMessageReceiver.sol";
 

--- a/contracts/src/v0.8/ccip/applications/DefensiveExample.sol
+++ b/contracts/src/v0.8/ccip/applications/DefensiveExample.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.20;
 
 import {IRouterClient} from "../interfaces/IRouterClient.sol";
 

--- a/contracts/src/v0.8/ccip/applications/PingPongDemo.sol
+++ b/contracts/src/v0.8/ccip/applications/PingPongDemo.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 import {ITypeAndVersion} from "../../shared/interfaces/ITypeAndVersion.sol";
 import {IRouterClient} from "../interfaces/IRouterClient.sol";

--- a/contracts/src/v0.8/ccip/applications/SelfFundedPingPong.sol
+++ b/contracts/src/v0.8/ccip/applications/SelfFundedPingPong.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.24;
 
 import {Router} from "../Router.sol";
 import {Client} from "../libraries/Client.sol";

--- a/contracts/src/v0.8/ccip/capability/interfaces/IOCR3ConfigEncoder.sol
+++ b/contracts/src/v0.8/ccip/capability/interfaces/IOCR3ConfigEncoder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 import {CCIPConfigTypes} from "../libraries/CCIPConfigTypes.sol";
 

--- a/contracts/src/v0.8/ccip/capability/libraries/CCIPConfigTypes.sol
+++ b/contracts/src/v0.8/ccip/capability/libraries/CCIPConfigTypes.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 import {Internal} from "../../libraries/Internal.sol";
 

--- a/contracts/src/v0.8/ccip/interfaces/IFeeQuoter.sol
+++ b/contracts/src/v0.8/ccip/interfaces/IFeeQuoter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 import {Client} from "../libraries/Client.sol";
 import {Internal} from "../libraries/Internal.sol";

--- a/contracts/src/v0.8/ccip/interfaces/IPriceRegistry.sol
+++ b/contracts/src/v0.8/ccip/interfaces/IPriceRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 import {Internal} from "../libraries/Internal.sol";
 

--- a/contracts/src/v0.8/ccip/interfaces/IRMNV2.sol
+++ b/contracts/src/v0.8/ccip/interfaces/IRMNV2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 import {Internal} from "../libraries/Internal.sol";
 

--- a/contracts/src/v0.8/ccip/interfaces/IRouterClient.sol
+++ b/contracts/src/v0.8/ccip/interfaces/IRouterClient.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 import {Client} from "../libraries/Client.sol";
 

--- a/contracts/src/v0.8/ccip/libraries/Internal.sol
+++ b/contracts/src/v0.8/ccip/libraries/Internal.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 import {MerkleMultiProof} from "../libraries/MerkleMultiProof.sol";
 import {Client} from "./Client.sol";

--- a/contracts/src/v0.8/ccip/libraries/MerkleMultiProof.sol
+++ b/contracts/src/v0.8/ccip/libraries/MerkleMultiProof.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 library MerkleMultiProof {
   /// @notice Leaf domain separator, should be used as the first 32 bytes of a leaf's preimage.

--- a/contracts/src/v0.8/ccip/libraries/RateLimiter.sol
+++ b/contracts/src/v0.8/ccip/libraries/RateLimiter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 /// @notice Implements Token Bucket rate limiting.
 /// @dev uint128 is safe for rate limiter state.

--- a/contracts/src/v0.8/ccip/ocr/MultiOCR3Base.sol
+++ b/contracts/src/v0.8/ccip/ocr/MultiOCR3Base.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 import {OwnerIsCreator} from "../../shared/access/OwnerIsCreator.sol";
 import {ITypeAndVersion} from "../../shared/interfaces/ITypeAndVersion.sol";

--- a/contracts/src/v0.8/ccip/ocr/OCR2Base.sol
+++ b/contracts/src/v0.8/ccip/ocr/OCR2Base.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 import {OwnerIsCreator} from "../../shared/access/OwnerIsCreator.sol";
 import {OCR2Abstract} from "./OCR2Abstract.sol";

--- a/contracts/src/v0.8/ccip/ocr/OCR2BaseNoChecks.sol
+++ b/contracts/src/v0.8/ccip/ocr/OCR2BaseNoChecks.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 import {OwnerIsCreator} from "../../shared/access/OwnerIsCreator.sol";
 import {OCR2Abstract} from "./OCR2Abstract.sol";

--- a/contracts/src/v0.8/ccip/pools/LegacyPoolWrapper.sol
+++ b/contracts/src/v0.8/ccip/pools/LegacyPoolWrapper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.24;
 
 import {IPoolPriorTo1_5} from "../interfaces/IPoolPriorTo1_5.sol";
 

--- a/contracts/src/v0.8/ccip/test/helpers/MaybeRevertingBurnMintTokenPool.sol
+++ b/contracts/src/v0.8/ccip/test/helpers/MaybeRevertingBurnMintTokenPool.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.24;
 
 import {IBurnMintERC20} from "../../../shared/token/ERC20/IBurnMintERC20.sol";
 

--- a/contracts/src/v0.8/ccip/test/helpers/MessageHasher.sol
+++ b/contracts/src/v0.8/ccip/test/helpers/MessageHasher.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 import {Client} from "../../libraries/Client.sol";
 import {Internal} from "../../libraries/Internal.sol";

--- a/contracts/src/v0.8/ccip/test/helpers/ReportCodec.sol
+++ b/contracts/src/v0.8/ccip/test/helpers/ReportCodec.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.24;
 
 import {Internal} from "../../libraries/Internal.sol";
 import {OffRamp} from "../../offRamp/OffRamp.sol";

--- a/contracts/src/v0.8/ccip/test/legacy/BurnMintTokenPool1_2.sol
+++ b/contracts/src/v0.8/ccip/test/legacy/BurnMintTokenPool1_2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 import {ITypeAndVersion} from "../../../shared/interfaces/ITypeAndVersion.sol";
 import {IPoolPriorTo1_5} from "../../interfaces/IPoolPriorTo1_5.sol";

--- a/contracts/src/v0.8/ccip/test/mocks/MockRouter.sol
+++ b/contracts/src/v0.8/ccip/test/mocks/MockRouter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 import {IAny2EVMMessageReceiver} from "../../interfaces/IAny2EVMMessageReceiver.sol";
 import {IRouter} from "../../interfaces/IRouter.sol";


### PR DESCRIPTION
## Motivation
We have several contracts using `^0.8.0` but also custom errors, or a child contract with custom errors. We also have several contracts at `^0.8.0` but a dependency locked at `0.8.24`.

## Solution
Update all pragmas to the pragma of the most restrictive dep or the minimum to enable custom errors (`0.8.4`)