### PR TITLE
Add Bitlayer OCR configs to CCIP

### DIFF
--- a/ccip/config/evm/Bitlayer_Mainnet.toml
+++ b/ccip/config/evm/Bitlayer_Mainnet.toml
@@ -1,0 +1,16 @@
+ChainID = '200901'
+FinalityTagEnabled = false
+FinalityDepth = 21 # confirmed with Bitlayer team and reccomended by docs: https://docs.bitlayer.org/docs/Learn/BitlayerNetwork/AboutFinality/#about-finality-at-stage-bitlayer-pos-bitlayer-mainnet-v1
+
+[EVM.GasEstimator]
+EIP1559DynamicFees = true
+PriceMax = '1 gwei' # DS&A reccommended value
+PriceMin = '40 mwei' # During testing, we saw minimum gas prices ~50 mwei
+PriceDefault = '1 gwei' # As we set PriceMax to '1 gwei' and PriceDefault must be less than or equal to PriceMax
+FeeCapDefault = '1 gwei' # As we set PriceMax to '1 gwei' and FeeCapDefault must be less than or equal to PriceMax
+TipCapDefault = '0.05 gwei' # reccomended by BitLayer's docs: https://docs.bitlayer.org/docs/Learn/BitlayerNetwork/AboutGas
+
+[EVM.GasEstimator.BlockHistory]
+# Default is 8, which leads to bumpy gas prices. In CCIP
+# we want to smooth out the gas prices, so we increase the sample size.
+BlockHistorySize = 200

--- a/ccip/config/evm/Bitlayer_Mainnet.toml
+++ b/ccip/config/evm/Bitlayer_Mainnet.toml
@@ -1,14 +1,14 @@
 ChainID = '200901'
 FinalityTagEnabled = false
-FinalityDepth = 21 # confirmed with Bitlayer team and reccomended by docs: https://docs.bitlayer.org/docs/Learn/BitlayerNetwork/AboutFinality/#about-finality-at-stage-bitlayer-pos-bitlayer-mainnet-v1
+FinalityDepth = 21 # confirmed with Bitlayer team and recommended by docs: https://docs.bitlayer.org/docs/Learn/BitlayerNetwork/AboutFinality/#about-finality-at-stage-bitlayer-pos-bitlayer-mainnet-v1
 
 [EVM.GasEstimator]
 EIP1559DynamicFees = true
-PriceMax = '1 gwei' # DS&A reccommended value
+PriceMax = '1 gwei' # DS&A recommended value
 PriceMin = '40 mwei' # During testing, we saw minimum gas prices ~50 mwei
 PriceDefault = '1 gwei' # As we set PriceMax to '1 gwei' and PriceDefault must be less than or equal to PriceMax
 FeeCapDefault = '1 gwei' # As we set PriceMax to '1 gwei' and FeeCapDefault must be less than or equal to PriceMax
-TipCapDefault = '0.05 gwei' # reccomended by BitLayer's docs: https://docs.bitlayer.org/docs/Learn/BitlayerNetwork/AboutGas
+TipCapDefault = '0.05 gwei' # recommended by BitLayer's docs: https://docs.bitlayer.org/docs/Learn/BitlayerNetwork/AboutGas
 
 [EVM.GasEstimator.BlockHistory]
 # Default is 8, which leads to bumpy gas prices. In CCIP

--- a/ccip/config/evm/Bitlayer_Testnet.toml
+++ b/ccip/config/evm/Bitlayer_Testnet.toml
@@ -1,14 +1,14 @@
 ChainID = '200810'
 FinalityTagEnabled = false
-FinalityDepth = 21 # confirmed with Bitlayer team and reccomended by docs: https://docs.bitlayer.org/docs/Learn/BitlayerNetwork/AboutFinality/#about-finality-at-stage-bitlayer-pos-bitlayer-mainnet-v1
+FinalityDepth = 21 # confirmed with Bitlayer team and recommended by docs: https://docs.bitlayer.org/docs/Learn/BitlayerNetwork/AboutFinality/#about-finality-at-stage-bitlayer-pos-bitlayer-mainnet-v1
 
 [EVM.GasEstimator]
 EIP1559DynamicFees = true
-PriceMax = '1 gwei' # DS&A reccommended value
+PriceMax = '1 gwei' # DS&A recommended value
 PriceMin = '40 mwei' # During testing, we saw minimum gas prices ~50 mwei
 PriceDefault = '1 gwei' # As we set PriceMax to '1 gwei' and PriceDefault must be less than or equal to PriceMax
 FeeCapDefault = '1 gwei' # As we set PriceMax to '1 gwei' and FeeCapDefault must be less than or equal to PriceMax
