### PR TITLE
Do not return the error in case if onRamp not initialized

### DIFF
--- a/core/services/ocr2/plugins/ccip/estimatorconfig/config.go
+++ b/core/services/ocr2/plugins/ccip/estimatorconfig/config.go
@@ -2,7 +2,6 @@ package estimatorconfig
 
 import (
 	"context"
-	"errors"
 	"math/big"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/types/ccip"
@@ -42,7 +41,7 @@ func (c *FeeEstimatorConfigService) SetOnRampReader(reader ccip.OnRampReader) {
 // GetDynamicConfig should be cached in the onRamp reader to avoid unnecessary on-chain calls
 func (c *FeeEstimatorConfigService) GetDataAvailabilityConfig(ctx context.Context) (destDataAvailabilityOverheadGas, destGasPerDataAvailabilityByte, destDataAvailabilityMultiplierBps int64, err error) {
 	if c.onRampReader == nil {
-		return 0, 0, 0, errors.New("no OnRampReader has been configured")
+		return 0, 0, 0, nil
 	}
 
 	cfg, err := c.onRampReader.GetDynamicConfig(ctx)

--- a/core/services/ocr2/plugins/ccip/estimatorconfig/config_test.go
+++ b/core/services/ocr2/plugins/ccip/estimatorconfig/config_test.go
@@ -24,8 +24,11 @@ func TestFeeEstimatorConfigService(t *testing.T) {
 	var expectedDestDataAvailabilityMultiplierBps int64 = 3
 
 	onRampReader := mocks.NewOnRampReader(t)
-	_, _, _, err := svc.GetDataAvailabilityConfig(ctx)
-	require.Error(t, err)
+	destDataAvailabilityOverheadGas, destGasPerDataAvailabilityByte, destDataAvailabilityMultiplierBps, err := svc.GetDataAvailabilityConfig(ctx)
+	require.NoError(t, err) // if onRampReader not set, return nil error and 0 values
+	require.EqualValues(t, 0, destDataAvailabilityOverheadGas)
+	require.EqualValues(t, 0, destGasPerDataAvailabilityByte)
+	require.EqualValues(t, 0, destDataAvailabilityMultiplierBps)
 	svc.SetOnRampReader(onRampReader)
 
 	onRampReader.On("GetDynamicConfig", ctx).
@@ -35,7 +38,7 @@ func TestFeeEstimatorConfigService(t *testing.T) {
 			DestDataAvailabilityMultiplierBps: uint16(expectedDestDataAvailabilityMultiplierBps),
 		}, nil).Once()
 
-	destDataAvailabilityOverheadGas, destGasPerDataAvailabilityByte, destDataAvailabilityMultiplierBps, err := svc.GetDataAvailabilityConfig(ctx)
+	destDataAvailabilityOverheadGas, destGasPerDataAvailabilityByte, destDataAvailabilityMultiplierBps, err = svc.GetDataAvailabilityConfig(ctx)
 	require.NoError(t, err)
 	require.Equal(t, expectedDestDataAvailabilityOverheadGas, destDataAvailabilityOverheadGas)
 	require.Equal(t, expectedDestGasPerDataAvailabilityByte, destGasPerDataAvailabilityByte)


### PR DESCRIPTION
## Motivation
For the exec provider, in some cases, the onRamp reader is not initialized. For immediate reaction, we need to allow execution without blocking in cases if onRamp is not initialized. It fails due the issue when onRampReader is not initialized for execProvider. This fix should fix this issue. In case the onRamp reader is not initialized, the module will return 0 values and DAGasEstimator will behave as it worked before this feature been implemented. 