-TipCapDefault = '0.05 gwei' # reccomended by BitLayer's docs: https://docs.bitlayer.org/docs/Learn/BitlayerNetwork/AboutGas
+TipCapDefault = '0.05 gwei' # recommended by BitLayer's docs: https://docs.bitlayer.org/docs/Learn/BitlayerNetwork/AboutGas
 
 [EVM.GasEstimator.BlockHistory]
 # Default is 8, which leads to bumpy gas prices. In CCIP

--- a/ccip/config/evm/Bitlayer_Testnet.toml
+++ b/ccip/config/evm/Bitlayer_Testnet.toml
@@ -1,0 +1,16 @@
+ChainID = '200810'
+FinalityTagEnabled = false
+FinalityDepth = 21 # confirmed with Bitlayer team and reccomended by docs: https://docs.bitlayer.org/docs/Learn/BitlayerNetwork/AboutFinality/#about-finality-at-stage-bitlayer-pos-bitlayer-mainnet-v1
+
+[EVM.GasEstimator]
+EIP1559DynamicFees = true
+PriceMax = '1 gwei' # DS&A reccommended value
+PriceMin = '40 mwei' # During testing, we saw minimum gas prices ~50 mwei
+PriceDefault = '1 gwei' # As we set PriceMax to '1 gwei' and PriceDefault must be less than or equal to PriceMax
+FeeCapDefault = '1 gwei' # As we set PriceMax to '1 gwei' and FeeCapDefault must be less than or equal to PriceMax
+TipCapDefault = '0.05 gwei' # reccomended by BitLayer's docs: https://docs.bitlayer.org/docs/Learn/BitlayerNetwork/AboutGas
+
+[EVM.GasEstimator.BlockHistory]
+# Default is 8, which leads to bumpy gas prices. In CCIP
+# we want to smooth out the gas prices, so we increase the sample size.
+BlockHistorySize = 200

--- a/core/chains/evm/config/toml/defaults/Bitlayer_Mainnet.toml
+++ b/core/chains/evm/config/toml/defaults/Bitlayer_Mainnet.toml
@@ -1,0 +1,16 @@
+ChainID = '200901'
+FinalityTagEnabled = false
+FinalityDepth = 21 # confirmed with Bitlayer team and reccomended by docs: https://docs.bitlayer.org/docs/Learn/BitlayerNetwork/AboutFinality/#about-finality-at-stage-bitlayer-pos-bitlayer-mainnet-v1
+
+[EVM.GasEstimator]
+EIP1559DynamicFees = true
+PriceMax = '1 gwei' # DS&A reccommended value
+PriceMin = '40 mwei' # During testing, we saw minimum gas prices ~50 mwei
+PriceDefault = '1 gwei' # As we set PriceMax to '1 gwei' and PriceDefault must be less than or equal to PriceMax
+FeeCapDefault = '1 gwei' # As we set PriceMax to '1 gwei' and FeeCapDefault must be less than or equal to PriceMax
+TipCapDefault = '0.05 gwei' # reccomended by BitLayer's docs: https://docs.bitlayer.org/docs/Learn/BitlayerNetwork/AboutGas
+
+[EVM.GasEstimator.BlockHistory]
+# Default is 8, which leads to bumpy gas prices. In CCIP
+# we want to smooth out the gas prices, so we increase the sample size.
+BlockHistorySize = 200

--- a/core/chains/evm/config/toml/defaults/Bitlayer_Mainnet.toml
+++ b/core/chains/evm/config/toml/defaults/Bitlayer_Mainnet.toml
@@ -1,14 +1,14 @@
 ChainID = '200901'
 FinalityTagEnabled = false
-FinalityDepth = 21 # confirmed with Bitlayer team and reccomended by docs: https://docs.bitlayer.org/docs/Learn/BitlayerNetwork/AboutFinality/#about-finality-at-stage-bitlayer-pos-bitlayer-mainnet-v1
+FinalityDepth = 21 # confirmed with Bitlayer team and recommended by docs: https://docs.bitlayer.org/docs/Learn/BitlayerNetwork/AboutFinality/#about-finality-at-stage-bitlayer-pos-bitlayer-mainnet-v1
 
 [EVM.GasEstimator]
 EIP1559DynamicFees = true
-PriceMax = '1 gwei' # DS&A reccommended value
+PriceMax = '1 gwei' # DS&A recommended value
 PriceMin = '40 mwei' # During testing, we saw minimum gas prices ~50 mwei
 PriceDefault = '1 gwei' # As we set PriceMax to '1 gwei' and PriceDefault must be less than or equal to PriceMax
 FeeCapDefault = '1 gwei' # As we set PriceMax to '1 gwei' and FeeCapDefault must be less than or equal to PriceMax
-TipCapDefault = '0.05 gwei' # reccomended by BitLayer's docs: https://docs.bitlayer.org/docs/Learn/BitlayerNetwork/AboutGas
+TipCapDefault = '0.05 gwei' # recommended by BitLayer's docs: https://docs.bitlayer.org/docs/Learn/BitlayerNetwork/AboutGas
 
 [EVM.GasEstimator.BlockHistory]
 # Default is 8, which leads to bumpy gas prices. In CCIP

--- a/core/chains/evm/config/toml/defaults/Bitlayer_Testnet.toml
+++ b/core/chains/evm/config/toml/defaults/Bitlayer_Testnet.toml
@@ -1,14 +1,14 @@
 ChainID = '200810'
 FinalityTagEnabled = false
-FinalityDepth = 21 # confirmed with Bitlayer team and reccomended by docs: https://docs.bitlayer.org/docs/Learn/BitlayerNetwork/AboutFinality/#about-finality-at-stage-bitlayer-pos-bitlayer-mainnet-v1
+FinalityDepth = 21 # confirmed with Bitlayer team and recommended by docs: https://docs.bitlayer.org/docs/Learn/BitlayerNetwork/AboutFinality/#about-finality-at-stage-bitlayer-pos-bitlayer-mainnet-v1
 
 [EVM.GasEstimator]
 EIP1559DynamicFees = true
-PriceMax = '1 gwei' # DS&A reccommended value
+PriceMax = '1 gwei' # DS&A recommended value
 PriceMin = '40 mwei' # During testing, we saw minimum gas prices ~50 mwei
 PriceDefault = '1 gwei' # As we set PriceMax to '1 gwei' and PriceDefault must be less than or equal to PriceMax
 FeeCapDefault = '1 gwei' # As we set PriceMax to '1 gwei' and FeeCapDefault must be less than or equal to PriceMax
-TipCapDefault = '0.05 gwei' # reccomended by BitLayer's docs: https://docs.bitlayer.org/docs/Learn/BitlayerNetwork/AboutGas
+TipCapDefault = '0.05 gwei' # recommended by BitLayer's docs: https://docs.bitlayer.org/docs/Learn/BitlayerNetwork/AboutGas
 
 [EVM.GasEstimator.BlockHistory]
 # Default is 8, which leads to bumpy gas prices. In CCIP

--- a/core/chains/evm/config/toml/defaults/Bitlayer_Testnet.toml
+++ b/core/chains/evm/config/toml/defaults/Bitlayer_Testnet.toml
@@ -1,0 +1,16 @@
+ChainID = '200810'
+FinalityTagEnabled = false
+FinalityDepth = 21 # confirmed with Bitlayer team and reccomended by docs: https://docs.bitlayer.org/docs/Learn/BitlayerNetwork/AboutFinality/#about-finality-at-stage-bitlayer-pos-bitlayer-mainnet-v1
+
+[EVM.GasEstimator]
+EIP1559DynamicFees = true
+PriceMax = '1 gwei' # DS&A reccommended value
+PriceMin = '40 mwei' # During testing, we saw minimum gas prices ~50 mwei
+PriceDefault = '1 gwei' # As we set PriceMax to '1 gwei' and PriceDefault must be less than or equal to PriceMax
+FeeCapDefault = '1 gwei' # As we set PriceMax to '1 gwei' and FeeCapDefault must be less than or equal to PriceMax
+TipCapDefault = '0.05 gwei' # reccomended by BitLayer's docs: https://docs.bitlayer.org/docs/Learn/BitlayerNetwork/AboutGas
+
+[EVM.GasEstimator.BlockHistory]
+# Default is 8, which leads to bumpy gas prices. In CCIP
+# we want to smooth out the gas prices, so we increase the sample size.
+BlockHistorySize = 200


### PR DESCRIPTION
## What
- Adds new Bitlayer Mainnet and Testnet OCR configs to CCIP

## Why
- This change supports an ongoing CCIP integration