### PR TITLE
Updating live environments contracts to 1.5

### DIFF
--- a/.github/workflows/ccip-live-network-tests.yml
+++ b/.github/workflows/ccip-live-network-tests.yml
@@ -291,7 +291,7 @@ jobs:
           - name: 'METIS_ANDROMEDA'
             pairs: 'METIS_ANDROMEDA,ARBITRUM_MAINNET'
             enabled: true
-            phaseTimeout: 60m
+            phaseTimeout: 300m
           - name: 'MODE_MAINNET'
             pairs: 'MODE_MAINNET,OPTIMISM_MAINNET;MODE_MAINNET,ARBITRUM_MAINNET;MODE_MAINNET,BASE_MAINNET;MODE_MAINNET,BSC_MAINNET'
             enabled: true
@@ -311,7 +311,7 @@ jobs:
           - name: 'ZKSYNC_MAINNET'
             pairs: 'ZKSYNC_MAINNET,ARBITRUM_MAINNET'
             enabled: true
-            phaseTimeout: 90m
+            phaseTimeout: 300m
     steps:
       - name: Collect Metrics
         if: ${{ matrix.lanes.enabled == true }}
@@ -399,7 +399,7 @@ jobs:
   # Custom reporting Jobs
   start-slack-thread:
     name: Start Slack Thread
-    if: ${{ always() && needs.ccip-smoke-test.result != 'skipped' && needs.ccip-smoke-test.result != 'cancelled' }}
+    if: ${{ failure() && needs.ccip-smoke-test.result != 'skipped' && needs.ccip-smoke-test.result != 'cancelled' }}
     environment: integration
     outputs:
       thread_ts: ${{ steps.slack.outputs.thread_ts }}
@@ -451,7 +451,7 @@ jobs:
 
   post-test-results-to-slack:
     name: Post Test Results
-    if: ${{ always() && needs.start-slack-thread.result != 'skipped' && needs.start-slack-thread.result != 'cancelled' }}
+    if: ${{ failure() && needs.start-slack-thread.result != 'skipped' && needs.start-slack-thread.result != 'cancelled' }}
     environment: integration
     permissions:
       checks: write
@@ -473,7 +473,7 @@ jobs:
           workflow_run_id: ${{ github.run_id }}
           github_job_name_regex: ^CCIP Smoke (.*)$
           message_title: CCIP Mainnet Smoke test
-          slack_channel_id: "#test-run-notifications"
+          slack_channel_id: "#ccip-testing"
           slack_bot_token: ${{ secrets.QA_SLACK_API_KEY }}
           slack_thread_ts: ${{ needs.start-slack-thread.outputs.thread_ts }}
 

--- a/integration-tests/ccip-tests/testconfig/override/mainnet.toml
+++ b/integration-tests/ccip-tests/testconfig/override/mainnet.toml
@@ -19,114 +19,114 @@ Data = """
       "wrapped_native": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
       "src_contracts": {
         "Avalanche Mainnet": {
-          "on_ramp": "0x05B723f3db92430FbE4395fD03E40Cc7e9D17988",
+          "on_ramp": "0xe80cC83B895ada027b722b78949b296Bd1fC5639",
           "deployed_at": 0
         },
         "BSC Mainnet": {
-          "on_ramp": "0x79f3ABeCe5A3AFFf32D47F4CFe45e7b65c9a2D91",
+          "on_ramp": "0x14bF7b1Ca6b843f386bfDfa76BFd439919b9378D",
           "deployed_at": 0
         },
         "Base Mainnet": {
-          "on_ramp": "0x77b60F85b25fD501E3ddED6C1fe7bF565C08A22A",
+          "on_ramp": "0xc1b6287A3292d6469F2D8545877E40A2f75CA9a6",
           "deployed_at": 0
         },
         "Blast Mainnet": {
-          "on_ramp": "0x54480425E9e24138fdF1644a1F70007F25abfB46",
+          "on_ramp": "0xc5490997680a39A1b4684ce2b668AE8A2eBEC7ee",
           "deployed_at": 0
         },
         "Ethereum Mainnet": {
-          "on_ramp": "0xCe11020D56e5FDbfE46D9FC3021641FfbBB5AdEE",
+          "on_ramp": "0x67761742ac8A21Ec4D76CA18cbd701e5A6F3Bef3",
           "deployed_at": 0
         },
         "Gnosis Mainnet": {
-          "on_ramp": "0x1216DC856Af47a833254a280A038185F51C1B5c4",
+          "on_ramp": "0xc7d6B885d8A4286E6311F79227430b7862311cd3",
           "deployed_at": 0
         },
         "Metis Andromeda": {
-          "on_ramp": "0x5b23A0a103fC9028363B3BC3577e8Bd45B8E819F",
+          "on_ramp": "0xF1e73c37CDa8E47768De2246AEf5eFD4d76330ae",
           "deployed_at": 0
         },
         "Mode Mainnet": {
-          "on_ramp": "0x3920BF474BB50fffb4B77c1e6e66F65210D1D722",
+          "on_ramp": "0xd236ea4DDE7de1e594021764E2f6Cd8e8cD7F047",
           "deployed_at": 0
         },
         "Optimism Mainnet": {
-          "on_ramp": "0xC09b72E8128620C40D89649019d995Cc79f030C3",
+          "on_ramp": "0xAFECc7b67c6a8e606e94ce4e2F70D83C2206C2cb",
           "deployed_at": 0
         },
         "Polygon Mainnet": {
-          "on_ramp": "0x122F05F49e90508F089eE8D0d868d1a4f3E5a809",
+          "on_ramp": "0x6087d6C33946670232DF09Fe93eECbaEa3D6864d",
           "deployed_at": 0
         },
         "WeMix Mainnet": {
-          "on_ramp": "0x66a0046ac9FA104eB38B04cfF391CcD0122E6FbC",
+          "on_ramp": "0x52e51f245e600C6A87Ef2090d607D2a0eAedA1a6",
           "deployed_at": 0
         },
         "ZKSync Mainnet": {
-          "on_ramp": "0x2C1016053d9873270d71613cA321aE97Fc89201d",
+          "on_ramp": "0xd67F6713Fa4448548c984a9a7DCFBD13B0fB78D6",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Avalanche Mainnet": {
-          "off_ramp": "0xe0109912157d5B75ea8b3181123Cf32c73bc9920",
-          "commit_store": "0xDaa61b8Cd85977820f92d1e749E1D9F55Da6CCEA",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x95095007d5Cc3E7517A1A03c9e228adA5D0bc376",
+          "commit_store": "0x46679C9E93B7312A9191A9aD12A73b0c86A33623",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "BSC Mainnet": {
-          "off_ramp": "0xB1b705c2315fced1B38baE463BE7DDef531e47fA",
-          "commit_store": "0x310cECbFf14Ad0307EfF762F461a487C1abb90bf",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x16B9709F8A23B9EB922E8Dde7EaB1Ede7C79F663",
+          "commit_store": "0x6c3fD63b9BdE38C414530727a5De858ca023cFc4",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Base Mainnet": {
-          "off_ramp": "0xdB19F77F87661f9be0F557cf9a1ebeCf7D8F206c",
-          "commit_store": "0x6e37f4c82d9A31cc42B445874dd3c3De97AB553f",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xb62178f8198905D0Fa6d640Bdb188E4E8143Ac4b",
+          "commit_store": "0x8F60C335a5d2BEC6B32867d3C05C377E88640AaF",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Blast Mainnet": {
-          "off_ramp": "0x449C59F4Ef3b1802DD054dd7837Eb2Ca91aFAB84",
-          "commit_store": "0x1E0e8B01693A248b3Aa1e5aca36336F9022Ceac0",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x40314FeC27C5FCc7AaA05e618802A3fEA8E23Ae3",
+          "commit_store": "0xe7C1904E00BAf5Ca61926da0d1d2B036f14A3ad8",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Ethereum Mainnet": {
-          "off_ramp": "0x542ba1902044069330e8c5b36A84EC503863722f",
-          "commit_store": "0x060331fEdA35691e54876D957B4F9e3b8Cb47d20",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x91e46cc5590A4B9182e47f40006140A7077Dec31",
+          "commit_store": "0x86be76A0FA2bD3ECB69330cBb4fd1f62c48F43E3",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Gnosis Mainnet": {
-          "off_ramp": "0x0C00414D9dcDB2DA7BF8AF26aE2deb617f09e756",
-          "commit_store": "0x1d464cd86c5C8358d56281aB31d2213534CCEA13",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xeE53872d1C695933B34cE0a11B58613CBBf37e20",
+          "commit_store": "0x5D88518a198b99F096d2893092a568A97F60B8d4",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Metis Andromeda": {
-          "off_ramp": "0xeF8dEb0c01f7389AD4ae05DAB30120dba915D53c",
-          "commit_store": "0xE594a09Aa8bCb55188758826A160615B95A6F3fE",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xF1A4DE22FF792b0457306C39f4CB5822Ab47bdAE",
+          "commit_store": "0x7F20F4374f8d99201F22434ad59f96bE898A9E0B",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Mode Mainnet": {
-          "off_ramp": "0xEDE7ADACFbD27DBEBbE2d6C3BaDf12a634a72Faa",
-          "commit_store": "0x032B209a6B7a00336047505b55a4cBFBd29eE2c1",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xa964355d8eBa62E9b043Eb27eEe6d999Ecc69429",
+          "commit_store": "0x72C3cdA94eCAC06f7605301dd7144815C2F05A03",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Optimism Mainnet": {
-          "off_ramp": "0xeeed4D86F3E0e6d32A6Ad29d8De6A0Dc91963A5f",
-          "commit_store": "0xbbB563c4d98020b9c0f3Cc34c2C0Ef9676806E35",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x27a971D482335d0f8d1917451390734f7372A4a3",
+          "commit_store": "0x6642E640321e1Ad01eef2fC2ad5427D84A2Ee269",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Polygon Mainnet": {
-          "off_ramp": "0x9bDA7c8DCda4E39aFeB483cc0B7E3C1f6E0D5AB1",
-          "commit_store": "0x63a0AeaadAe851b990bBD9dc41f5C1B08b32026d",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xcabc2D71dC3172a154A5A34cD706B050e0ef9b6f",
+          "commit_store": "0x78B15A57889200F246fc52790c4F3DfC37d82Aa2",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "WeMix Mainnet": {
-          "off_ramp": "0xEEf5Fb4c4953F9cA9ab1f25cE590776AfFc2c455",
-          "commit_store": "0xD268286A277095a9C3C90205110831a84505881c",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x893c14bA328A49336a188F972f997C0d7286B8E4",
+          "commit_store": "0xc986D260b096E8708D82063309fB98734481A045",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "ZKSync Mainnet": {
-          "off_ramp": "0x50Fc0de671c775301e1Bdf19C17E778D0f978f6F",
-          "commit_store": "0x87732C2647168818ED49268EdA8A98C2e62ed744",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x052CF0c46375287255c71B179b10a7BFFD97502F",
+          "commit_store": "0xE19E9765857A2371d849FDd26D62D2463fb7a0a9",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         }
       }
     },
@@ -135,82 +135,82 @@ Data = """
       "fee_token": "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
       "arm": "0x4f6Ec25f06A114ADD3154DC17fb637F750AdaA31",
       "router": "0xF4c7E640EdA248ef95972845a62bdC74237805dB",
-      "price_registry": "0x2d3b38E0a4DFFDad2A613f7760bE1683F272eA18",
+      "price_registry": "0xfA4edD04eaAcDB07c8D73621bc1790eC50D8c489",
       "wrapped_native": "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
       "src_contracts": {
         "Arbitrum Mainnet": {
-          "on_ramp": "0x98f51B041e493fc4d72B8BD33218480bA0c66DDF",
+          "on_ramp": "0x4e910c8Bbe88DaDF90baa6c1B7850DbeA32c5B29",
           "deployed_at": 0
         },
         "BSC Mainnet": {
-          "on_ramp": "0x8eaae6462816CB4957184c48B86afA7642D8Bf2B",
+          "on_ramp": "0xe6e161d55019AA5960DcF0Af9bB6e4d574C69F99",
           "deployed_at": 0
         },
         "Base Mainnet": {
-          "on_ramp": "0x268fb4311D2c6CB2bbA01CCA9AC073Fb3bfd1C7c",
+          "on_ramp": "0x139D4108C23e66745Eda4ab47c25C83494b7C14d",
           "deployed_at": 0
         },
         "Ethereum Mainnet": {
-          "on_ramp": "0xD0701FcC7818c31935331B02Eb21e91eC71a1704",
+          "on_ramp": "0xe8784c29c583C52FA89144b9e5DD91Df2a1C2587",
           "deployed_at": 0
         },
         "Gnosis Mainnet": {
-          "on_ramp": "0xBd0B9317F6AaA1085993F7b4CD468dE7A6428722",
+          "on_ramp": "0x38fd0DF16F6fD0a2C3Ec6615c73e50F5d027b8bA",
           "deployed_at": 0
         },
         "Optimism Mainnet": {
-          "on_ramp": "0x8629008887E073260c5434D6CaCFc83C3001d211",
+          "on_ramp": "0x3e3b4Fba004E7824219e79aE9f676d9D41A216Fa",
           "deployed_at": 0
         },
         "Polygon Mainnet": {
-          "on_ramp": "0x97500490d9126f34cf9aA0126d64623E170319Ef",
+          "on_ramp": "0x5570a4E979d7460F13b84075ACEF69FAc73914b1",
           "deployed_at": 0
         },
         "WeMix Mainnet": {
-          "on_ramp": "0x9b1ed9De069Be4d50957464b359f98eD0Bf34dd5",
+          "on_ramp": "0x1DA12512f852DAaba7883340A4074FfB73FA8f21",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Arbitrum Mainnet": {
-          "off_ramp": "0x770b1375F86E7a9bf30DBe3F97bea67193dC9135",
-          "commit_store": "0x23E2b34Ce8e12c53f8a39AD4b3FFCa845f8E617C",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x508Ea280D46E4796Ce0f1Acf8BEDa610c4238dB3",
+          "commit_store": "0x20bEde74Da64C9aE47FFDf4B87613752CD13bE5D",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "BSC Mainnet": {
-          "off_ramp": "0x83F53Fc798FEbfFbdF84830AD403b9989187a06C",
-          "commit_store": "0xD8ceCE2D7794385E00Ce3EF94550E732b0A0B959",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x6CDAa2711BdF0B719911BF00588A79FA97bf9264",
+          "commit_store": "0x4c05E7AB694C602De3135e025aEc7F7de06E80F7",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Base Mainnet": {
-          "off_ramp": "0x4d6A796Bc85dcDF41ce9AaEB50B094C6b589748f",
-          "commit_store": "0xc4C4358FA01a04D6c6FE3b96a351946d4c2715C2",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x37879EBFCb807f8C397fCe2f42DC0F5329AD6823",
+          "commit_store": "0xDe615EEaD232BEECF6c9b71c293A387B97814E8D",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Ethereum Mainnet": {
-          "off_ramp": "0x5B833BD6456c604Eb396C0fBa477aD49e82B1A2a",
-          "commit_store": "0x23E23958D220B774680f91c2c91a6f2B2f610d7e",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xE5F21F43937199D4D57876A83077b3923F68EB76",
+          "commit_store": "0xf0F791901854fAb16adeBd60F0639b960B6ea0CF",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Gnosis Mainnet": {
-          "off_ramp": "0xDE7ebf1Dc753D916A9fbEC4ae521Ee74EC2d0B5f",
-          "commit_store": "0x2dbc917b4DD455532015949c3103B64fcDB891b2",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x1181A59FF0BAEd1E0EA77e919185cB8C3D5D3125",
+          "commit_store": "0x60b2Bc7858D6296D8c4370E35a930E5ddF13085E",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Optimism Mainnet": {
-          "off_ramp": "0xb68A3EE8bD0A09eE221cf1859Dd5a4d5765188Fe",
-          "commit_store": "0x83DCeeCf822981F9F8552925eEfd88CAc1905dEA",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x376C0AFC9E64efE0d9202E1F02c3d7f9Dc15e404",
+          "commit_store": "0xF8728f8Cd9C809287e6a97B71A2cdfD2c3C034cE",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Polygon Mainnet": {
-          "off_ramp": "0x19250aBE66B88F214d02B6f3BF80F4118290C619",
-          "commit_store": "0x87A0935cE6254dB1252bBac90d1D07D04846aDCA",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xFf49E35626Eba28Bee1d251782AB75A6cEd91c45",
+          "commit_store": "0xee2570De22C0D07d0FaBC1169dC5EcA342B838Da",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "WeMix Mainnet": {
-          "off_ramp": "0x317dE8bc5c3292E494b6496586696d4966A922B0",
-          "commit_store": "0x97Fbf3d6DEac16adC721aE9187CeEa1e610aC7Af",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xFA5CF1bBFe0Ba5c01e60513EF8960945A99B78A4",
+          "commit_store": "0x671c83B1Ebe798bfC625E99Be0FF7C48F6E4C491",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         }
       }
     },
@@ -219,100 +219,100 @@ Data = """
       "fee_token": "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
       "arm": "0x56491A98199aD2e687Ea9D0cFB7b4AC57B4980Fc",
       "router": "0x34B03Cb9086d7D758AC55af71584F81A598759FE",
-      "price_registry": "0x18C3D917D55Bc1784a3d4729AA3e2C1ecd662fFd",
+      "price_registry": "0xd64aAbD70A71d9f0A00B99F6EFc1626aA2dD43C7",
       "wrapped_native": "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
       "src_contracts": {
         "Arbitrum Mainnet": {
-          "on_ramp": "0x2788b46BAcFF49BD89562e6bA5c5FBbbE5Fa92F7",
+          "on_ramp": "0x5577c19bD183e39a007ce4CE236f1D91e9132D5c",
           "deployed_at": 0
         },
         "Avalanche Mainnet": {
-          "on_ramp": "0x6aa72a998859eF93356c6521B72155D355D0Cfd2",
+          "on_ramp": "0x43F00dBf0Aa61A099c674A74FBdCb93786564950",
           "deployed_at": 0
         },
         "Base Mainnet": {
-          "on_ramp": "0x70bC7f7a6D936b289bBF5c0E19ECE35B437E2e36",
+          "on_ramp": "0xdABb6De5eC48dd2fcF28ac85CbEFe3F19E03F1BD",
           "deployed_at": 0
         },
         "Blast Mainnet": {
-          "on_ramp": "0x02082b23D35d2670B8a636A431F3C30AF9d21e07",
+          "on_ramp": "0x0b7Bfe549F26AF4B6aA5246CB3FD96C8a5c23a68",
           "deployed_at": 0
         },
         "Ethereum Mainnet": {
-          "on_ramp": "0x0Bf40b034872D0b364f3DCec04C7434a4Da1C8d9",
+          "on_ramp": "0x35C724666ba31632A56Bad4390eb69f206ab60C7",
           "deployed_at": 0
         },
         "Gnosis Mainnet": {
-          "on_ramp": "0xAc9fE4179816077674d769698306CE6A7C6A1096",
+          "on_ramp": "0x83AC865c2E18f2CDc1d10126987FfC465e11c0DF",
           "deployed_at": 0
         },
         "Mode Mainnet": {
-          "on_ramp": "0x4A83dA46c148AB5941a379b4cA49f42d14281C78",
+          "on_ramp": "0x9d4d125788A548C2f69fAC7f8C3A64FA21d18C9e",
           "deployed_at": 0
         },
         "Optimism Mainnet": {
-          "on_ramp": "0x4FEB11A454C9E8038A8d0aDF599Fe7612ce114bA",
+          "on_ramp": "0x3A3649852A518ab180f41f28288c6c9184563616",
           "deployed_at": 0
         },
         "Polygon Mainnet": {
-          "on_ramp": "0x6bD4754D86fc87FE5b463D368f26a3587a08347c",
+          "on_ramp": "0x1C88e3Fd2B0a8735D1b19A77AA6e2333555BB95c",
           "deployed_at": 0
         },
         "WeMix Mainnet": {
-          "on_ramp": "0x1467fF8f249f5bc604119Af26a47035886f856BE",
+          "on_ramp": "0x9BaFC5E78C0051c7Bcd1EF37FF02fcBd31B37a72",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Arbitrum Mainnet": {
-          "off_ramp": "0x3DA330fd8Ef10d93cFB7D4f8ecE7BC1F10811feC",
-          "commit_store": "0x86D55Ff492cfBBAf0c0D42D4EE615144E78b3D02",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x2A9C65afF39758CeAa24dBD1ACd1BeB3618e6780",
+          "commit_store": "0x99C7C97Ed175A3f0BFd4f52526E7B1310bB3fc16",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Avalanche Mainnet": {
-          "off_ramp": "0x37a6fa55fe61061Ae97bF7314Ae270eCF71c5ED3",
-          "commit_store": "0x1f558F6dcf0224Ef1F78A24814FED548B9602c80",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xc69a550470bEbC5c3Be98A4C3dD26C6AdD90C64b",
+          "commit_store": "0x49FeF2978569E8061a7CA5cC676d46970613e9D0",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Base Mainnet": {
-          "off_ramp": "0x574c697deab06B805D8780898B3F136a1F4892Dc",
-          "commit_store": "0x002B164b1dcf4E92F352DC625A01Be0E890EdEea",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x133672C0F0067573254dd7C8C9818a37d6208610",
+          "commit_store": "0xEc44EFcf3E0aC801C742e444B130918a5a3A87E9",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Blast Mainnet": {
-          "off_ramp": "0x6500EDFBD27d34b7B69D0D45865ddaC4A1ceafE1",
-          "commit_store": "0x3A328B3fA852409415c15271442EFE4c77C04992",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x38cA434FE65D540942A36c84FdFD4B7C7a9a4612",
+          "commit_store": "0xF70409dC69Bc50aA30b001d45C7F9E2C706Ad387",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Ethereum Mainnet": {
-          "off_ramp": "0x181Bb1E97b0bDD1D85E741ad0943552D3682cc35",
-          "commit_store": "0x3fF27A34fF0FA77921C3438e67f58da1a83e9Ce1",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xF616733641D420207b8F30db9C4cE39684768991",
+          "commit_store": "0x7aa39A9c9D539b5E7388872a193b3447D34bf11F",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Gnosis Mainnet": {
-          "off_ramp": "0xBE9b0cc569E970dAb953d336c670fc6b7c856c19",
-          "commit_store": "0xEe89CC6C2236d3b99C2D9c0b3b911690F757FadF",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x53AF5cE4534C39582E6a5E3fD77946E0c3BFe870",
+          "commit_store": "0xe7a0Ffc182E2330d19fF79adEEC637094c02dcA3",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Mode Mainnet": {
-          "off_ramp": "0x6C702159daA4DEbae32E294c584B1EaF2356cB1A",
-          "commit_store": "0x73C8d1E9e240331E3345c6fBe6CDFC71B742B69C",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xFc2278eBc27B9d205e3DC9F1b88D6D863D71190D",
+          "commit_store": "0x92eeb265F465Aff3AE708117ba7aE35279227845",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Optimism Mainnet": {
-          "off_ramp": "0xE7E080C8d62d595a223C577C7C8d1f75d9A5E664",
-          "commit_store": "0xF4d53346bDb6d393C74B0B72Aa7D6689a3eAad79",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x3c5E62cdFD08e23a0961ff2A3155CaBb96cbc89D",
+          "commit_store": "0xDC39E05264D0C17eD16F2Db363364B127Cf56d75",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Polygon Mainnet": {
-          "off_ramp": "0x26af2046Da85d7f6712D5edCa81B9E3b2e7A60Ab",
-          "commit_store": "0x4C1dA405a789AC2853A69D8290B8B9b47a0374F8",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x21159ebdA3E6A2437bCD6ef39853042ACC436D2D",
+          "commit_store": "0x018Bb120265672C699969a9e2193755d4CF1ca16",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "WeMix Mainnet": {
-          "off_ramp": "0xC027C5AEb230008c243Be463A73571e581F94c13",
-          "commit_store": "0x2EB426C8C54D740d1FC856eB3Ff96feA03957978",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x512CA54a0F6447AC41c07Da3336DFcA042D88A7B",
+          "commit_store": "0xae79C737801b04ECA277d50FDeaC4006C3725F62",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         }
       }
     },
@@ -321,91 +321,91 @@ Data = """
       "fee_token": "0x4200000000000000000000000000000000000006",
       "arm": "0x91cB19E7c4Ba9B08CF544cDc9143042150B007C3",
       "router": "0x881e3A65B4d4a04dD529061dd0071cf975F58bCD",
-      "price_registry": "0x1bA15c57c8b74cD32443D7583E7f6d7c638aCf46",
+      "price_registry": "0x6337a58D4BD7Ba691B66341779e8f87d4679923a",
       "wrapped_native": "0x4200000000000000000000000000000000000006",
       "src_contracts": {
         "Arbitrum Mainnet": {
-          "on_ramp": "0x1E5Ca70d1e7A1B26061125738a880BBeA42FeB21",
+          "on_ramp": "0x9D0ffA76C7F82C34Be313b5bFc6d42A72dA8CA69",
           "deployed_at": 0
         },
         "Avalanche Mainnet": {
-          "on_ramp": "0xBE5a9E336D9614024B4Fa10D8112671fc9A42d96",
+          "on_ramp": "0x4be6E0F97EA849FF80773af7a317356E6c646FD7",
           "deployed_at": 0
         },
         "BSC Mainnet": {
-          "on_ramp": "0xdd4Fb402d41Beb0eEeF6CfB1bf445f50bDC8c981",
+          "on_ramp": "0xE5FD5A0ec3657Ad58E875518e73F6264E00Eb754",
           "deployed_at": 0
         },
         "Blast Mainnet": {
-          "on_ramp": "0xCCC32e2794EaD73f0a0a514Ac1c78D048968ab81",
+          "on_ramp": "0x9A59832b85217C20b17a990A45BD5d0F3de36266",
           "deployed_at": 0
         },
         "Ethereum Mainnet": {
-          "on_ramp": "0xDEA286dc0E01Cb4755650A6CF8d1076b454eA1cb",
+          "on_ramp": "0x56b30A0Dcd8dc87Ec08b80FA09502bAB801fa78e",
           "deployed_at": 0
         },
         "Gnosis Mainnet": {
-          "on_ramp": "0xcDD0e963E0708a4E936202396983E458cFA4A363",
+          "on_ramp": "0xDcFB24AEbcB9Edfb6746a045DDcae402381F984B",
           "deployed_at": 0
         },
         "Mode Mainnet": {
-          "on_ramp": "0x626aCCbDDD73532df1caEDb5628Fdc40C5f429Ba",
+          "on_ramp": "0xEB50Fc6F57AAc6bf060A2Dfc6479fED592e6e184",
           "deployed_at": 0
         },
         "Optimism Mainnet": {
-          "on_ramp": "0xd952FEAcDd5919Cc5E9454b53bF45d4E73dD6457",
+          "on_ramp": "0x362E6bE957c18e268ad91046CA6b47EB09AD98C1",
           "deployed_at": 0
         },
         "Polygon Mainnet": {
-          "on_ramp": "0x3DB8Bea142e41cA3633890d0e5640F99a895D6A5",
+          "on_ramp": "0xd3Bde678BB706Cf727A512515C254BcF021dD203",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Arbitrum Mainnet": {
-          "off_ramp": "0x8531E63aE9279a1f0D09eba566CD1b092b95f3D5",
-          "commit_store": "0x327E13f54c7871a2416006B33B4822eAAD357916",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x7D38c6363d5E4DFD500a691Bc34878b383F58d93",
+          "commit_store": "0x17891fe60a577c5E1e4a4Ddd78E642428A56039f",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Avalanche Mainnet": {
-          "off_ramp": "0x8345F2fF67e5A65e85dc955DE1414832608E00aD",
-          "commit_store": "0xd0b13be4c53A6262b47C5DDd36F0257aa714F562",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x61C3f6d72c80A3D1790b213c4cB58c3d4aaFccDF",
+          "commit_store": "0x700C6715734111a6D1Cf414F46D85627b298B5dd",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "BSC Mainnet": {
-          "off_ramp": "0x48a51f5D38BE630Ddd6417Ea2D9052B8efc91a18",
-          "commit_store": "0xF97127e77252284EC9D4bc13C247c9D1A99F72B0",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x45d524b6Fe99C005C52C65c578dc0e02d9751083",
+          "commit_store": "0x1ccD0D49e283789a73E882B0ED4B5b1163675c3C",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Blast Mainnet": {
-          "off_ramp": "0x15F54FDd37ccC8E5a0b64633C95Ef8209Fd86401",
-          "commit_store": "0x52b5b4f3Cc50E38f736f23897f192430E131ccB8",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x941F0E2E0556aCf60fE0f09972f599d9F8916F01",
+          "commit_store": "0x575F920e3ef294EA80efB1A4C815EF4B8a67878F",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Ethereum Mainnet": {
-          "off_ramp": "0xEC0cFe335a4d53dBA70CB650Ab56eEc32788F0BB",
-          "commit_store": "0x0ae3c2c7FB789bd05A450CD3075D11f6c2Ca4F77",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xCA04169671A81E4fB8768cfaD46c347ae65371F1",
+          "commit_store": "0xb40659aACb709D1D54c80FC0d38b15705358Ce0B",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Gnosis Mainnet": {
-          "off_ramp": "0xA24D3Bc3A59798a57AF58f69c89DC1C8aFD78F18",
-          "commit_store": "0x672dbdC3aF7eE37436fe101531D33266D85F33c9",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x300977dBA924af14E166B31F4926892B1f310661",
+          "commit_store": "0x932D6D5c6647e6495Ed3473ff0F4e31a6056D837",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Mode Mainnet": {
-          "off_ramp": "0xFC30bFe46b11D4E25C6f7492fd064A70FbF18848",
-          "commit_store": "0xaeDBe55633F74A291F0A43Daa0Fd719615b78363",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x639Dc04368006544eba7CbC959f3e4361bfEAB0d",
+          "commit_store": "0x2D3FC7f8b03718157359266ac06AF6373aFee2f1",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Optimism Mainnet": {
-          "off_ramp": "0xf50c0d2a8B6Db60f1D93E60f03d0413D56153E4F",
-          "commit_store": "0x16f72C15165f7C9d74c12fDF188E399d4d3724e4",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x18095fbD53184A50C2BB3929a6c62Ca328732062",
+          "commit_store": "0xa8FA8aE51dB9661e7D1c21141d967d07110036cb",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Polygon Mainnet": {
-          "off_ramp": "0x75F29f058b31106F99caFdc17c9b26ADfcC7b5D7",
-          "commit_store": "0xb719616E732581B570232DfB13Ca49D27667Af9f",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x74d574D11977fC8D40f8590C419504cbE178ADB7",
+          "commit_store": "0x565f70396Ff82C23d25Dd3E57A9A66367dccdF3B",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         }
       }
     },
@@ -418,42 +418,42 @@ Data = """
       "wrapped_native": "0x4300000000000000000000000000000000000004",
       "src_contracts": {
         "Arbitrum Mainnet": {
-          "on_ramp": "0x42E1f5f5ACCe6e4971D9B9468D7A9Abed8D69DdD",
+          "on_ramp": "0x28f7E57cEE31241B4B8B72e6b710c4dC2e9bEb28",
           "deployed_at": 0
         },
         "BSC Mainnet": {
-          "on_ramp": "0x9c98d7aE731b0A53bedffBc1a12d9d43501Ea464",
+          "on_ramp": "0x01D1A2Ed2053e410177f8E762aF635ee78b7a581",
           "deployed_at": 0
         },
         "Base Mainnet": {
-          "on_ramp": "0x955f139225F5d7021EB911ED2787a795f71E5eb6",
+          "on_ramp": "0xAbBC1fC0C919ecFb0220e90749111e0619abf79A",
           "deployed_at": 0
         },
         "Ethereum Mainnet": {
-          "on_ramp": "0xBD9bf9AA79adF083BB7100848Eb15F4e8282E27e",
+          "on_ramp": "0xEa8112530cA10945C2aA976f8F615582Af9B70fa",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Arbitrum Mainnet": {
-          "off_ramp": "0x01A38cd2da195C704bA192fCCDddd8986cb7EdE9",
-          "commit_store": "0xab6D69db1C1E9B97a26eB3983b0878AdeD248200",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x8e4E966a3f6b3aB56185800a2afFe75CCf7B4DfD",
+          "commit_store": "0x4a577dC79BfeF5C84a55EF6Df30400083F16AE8d",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "BSC Mainnet": {
-          "off_ramp": "0xabC7Dffb2590c44a201EC7532382e1fc01Cd9eEb",
-          "commit_store": "0xA3086bf1D609d8e8028E8339e4aa4362C7da339D",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x9A9f3714b517231869b97F3b49E2ba1009499d9b",
+          "commit_store": "0xAB0eCFDE9E681B1CD04D6C5536BafdBada180716",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Base Mainnet": {
-          "off_ramp": "0x0406F8f66C10Da99ff518bc2242e0Ec486a2c787",
-          "commit_store": "0xc6A97d753a3001e0B893e5FA2b0ec3d623af6C20",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x5837622b622D3c88Faf5491324575f5c0BB40001",
+          "commit_store": "0x9fAE0d8F4A15Fb96B999aad81a1C0e39deFDF49e",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Ethereum Mainnet": {
-          "off_ramp": "0x4e0092bBC8EfAb6Eca295caB66986193b90a1Bb9",
-          "commit_store": "0xd7cA96B58EE33FdB3aa1392c30eD02645b1F28e2",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xFf094AC08B0AA8Ab3d29e034a51199a0ddE3d8C8",
+          "commit_store": "0x544f068b14e4FAc004579f158ccCE14225264c71",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         }
       }
     },
@@ -466,15 +466,15 @@ Data = """
       "wrapped_native": "0x2021B12D8138e2D63cF0895eccABC0DFc92416c6",
       "src_contracts": {
         "Ethereum Mainnet": {
-          "on_ramp": "0x27C96A8a2f70a8408aD6c620717a3bDaA54bb10b",
+          "on_ramp": "0xc319484eF6cdA3a7f4D470e660b343FB569e9A1e",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Ethereum Mainnet": {
-          "off_ramp": "0x90902C0AEE857F3A42f2beBEa38724cE7b7a0cff",
-          "commit_store": "0x25adA90B241143DD5Df04Fb06C1fF6E7f7624ad9",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x1B12D218280DD1767304A00070101a91f7A61470",
+          "commit_store": "0x8Ad3FEFf222e2200CbC79cC3AdbaE3b64a37d1F8",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         }
       }
     },
@@ -483,127 +483,127 @@ Data = """
       "fee_token": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
       "arm": "0xdCD48419bD5Cd9d1b097695F2af4Ee125aADF84F",
       "router": "0x80226fc0Ee2b096224EeAc085Bb9a8cba1146f7D",
-      "price_registry": "0x020082A7a9c2510e1921116001152DEE4da81985",
+      "price_registry": "0x8c9b2Efb7c64C394119270bfecE7f54763b958Ad",
       "wrapped_native": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
       "src_contracts": {
         "Arbitrum Mainnet": {
-          "on_ramp": "0x925228D7B82d883Dde340A55Fe8e6dA56244A22C",
+          "on_ramp": "0x69eCC4E2D8ea56E2d0a05bF57f4Fd6aEE7f2c284",
           "deployed_at": 0
         },
         "Avalanche Mainnet": {
-          "on_ramp": "0x3df8dAe2d123081c4D5E946E655F7c109B9Dd630",
+          "on_ramp": "0xaFd31C0C78785aDF53E4c185670bfd5376249d8A",
           "deployed_at": 0
         },
         "BSC Mainnet": {
-          "on_ramp": "0x91D25A56Db77aD5147437d8B83Eb563D46eBFa69",
+          "on_ramp": "0x948306C220Ac325fa9392A6E601042A3CD0b480d",
           "deployed_at": 0
         },
         "Base Mainnet": {
-          "on_ramp": "0xe2c2AB221AA0b957805f229d2AA57fBE2f4dADf7",
+          "on_ramp": "0xb8a882f3B88bd52D1Ff56A873bfDB84b70431937",
           "deployed_at": 0
         },
         "Blast Mainnet": {
-          "on_ramp": "0x4545F9a17DA50110632C14704a15d893BF9CBD27",
+          "on_ramp": "0x6751cA96b769129dFE6eB8E349c310deCEDb4e36",
           "deployed_at": 0
         },
         "Celo": {
-          "on_ramp": "0xEd5bE9508ae56531cc0EDe6A3bD588Eb9E2e3cfa",
+          "on_ramp": "0x741599d9a5a1bfC40A22f530fbCd85E2718e9F90",
           "deployed_at": 0
         },
         "Gnosis Mainnet": {
-          "on_ramp": "0xF538dA6c673A30338269655f4e019B71ba58CFd4",
+          "on_ramp": "0xf50B9A46C394bD98491ce163d420222d8030F6F0",
           "deployed_at": 0
         },
         "Metis Andromeda": {
-          "on_ramp": "0xa5ef33B57dD8B653F9A9EA7114f46376d18264aC",
+          "on_ramp": "0x75d536eED32f4c8Bb39F4B0c992163f5BA49B84e",
           "deployed_at": 0
         },
         "Mode Mainnet": {
-          "on_ramp": "0x466a078d17e3706a9414ACc48029EE9Bae4C9b65",
+          "on_ramp": "0xeA6d4a24B262aB3e61a8A62f018A30beCD086f82",
           "deployed_at": 0
         },
         "Optimism Mainnet": {
-          "on_ramp": "0x86B47d8411006874eEf8E4584BdFD7be8e5549d1",
+          "on_ramp": "0x3455D8E039736944e66e19eAc77a42e8077B07bf",
           "deployed_at": 0
         },
         "Polygon Mainnet": {
-          "on_ramp": "0x35F0ca9Be776E4B38659944c257bDd0ba75F1B8B",
+          "on_ramp": "0x15a9D79d6b3485F70bF82bC49dDD1fcB37A7149c",
           "deployed_at": 0
         },
         "WeMix Mainnet": {
-          "on_ramp": "0xCbE7e5DA76dC99Ac317adF6d99137005FDA4E2C4",
+          "on_ramp": "0xdEFeADd30D5BFD403d86245b43e39a73d76423cC",
           "deployed_at": 0
         },
         "ZKSync Mainnet": {
-          "on_ramp": "0xD54C93A99CBCb8D865E13DA321B540171795A89f",
+          "on_ramp": "0x9B14AE850653dD0E30fBC93ab7f77D0d638a365B",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Arbitrum Mainnet": {
-          "off_ramp": "0xeFC4a18af59398FF23bfe7325F2401aD44286F4d",
-          "commit_store": "0x9B2EEd6A1e16cB50Ed4c876D2dD69468B21b7749",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xdf615eF8D4C64d0ED8Fd7824BBEd2f6a10245aC9",
+          "commit_store": "0xf7B343A17445F175f2Dd9f5CB29BAf0a8dE75ed3",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Avalanche Mainnet": {
-          "off_ramp": "0x569940e02D4425eac61A7601632eC00d69f75c17",
-          "commit_store": "0x2aa101BF99CaeF7fc1355D4c493a1fe187A007cE",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xd98E80C79a15E4dbaF4C40B6cCDF690fe619BFBb",
+          "commit_store": "0xA9f9bF2b643348c0884f2eBA4F712E833DA9a2b8",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "BSC Mainnet": {
-          "off_ramp": "0x7Afe7088aff57173565F4b034167643AA8b9171c",
-          "commit_store": "0x87c55D48DF6EF7B08153Ab079e76bFEcbb793D75",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x66d84fedED0e51aeB47ceD1BB2fc0221Ae8D7C12",
+          "commit_store": "0x9B9Ec8E26955c034828bBD78E22ab258d983dCdb",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Base Mainnet": {
-          "off_ramp": "0xdf85c8381954694E74abD07488f452b4c2Cddfb3",
-          "commit_store": "0x8DC27D621c41a32140e22E2a4dAf1259639BAe04",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x6B4B6359Dd5B47Cdb030E5921456D2a0625a9EbD",
+          "commit_store": "0xDaC3A82Cc5e7C137bF28e6EF4F68f29D66205ffe",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Blast Mainnet": {
-          "off_ramp": "0x1a904DbbaDdE629a1460e2F6E2E485Ce06Ed7599",
-          "commit_store": "0x3CB2A81bb8a188C5353CdFa9994ed8666556FC53",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xF4468E56179e6EF59d6f5B133D9355AAD91Ea9ae",
+          "commit_store": "0x52275dC17f9eD92230C8C4d57fD36d128701f694",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Celo": {
-          "off_ramp": "0xd5083684eE92dDeA117636ae5E2F1cb7fE4dfd46",
-          "commit_store": "0x831097033C88c82a7F1897b168Aa88cC44540C8f",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x794aE32b63b8a82a6e2Ec5017bbC6bfbddA5ce96",
+          "commit_store": "0x95deB0c4bB9168202d50E874865f9A1842b82D64",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Gnosis Mainnet": {
-          "off_ramp": "0xE93ec2A57e38C8541c893348cCafEAB01F7D47d4",
-          "commit_store": "0x118a9389960F86390A4F14ce4C95D6ff076C6bFC",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x70C705ff3eCAA04c8c61d581a59a168a1c49c2ec",
+          "commit_store": "0x9D93D536Ced80871Bf3DA5Bb47bAedE62c794f8A",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Metis Andromeda": {
-          "off_ramp": "0xCe6364dBe64D2789D916180131fAda2ABFF702E8",
-          "commit_store": "0x3d8a95adA63D406ee8232562AbD83CEdb0B90466",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x330349112e13232131Da51f9f3b153d825f65e61",
+          "commit_store": "0x0f89C7c0586536B618e0469402e1c8234bc52959",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Mode Mainnet": {
-          "off_ramp": "0xE8af3b68eDfFf65Ce48648009982380701f09B92",
-          "commit_store": "0x76264869a3eBF51a59FCa5ABa84ee2867c7F190e",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xb57D52F7Cb7BBD19a117585bbaf712108E56dd8f",
+          "commit_store": "0x01346721418045A6c07b71052e452eF8615e9084",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Optimism Mainnet": {
-          "off_ramp": "0xB095900fB91db00E6abD247A5A5AD1cee3F20BF7",
-          "commit_store": "0x4af4B497c998007eF83ad130318eB2b925a79dc8",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x562a2025E60AA19Aa03Ea41D70ea1FD3286d1D3B",
+          "commit_store": "0x83F3DA5aa2C7534d694B0acde7624573c830250D",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Polygon Mainnet": {
-          "off_ramp": "0x0af338F0E314c7551bcE0EF516d46d855b0Ee395",
-          "commit_store": "0xD37a60E8C36E802D2E1a6321832Ee85556Beeb76",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x718672076D6d51E4c76142B37bC99E4945d704a3",
+          "commit_store": "0x57b548C9c213EA2bcf60193E3D7fd2d2b53Fb9b3",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "WeMix Mainnet": {
-          "off_ramp": "0x3a129e6C18b23d18BA9E6Aa14Dc2e79d1f91c6c5",
-          "commit_store": "0x31f6ab382DDeb9A316Ab61C3945a5292a50a89AB",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xc1EcCE580B2C96f4fd202fB7c2a259ECe19a1bF2",
+          "commit_store": "0xA4755Cd68CA2092447c8c842659a2931f9110320",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "ZKSync Mainnet": {
-          "off_ramp": "0xb368c8946D9fa5A497cDe1Dff7213f9CdfD143Bf",
-          "commit_store": "0xa4d264470a67D9f6682EE12Bdc9c35Df44e3F194",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x6868FefbEFDc2B2FB75E6ED216dB1BeC02563D69",
+          "commit_store": "0x0d26BaE784c8986502E072F4e73B6168e2052045",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         }
       }
     },
@@ -616,69 +616,69 @@ Data = """
       "wrapped_native": "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d",
       "src_contracts": {
         "Arbitrum Mainnet": {
-          "on_ramp": "0x7A36511202f54a8A3Bc62Cc1df24bd391f7c9864",
+          "on_ramp": "0x140E6D5ba903F684944Dd27369d767DdEf958c9B",
           "deployed_at": 0
         },
         "Avalanche Mainnet": {
-          "on_ramp": "0x732753869bc6bB07Ec81A403F926bbF6fC2FeaE2",
+          "on_ramp": "0xB707a6D1d32CE99D5c669DeE71D30d25a066D32c",
           "deployed_at": 0
         },
         "BSC Mainnet": {
-          "on_ramp": "0xD5d33bc0BF395B39514B7f9f8F66ebc9D8e650Cb",
+          "on_ramp": "0xb485634dd2E545091722b9d4843d3644addf97e3",
           "deployed_at": 0
         },
         "Base Mainnet": {
-          "on_ramp": "0x400eFb50480a73FEc02b115b53F0Ec6EcFf03C67",
+          "on_ramp": "0xAAb6D9fc00aAc37373206e91789CcDE1E851b3E4",
           "deployed_at": 0
         },
         "Ethereum Mainnet": {
-          "on_ramp": "0x0F246651F1c2275B4E14d8ae166D1fd3Af05c405",
+          "on_ramp": "0x014ABcfDbCe9F67d0Df34574664a6C0A241Ec03A",
           "deployed_at": 0
         },
         "Optimism Mainnet": {
-          "on_ramp": "0x391516732884d3F8Eec3301C19b819E6e6044C17",
+          "on_ramp": "0x9379b446fcA75CA57834a4dA33f64ae317Be05e4",
           "deployed_at": 0
         },
         "Polygon Mainnet": {
-          "on_ramp": "0x566c7A2Cb557c36082301B97E998721D14E4bF7d",
+          "on_ramp": "0xD7a49AfEA62E77Ad6BEB2ed64673026271aae188",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Arbitrum Mainnet": {
-          "off_ramp": "0x1bee1FD97824288a36B725f9CF20E07A67d5113b",
-          "commit_store": "0xB3a48e8664C5dE26822ae44577b100b717C36a54",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x2C1539696E29012806a15Bcd9845Ed1278a9fd63",
+          "commit_store": "0x5b1762a6023157edaf2c46c818f447B1940765D6",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Avalanche Mainnet": {
-          "off_ramp": "0x633c19cCD7A818770f7BF59eB9C5AB632CDbc4D5",
-          "commit_store": "0xbbC073fb2D424eA45A571cc4dd91745E45d0aC73",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xe596D90EF0AEe10257109AC8394a85F8944bF6D0",
+          "commit_store": "0xd6Dc07804AE06f575C28094F99aCdDC1535904e7",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "BSC Mainnet": {
-          "off_ramp": "0x4D90524de5783257fd64d1a20689a5b9Bad25de0",
-          "commit_store": "0xAae8De9f1B7e2FFF0563c2BBf0c69593BD517b52",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x972a85d7ba0209F1896992B2687cC728cf769e50",
+          "commit_store": "0x5FB18729651f1EDA5ed5ac67594FD94Fa3DBcd29",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Base Mainnet": {
-          "off_ramp": "0x9118303DE7f4342F9B057f6EC1Be282aa543D99C",
-          "commit_store": "0xa75f463b8a1d8bf7694Ac13E02938894F45eFbaA",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xbeEDd1C5C13C5886c3d600e94Ff9e82C04A53C38",
+          "commit_store": "0x392304E3cb636f75Dc95340672F3b8A2359d5Ebc",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Ethereum Mainnet": {
-          "off_ramp": "0xFF61E57A2eE83FA262006C2DaF0D5fB2b36F3070",
-          "commit_store": "0xF433De9A293553c133E2dB90e226c2F2911f435C",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x658d9ae41A9c291De423d3B4B6C064f6dD0e7Ed2",
+          "commit_store": "0xd23391fCBb8a41b971f90bC6e95CC8beaD885221",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Optimism Mainnet": {
-          "off_ramp": "0x9D3aA479525a5BcE776dD83769e9F9b5B4dD4193",
-          "commit_store": "0x2B721632693A8BbABa3bA5F125C8cD33D66F28F7",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xd84E2316634ab6516Ecc829E2367633bfB3e4B6D",
+          "commit_store": "0x9d432DaF8aF8803baF6Cf560CF0f115c7D7b7f16",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Polygon Mainnet": {
-          "off_ramp": "0x9714098CDdAc380D4443293C55B6CBf6D6bbDbEb",
-          "commit_store": "0x4338f204C7698eE678d6c44117503f812ca1FA69",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x6d6a4a60E0E23dbea089c0fEbbA9c5912f02bc57",
+          "commit_store": "0x9CBe49E232aEF27B9d98aC752354879efd7b1E70",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         }
       }
     },
@@ -691,15 +691,15 @@ Data = """
       "wrapped_native": "0x4200000000000000000000000000000000000001",
       "src_contracts": {
         "WeMix Mainnet": {
-          "on_ramp": "0x3C5Ab46fA1dB1dECD854224654313a69bf9fcAD3",
+          "on_ramp": "0xf3baf38136b55F656CC5fdd4417EB6C160877104",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "WeMix Mainnet": {
-          "off_ramp": "0x2B555774B3D1dcbcd76efb7751F3c5FbCFABC5C4",
-          "commit_store": "0x213124614aAf31eBCE7c612A12aac5f8aAD77DE4",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xcB154Bb4ed63FC30C416Dd16A2d1C64D8DE8DfD5",
+          "commit_store": "0x6091D319080D06e1b656F83Ff001DAc124C55613",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         }
       }
     },
@@ -712,24 +712,24 @@ Data = """
       "wrapped_native": "0x75cb093E4D61d2A2e65D8e0BBb01DE8d89b53481",
       "src_contracts": {
         "Arbitrum Mainnet": {
-          "on_ramp": "0x87353b87A373E1551D27EDacDaC1644741c6499F",
+          "on_ramp": "0x8d3039fE2400151c06Ae84a18CAf38dD9b6Ce58b",
           "deployed_at": 0
         },
         "Ethereum Mainnet": {
-          "on_ramp": "0xE43f9eD3146d76E627C2504E5140005027992De6",
+          "on_ramp": "0xdF5394c57A0570ECe45DE0c0fA2e722A672B9198",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Arbitrum Mainnet": {
-          "off_ramp": "0x2cc33de75dAFDb3F8F4f24244a9C420374e2C001",
-          "commit_store": "0x67fE38dB73be154a1f1a63221F898B9d5EE4eF63",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xc6bA5a79991b3775F28259BA551b30eCb0b6D499",
+          "commit_store": "0xb81b0EE9675879a2Dcaa70CCC3b2c2D38fa404b0",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Ethereum Mainnet": {
-          "off_ramp": "0xc2B1A8c931582D041ba5fF30AEB9fA828B30754d",
-          "commit_store": "0x90073Ea7A1Ee4Fe5d638B4216Bc60479Eba52001",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x1fd37Bf813D0723BEF614bC93d9D2Ce1AcB3228f",
+          "commit_store": "0x7C1efda9F744a2B4f88b924B03C6d6B53E3E390F",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         }
       }
     },
@@ -742,51 +742,51 @@ Data = """
       "wrapped_native": "0x4200000000000000000000000000000000000006",
       "src_contracts": {
         "Arbitrum Mainnet": {
-          "on_ramp": "0x65Ad802d80aD6a96C5a4bc9e57E16099de99Dc7F",
+          "on_ramp": "0xb2e694efcDa0aeB81700019c3047F92fC3bb520E",
           "deployed_at": 0
         },
         "BSC Mainnet": {
-          "on_ramp": "0x8C5149ff7Cfd99dd561caE9B7abFAA0Ef79eAbeC",
+          "on_ramp": "0xeb7E8c40E95Cd31666359AaeB1F2CccaAB935643",
           "deployed_at": 0
         },
         "Base Mainnet": {
-          "on_ramp": "0x71dB32eF442c29d8cbf72a9AFcb1Ef12B35b0BF4",
+          "on_ramp": "0x347A070EA1B04bc2b4A8f14320688C277022C90e",
           "deployed_at": 0
         },
         "Ethereum Mainnet": {
-          "on_ramp": "0xbD5F9C193a7fEF5D578C55Ddfe4d08d6BCc15648",
+          "on_ramp": "0x7d2aF78868993a5a86676BA639eC0412709707D9",
           "deployed_at": 0
         },
         "Optimism Mainnet": {
-          "on_ramp": "0x659303e8d4306D3ea8676FB034d56FB6f37E19d9",
+          "on_ramp": "0x7AB4329D19A0255DA90Ee8dbAA60f8f0cB7950C1",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Arbitrum Mainnet": {
-          "off_ramp": "0x8d3E1b15ebC96cec1ffc092cEcAeA6c1DD00aF9b",
-          "commit_store": "0x1f1DEa0210aE346A20E270a1C3355d99b0B949D2",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x0Cb870C12013c2d5743585F85b298e129cE57203",
+          "commit_store": "0x682Af2Cfaa5aE554eF222728fF7C7168232e2Ea5",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "BSC Mainnet": {
-          "off_ramp": "0x7a57670Fa0Cf1Bc2665a1Ae0f5031b9f5a43dD3a",
-          "commit_store": "0x18ffb74D94175d00D8bB67B70737dE2cE45eed07",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xdfA601DA2163Ca2C77Eb32126E6B7A97024f6181",
+          "commit_store": "0xb88F947C85b1c6B1E2A0C22792BA58C40c07a644",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Base Mainnet": {
-          "off_ramp": "0xEfa90cE6289A2777cd5B8fb991B2D0Be44cA5067",
-          "commit_store": "0xACa5f0942Bb7fF297A7c25E8364373702D81bb3f",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x30612D8fb7EcD05ECb863560BA8806d88e8BbFAF",
+          "commit_store": "0xf84d023CCFF8b74e565117cBc034859D06EA1976",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Ethereum Mainnet": {
-          "off_ramp": "0xdF8f09AB4DfB49dEC8a0B8b7f1B7F4134252D3e9",
-          "commit_store": "0x8Ae635d264f20f1dbC0dea03712C194AdbeF50D1",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xb1caBa234721b8F12C545B3dC25B3F87f6a9c91B",
+          "commit_store": "0x67Ff921DA5d0B61a9b05BDFa92d9f5f992d7861a",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Optimism Mainnet": {
-          "off_ramp": "0xE4D6AAF678b986D3E6B7A85FA33d0519716a5525",
-          "commit_store": "0xBF80E30c8c013Ec0d05e2a959CF8000407C813EC",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x4adcD1FB4ec76A3c9960E048f81C19A51B2eAC49",
+          "commit_store": "0x7B58aF65DFD717fC0d044D860c8f9A85Ca6813D6",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         }
       }
     },
@@ -795,91 +795,91 @@ Data = """
       "fee_token": "0x4200000000000000000000000000000000000006",
       "arm": "0x1c51b6D5BFcFB7ee82C80949DFD146dB157a7E49",
       "router": "0x3206695CaE29952f4b0c22a169725a865bc8Ce0f",
-      "price_registry": "0x9270AAA75F4B9038f4c25fEc665B02a150a90361",
+      "price_registry": "0xb52545aECE8C73A97E52a146757EC15b90Ed8488",
       "wrapped_native": "0x4200000000000000000000000000000000000006",
       "src_contracts": {
         "Arbitrum Mainnet": {
-          "on_ramp": "0x0C9BE7Cfd12c735E5aaE047C1dCB845d54E518C3",
+          "on_ramp": "0x6bA81b83091A23e8F2AA173B2b939fAf9E320DfB",
           "deployed_at": 0
         },
         "Avalanche Mainnet": {
-          "on_ramp": "0xD0D3E757bFBce7ae1881DDD7F6d798DDcE588445",
+          "on_ramp": "0xB9D655Ad5ba80036725d6c753Fa6AF0454cBF630",
           "deployed_at": 0
         },
         "BSC Mainnet": {
-          "on_ramp": "0xa3c9544B82846C45BE37593d5d9ACffbE61BF3A6",
+          "on_ramp": "0xfC51a4CF925f202d86c6092cda879689d2C17201",
           "deployed_at": 0
         },
         "Base Mainnet": {
-          "on_ramp": "0x0b1760A8112183303c5526C6b24569fd3A274f3B",
+          "on_ramp": "0xfE11cfC957cCa331192EAC60040b442303CcA0a9",
           "deployed_at": 0
         },
         "Ethereum Mainnet": {
-          "on_ramp": "0x55183Db1d2aE0b63e4c92A64bEF2CBfc2032B127",
+          "on_ramp": "0xE4C51Dc01A4E0aB14c7a7a2ed1655E9CF8A3E698",
           "deployed_at": 0
         },
         "Gnosis Mainnet": {
-          "on_ramp": "0x14aA3CC03583aA557DBca4ce72288Cc5F37DDE34",
+          "on_ramp": "0x604a9dda2e27D56cfCe457E437a61f4ED0De9dE6",
           "deployed_at": 0
         },
         "Mode Mainnet": {
-          "on_ramp": "0x034eA573B049210315110f7eA11c9618E32F08Ae",
+          "on_ramp": "0xc6d9Cb39e34D83d21A021504024887A0e96D4e94",
           "deployed_at": 0
         },
         "Polygon Mainnet": {
-          "on_ramp": "0x6B57145e322c877E7D91Ed8E31266eB5c02F7EfC",
+          "on_ramp": "0x9c725164b60E3f6d4d5b7A2841C63E9FD0988805",
           "deployed_at": 0
         },
         "WeMix Mainnet": {
-          "on_ramp": "0x82e9f4C5ec4a84E310d60D462a12042E5cbA0954",
+          "on_ramp": "0x6Dbc8D4e5556FD0B82bB0D67c94D0fA1cd288AbD",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Arbitrum Mainnet": {
-          "off_ramp": "0xaC8C94242aa8234Bf89682aBcDDf805AE8cff61D",
-          "commit_store": "0x55028780918330FD00a34a61D9a7Efd3f43ca845",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xEB3d6956BCf7b1E29634C8cd182fC9FA740Bce34",
+          "commit_store": "0x6569761680DaC4Bf940244E3cF198A069E34E91F",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Avalanche Mainnet": {
-          "off_ramp": "0x8dc6490A6204dF846BaBE809cB695ba17Df1F9B1",
-          "commit_store": "0xA190660787B6B183Dd82B243eA10e609327c7308",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xF8E38B4503418659F791F2135c4912F85BFB7988",
+          "commit_store": "0x23CAc55aDDF28179A999858720E9Fe686372083A",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "BSC Mainnet": {
-          "off_ramp": "0xE14501F2838F2fA1Ceb52E78ABdA289EcE1705EA",
-          "commit_store": "0xa8DD25B29787527Df283211C24Ac72B17150A696",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x51f37b538aD2Bcb9Eaf884859BF7C5Ec58AEc885",
+          "commit_store": "0xF472FEb09544Bf991773f4B94fe3F03e458d1b8d",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Base Mainnet": {
-          "off_ramp": "0xBAE6560eCa9B77Cb047158C783e36F7735C86037",
-          "commit_store": "0x6168aDF58e1Ad446BaD45c6275Bef60Ef4FFBAb8",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x519ee6B83f57df95486aeA6E26819cb7b4B8ee99",
+          "commit_store": "0xCfdF2b21D9777E2B0a221F6b6D8fe176461f058e",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Ethereum Mainnet": {
-          "off_ramp": "0xd2D98Be6a1C241e86C807e51cED6ABb51d044203",
-          "commit_store": "0x4d75A5cE454b264b187BeE9e189aF1564a68408D",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x9979c2dfEcA9051Cf7f08274d978984B2dB12C60",
+          "commit_store": "0x9358663E8f89df8EFE2346a3c4c1D65d03300576",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Gnosis Mainnet": {
-          "off_ramp": "0x4358640A2419119DBe0933b5F2c288c3EB2c082C",
-          "commit_store": "0x44d1a05ef6e54a3CB35a1497303bA272f15f45ed",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x01449040D92D75c58FaDc9Bc1c0eadc70C550484",
+          "commit_store": "0xb63230DfcE291DA76FD946EFbc966549F9300347",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Mode Mainnet": {
-          "off_ramp": "0xDf9717d724828537902Fb0c3B7C56c641463Fa38",
-          "commit_store": "0x8aEFF283381914E07Fc371601D59648ab6D2C0B1",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x5a4BEeafd345264360E6894a6bc5F54a70814E68",
+          "commit_store": "0x4E94a327A38E6F3509a5639dCF933CfF6DE93FFD",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Polygon Mainnet": {
-          "off_ramp": "0x7c6221880A1D62506b1A08Dab3Bf695A49AcDD22",
-          "commit_store": "0x0684076EE3595221861C50cDb9Cb66402Ec11Cb9",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x4BA0A3bD1E2b70b2fe165A53219e7eF6376849a4",
+          "commit_store": "0xA0f02e1F9C641C9610f688be84F889fE518b36e3",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "WeMix Mainnet": {
-          "off_ramp": "0x3e5B3b7559D39563a74434157b31781322dA712D",
-          "commit_store": "0x7954372FF6f80908e5A2dC2a19d796A1005f91D2",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x2f40dCCb74d8B2dd7af065232a06778f2D019375",
+          "commit_store": "0xd1111a601BAb64a6428426095206A43710CaE932",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         }
       }
     },
@@ -892,78 +892,78 @@ Data = """
       "wrapped_native": "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
       "src_contracts": {
         "Arbitrum Mainnet": {
-          "on_ramp": "0xD16D025330Edb91259EEA8ed499daCd39087c295",
+          "on_ramp": "0x13263aC754d1e29430930672E3C0019f2BC44Ba2",
           "deployed_at": 0
         },
         "Avalanche Mainnet": {
-          "on_ramp": "0x5FA30697e90eB30954895c45b028F7C0dDD39b12",
+          "on_ramp": "0x56cb9Cd82553Bd8157e6504020c38f6DA4971717",
           "deployed_at": 0
         },
         "BSC Mainnet": {
-          "on_ramp": "0xF5b5A2fC11BF46B1669C3B19d98B19C79109Dca9",
+          "on_ramp": "0x164507757F7d5Ab35C6af44EeEB099F5be29Da57",
           "deployed_at": 0
         },
         "Base Mainnet": {
-          "on_ramp": "0x20B028A2e0F6CCe3A11f3CE5F2B8986F932e89b4",
+          "on_ramp": "0xD26A4E0c664E72e3c29E634867191cB1cb9AF570",
           "deployed_at": 0
         },
         "Ethereum Mainnet": {
-          "on_ramp": "0xFd77c53AA4eF0E3C01f5Ac012BF7Cc7A3ECf5168",
+          "on_ramp": "0x1DAcBae00c779913e6E9fc1A3323FbA4847ba53C",
           "deployed_at": 0
         },
         "Gnosis Mainnet": {
-          "on_ramp": "0x4616621704C81801A56D29c961F9395ee153d46C",
+          "on_ramp": "0xcc4A8CFd756895d91B476Dd5461286b300914aBf",
           "deployed_at": 0
         },
         "Optimism Mainnet": {
-          "on_ramp": "0x3111cfbF5e84B5D9BD952dd8e957f4Ca75f728Cf",
+          "on_ramp": "0x868B71490B36674B3B9006fa8711C6fA26A26631",
           "deployed_at": 0
         },
         "WeMix Mainnet": {
-          "on_ramp": "0x5060eF647a1F66BE6eE27FAe3046faf8D53CeB2d",
+          "on_ramp": "0x9363330c6d807a1393c1fd35893c64d26931CDe6",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Arbitrum Mainnet": {
-          "off_ramp": "0xa8a9eDa2867c2E0CE0d5ECe273961F1EcC3CC25B",
-          "commit_store": "0xbD4480658dca8496a65046dfD1BDD44EF897Bdb5",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x60f2788225CeE4a94f8E7589931d5A14Cbc4367d",
+          "commit_store": "0x4DEc80ED383171EC54699B22B869bE098d3cBac9",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Avalanche Mainnet": {
-          "off_ramp": "0xB9e3680639c9F0C4e0b02FD81C445094426244Ae",
-          "commit_store": "0x8c63d4e67f7c4af6FEd2f56A34fB4e01CB807CFF",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x35c1Bb5A9c2F3fa8f8dFF470a6bE7d362CeA1ef3",
+          "commit_store": "0xB3324b80f50a31b12c0C733560D3aA2a32dc5C33",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "BSC Mainnet": {
-          "off_ramp": "0x592773924741F0Da889a0dfdab71171Dd11E054C",
-          "commit_store": "0xEC4d35E1A85f770f4D93BA43a462c9d87Ef7017e",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xE58074f8F56E23836f088Ac8b4f3882c1b4CAcbb",
+          "commit_store": "0x2110a5f138364d788FDF54eCBa25C1688181cb00",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Base Mainnet": {
-          "off_ramp": "0xD0FA7DE2D18A0c59D3fD7dfC7aB4e913C6Aa7b68",
-          "commit_store": "0xF88053B9DAC8Dd3039a4eFa8639159aaa3F2D4Cb",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xF4a9Dbb7f3FBa02e3a244B464e459C32B63857F1",
+          "commit_store": "0x936A0C8635D7087a2D22494762e9a697C3C3D545",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Ethereum Mainnet": {
-          "off_ramp": "0x45320085fF051361D301eC1044318213A5387A15",
-          "commit_store": "0x4Dc771B5ef21ef60c33e2987E092345f2b63aE08",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xa06e68a11d5694316Cc819f2FFD02663e3314C7C",
+          "commit_store": "0xB73d668B26817659E9f48F16b780480B4401cFcE",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Gnosis Mainnet": {
-          "off_ramp": "0x0A04eC196454825d361886cf4FA113A948164Ef8",
-          "commit_store": "0x74b72633b63A8f4374a12DB6F609305BC5a1b2d5",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x9e2e4e397226f347d11D3fF8469d0c3FFa750C3B",
+          "commit_store": "0x75faF05ec32C9dA97E99Eb6fb18b5087DecAAa82",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Optimism Mainnet": {
-          "off_ramp": "0xBa754ecd3CFA7E9093F688EAc3860cf9D07Fc0AC",
-          "commit_store": "0x04C0D5302E3D8Ca0A0019141a52a23B59cdb70e4",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x805c292775Be43b10Cc744ea7E81d9939a08cEa4",
+          "commit_store": "0x52faD8fb48451AA555c0f59accA1dC7C69B9681B",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "WeMix Mainnet": {
-          "off_ramp": "0xd7c877ea02310Cce9278D9A048Aa1Bb9aF72F00d",
-          "commit_store": "0x92A1C927E8E10Ab6A40E5A5154e2300D278d1a67",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xd357Bee1Ff4B1cce7dc0d953a9E5613476781732",
+          "commit_store": "0x784F81E5c2960a7c7e714D6BA383f0d14e93eD65",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         }
       }
     },
@@ -976,69 +976,69 @@ Data = """
       "wrapped_native": "0x7D72b22a74A216Af4a002a1095C8C707d6eC1C5f",
       "src_contracts": {
         "Arbitrum Mainnet": {
-          "on_ramp": "0x9aBfd6f4C865610692AB6fb1Be862575809fFabf",
+          "on_ramp": "0xA89c8E2b85a6BeC901C29107E9B640Ff256fc762",
           "deployed_at": 0
         },
         "Avalanche Mainnet": {
-          "on_ramp": "0xbE0Cfae74677F8dd16a246a3a5c8cbB1973118f4",
+          "on_ramp": "0xEe41778FdE32C19f8f7E0C780838b1cb76bf8aEA",
           "deployed_at": 0
         },
         "BSC Mainnet": {
-          "on_ramp": "0x56657ec4D15C71f7F3C17ba2b21C853A24Dc5381",
+          "on_ramp": "0x4A62c842f06AC261c93bb5805289c613f55e2Aeb",
           "deployed_at": 0
         },
         "Ethereum Mainnet": {
-          "on_ramp": "0x190bcE84CF2d500B878966F4Cf98a50d78f2675E",
+          "on_ramp": "0x6c6Dd4fCa5A7B2F11AA3057AB573DD8878C76C5e",
           "deployed_at": 0
         },
         "Kroma Mainnet": {
-          "on_ramp": "0x47E9AE0A815C94836202E696748A5d5476aD8735",
+          "on_ramp": "0x19e7aD9B0cb28E4604f91376eE2f7dFF0E66318a",
           "deployed_at": 0
         },
         "Optimism Mainnet": {
-          "on_ramp": "0x70f3b0FD7e6a4B9B623e9AB859604A9EE03e48BD",
+          "on_ramp": "0x96c4e2B1b2c949F570D5992272B7722a3a1d1709",
           "deployed_at": 0
         },
         "Polygon Mainnet": {
-          "on_ramp": "0x777058C1e1dcE4eB8001F38631a1cd9450816e5a",
+          "on_ramp": "0x728C5d58f6079744E1e41BDAE16200f6c3725954",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Arbitrum Mainnet": {
-          "off_ramp": "0x2ba68a395B72a6E3498D312efeD755ed2f3CF223",
-          "commit_store": "0xdAeC234DA83F68707Bb8AcB2ee6a01a5FD4c2391",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x007b0D0e63B5939E64286F4C4afB2D52c6114025",
+          "commit_store": "0x4D8BaDA9006A6C1cd724ae6F2E343640a0D9706d",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Avalanche Mainnet": {
-          "off_ramp": "0xFac907F9a1087B846Faa75A14C5d34A8639233d8",
-          "commit_store": "0xF2812063446c7deD2CA306c67A68364BdDcbEfc5",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x8Ef00c4B45f7B3D895150F0C5D978AC6949Af174",
+          "commit_store": "0xF580F5ba66Eec295B8bE3Ea613985b6CEc65D7C8",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "BSC Mainnet": {
-          "off_ramp": "0x6ec9ca4Cba62cA17c55F05ad2000B46192f02035",
-          "commit_store": "0x84534BE763366a69710E119c100832955795B34B",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x90fC76fBd6B82eAe27b34e136271b94788237738",
+          "commit_store": "0xda174CA3c585b260fc5c347c88cA5946Ce0f46E8",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Ethereum Mainnet": {
-          "off_ramp": "0xF92Fa796F5307b029c65CA26f322a6D86f211194",
-          "commit_store": "0xbeC110FF43D52be2066B06525304A9924E16b73b",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x76DE34244b92aB9F4e9D550269Ef1CAdE0d1A2E9",
+          "commit_store": "0xcbCFFD854a2d033019B98f5583FcD5caDc2bb802",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Kroma Mainnet": {
-          "off_ramp": "0xF886d8DC64E544af4835cbf91e5678A54D95B80e",
-          "commit_store": "0x8794C9534658fdCC44f2FF6645Bf31cf9F6d2d5D",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x64F833f1347fd8Ac6b07a08adCc844FFeB8dF928",
+          "commit_store": "0xf79eA7f1D70640A7a8A309465ca29b35D4103c11",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Optimism Mainnet": {
-          "off_ramp": "0x87220D01DF0fF27149B47227897074653788fd23",
-          "commit_store": "0xF8dD2be2C6FA43e48A17146380CbEBBB4291807b",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xd76783CF6A98C95F5927b4b98D5E1Efb78CFc563",
+          "commit_store": "0x3837A341afE24A451d868966114A39715e91C6f6",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Polygon Mainnet": {
-          "off_ramp": "0x8f0229804513A9Bc00c1308414AB279Dbc718ae1",
-          "commit_store": "0x3A85D1b8641d83a87957C6ECF1b62151213e0842",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xe22ef88FccfE6C304Fd245005e959837C86B52F6",
+          "commit_store": "0x98Ebd40E2535D404fFB361A85bf6b82D64Bda151",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         }
       }
     },
@@ -1051,24 +1051,24 @@ Data = """
       "wrapped_native": "0x5AEa5775959fBC2557Cc8789bC1bf90A239D9a91",
       "src_contracts": {
         "Arbitrum Mainnet": {
-          "on_ramp": "0x9033687a0f03012e015f8f8f2a59da57531d2B43",
+          "on_ramp": "0x66EcB7c8c122d74f19Fc28b275f213Ef8991B7AB",
           "deployed_at": 0
         },
         "Ethereum Mainnet": {
-          "on_ramp": "0x3B80Fe300c9A611abA0496e2543B66Ff7bD4B9e9",
+          "on_ramp": "0xD1B33FAd3fF7a793EE39473f865630e3b6371086",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Arbitrum Mainnet": {
-          "off_ramp": "0xF0a08aC528668D4fe8C4cF235a8B82cbf242Fa9d",
-          "commit_store": "0x5a3C9b21b03E4eBcccb57D296e7ff54102F04424",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0xd448c815C421fFBd770C2d3B9a9cBa4E33E3885c",
+          "commit_store": "0xC64f4b53eDb629B3293eE806D9b2aCBd1dDE4e13",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         },
         "Ethereum Mainnet": {
-          "off_ramp": "0x7c887B97F9Bba9355EC10e2bA949AdB491Ef44Fd",
-          "commit_store": "0xA42bf0c8794FA8853Ec0F1B24a489972e8CF4C30",
-          "receiver_dapp": "0xb509c046e1182c7b36d2d9733554bc268716803c"
+          "off_ramp": "0x6BACb854483Ffe310F5Ac08879868E96AE0DC000",
+          "commit_store": "0x117D1015FD2CBaa32A1fe0e0C913fc02B4D5f115",
+          "receiver_dapp": "0xB509c046e1182c7B36d2D9733554BC268716803C"
         }
       }
     }

--- a/integration-tests/ccip-tests/testconfig/tomls/beta-testnet/testnet-beta-workinglane.toml
+++ b/integration-tests/ccip-tests/testconfig/tomls/beta-testnet/testnet-beta-workinglane.toml
@@ -13,41 +13,29 @@ Data = """
     "Arbitrum Sepolia": {
       "is_mock_arm": true,
       "fee_token": "0xb1D4538B4571d411F07960EF2838Ce337FE1E80E",
-      "bridge_tokens": null,
-      "bridge_tokens_pools": null,
-      "price_aggregators": null,
-      "arm": "0x2aE6d5495fc20226F433be50e37D59c05D186AaA",
-      "router": "0x0fF6b6F3Ad10D66600Fd5CC25b98542A05Aa7Bc2",
-      "price_registry": "0x25d997d8618e1299418b3D905E40bC353ec89F61",
+      "arm": "0x5261Eac6b2A158b1eafed0144B4894f41b67b01f",
+      "router": "0x32C3C32B1b3858e45AFc53e1D0D4607463d47d1C",
+      "price_registry": "0x845A8190d31602fD0862467880468339E04d885b",
       "wrapped_native": "0xE591bf0A0CF924A0674d7792db046B23CEbF5f34",
       "src_contracts": {
-        "Base Sepolia": {
-          "on_ramp": "0x6BD0f1efA261Ea84DB219c1284b538A65E530ea1",
-          "deployed_at": 29428386
+        "Avalanche Fuji": {
+          "on_ramp": "0x59f2492ebDfdD3E99b9198A2313AB0A4113014c8",
+          "deployed_at": 85949437
         },
         "Optimism Sepolia": {
-          "on_ramp": "0x94cd0d171eF08924F0008305e5Bb90b0fC1b61AB",
-          "deployed_at": 13945916
-        },
-        "Sepolia Testnet": {
-          "on_ramp": "0x44225eb3B73B1b52Dd2ecD258F9b63418eC6Bf79",
-          "deployed_at": 13730868
+          "on_ramp": "0x3FF2852A4597E6Ac363340Cadbf1666C4246b4B9",
+          "deployed_at": 87452680
         }
       },
       "dest_contracts": {
-        "Base Sepolia": {
-          "off_ramp": "0x21560B4ACAEdb8AA2Dd935618F15da43197bdc12",
-          "commit_store": "0x27B882c393151ADD910F3557849AF0bb09c7d5A6",
+        "Avalanche Fuji": {
+          "off_ramp": "0x1b3841f8923195F1E438B471D0415bBE8b3c133D",
+          "commit_store": "0x55F4a33AC60D994c2F1A3b400Fc2C40140CF50D9",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Optimism Sepolia": {
-          "off_ramp": "0xAE32FD8Ae148BD88E3da6FaE8Cd7561Eed3ec5Cc",
-          "commit_store": "0x1f1160Ac7828B647A85c9a6b3A58A232C59D67Ab",
-          "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
-        },
-        "Sepolia Testnet": {
-          "off_ramp": "0xc136114F379b812345bb7e467ECDdb6D0c87De8b",
-          "commit_store": "0x42b3EbEA14F6CB803e3C7df84392Efb85CE90168",
+          "off_ramp": "0x695C84498573AEE9A2Be410Aaf7C275535A337D7",
+          "commit_store": "0xCBDdCEaE1d51F9C40640fa17fb7a2FeEB51DB702",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -55,47 +43,20 @@ Data = """
     "Avalanche Fuji": {
       "is_mock_arm": true,
       "fee_token": "0x0b9d5D9136855f6FEc3c0993feE6E9CE8a297846",
-      "bridge_tokens": null,
-      "bridge_tokens_pools": null,
-      "price_aggregators": null,
-      "arm": "0xD4A51dC0F5C680A8A18eA4Ec3A2f25C6db9424B7",
-      "router": "0xa62e685aDFF45f38eC94378513D128F168964E99",
-      "price_registry": "0xdbeA1a10AC6a2B729bF128aE9281Ed420dbE7113",
+      "arm": "0xd550342aE3f8d5D3D38509900034C8b01f556f0e",
+      "router": "0x13b766d0fe3e01fa5b02b378DF31724dD5368B37",
+      "price_registry": "0xAEc164EDF7Be32c6d38565BD09c24DAAA5b5887f",
       "wrapped_native": "0xd00ae08403B9bbb9124bB305C09058E32C39A48c",
       "src_contracts": {
-        "BSC Testnet": {
-          "on_ramp": "0xe4f1F7750352f1c37C15C4A314554d6A79d7d146",
-          "deployed_at": 31437550
+        "Arbitrum Sepolia": {
+          "on_ramp": "0x2Df17a22794499963EC0DDD43699B1020fdDD4d3",
+          "deployed_at": 36151865
         }
       },
       "dest_contracts": {
-        "BSC Testnet": {
-          "off_ramp": "0x796D720ea9D4326ff356eadE13b123B267C03C80",
-          "commit_store": "0xaDb37cFd91fa9b6Df1DaAcbAfB4cDFF41e06c956",
-          "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
-        }
-      }
-    },
-    "BSC Testnet": {
-      "is_mock_arm": true,
-      "fee_token": "0x84b9B910527Ad5C03A9Ca831909E21e236EA7b06",
-      "bridge_tokens": null,
-      "bridge_tokens_pools": null,
-      "price_aggregators": null,
-      "arm": "0xbBF534D89d9640e3886db25FE1ffE603Fe160D75",
-      "router": "0x9CdA5b77eA23459eBaf2e3092c570a6B5605850A",
-      "price_registry": "0x9213967a47FC3F15A16A0b813208e8Ccb63Dbba6",
-      "wrapped_native": "0xae13d989daC2f0dEbFf460aC112a837C89BAa7cd",
-      "src_contracts": {
-        "Avalanche Fuji": {
-          "on_ramp": "0x0B4F541a7fcE5c251993Bc19D5A40B661e0463f5",
-          "deployed_at": 39097639
-        }
-      },
-      "dest_contracts": {
-        "Avalanche Fuji": {
-          "off_ramp": "0x41E59DCdDec18d7f79DA5F76Ce567d2c5e301E6B",
-          "commit_store": "0x9487C01D4b3Ae1c9Ac8740A07f3862D646548A14",
+        "Arbitrum Sepolia": {
+          "off_ramp": "0xFFBf82f59e5A7E1f92CE3565A6d6C835dEA19D1A",
+          "commit_store": "0x79357546378F29Ffcf3B7f3492Ee2Bcb9dB4d847",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -103,29 +64,17 @@ Data = """
     "Base Sepolia": {
       "is_mock_arm": true,
       "fee_token": "0xE4aB69C077896252FAFBD49EFD26B5D171A32410",
-      "bridge_tokens": null,
-      "bridge_tokens_pools": null,
-      "price_aggregators": null,
       "arm": "0x866faB92E04bAE5EDa238A9cbFf1e56E09508Ade",
       "router": "0x2aE6d5495fc20226F433be50e37D59c05D186AaA",
       "price_registry": "0xD886E2286Fd1073df82462ea1822119600Af80b6",
       "wrapped_native": "0x4200000000000000000000000000000000000006",
       "src_contracts": {
-        "Arbitrum Sepolia": {
-          "on_ramp": "0xAE32FD8Ae148BD88E3da6FaE8Cd7561Eed3ec5Cc",
-          "deployed_at": 8133125
-        },
         "Optimism Sepolia": {
           "on_ramp": "0x9213967a47FC3F15A16A0b813208e8Ccb63Dbba6",
           "deployed_at": 11607777
         }
       },
       "dest_contracts": {
-        "Arbitrum Sepolia": {
-          "off_ramp": "0x34433469A4d6c8b1B0a1a7B91a5C5C2Dd74c67Fb",
-          "commit_store": "0xFEE7c8E229F538a98437b9A7D0Dd8fCd8A1Ab569",
-          "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
-        },
         "Optimism Sepolia": {
           "off_ramp": "0x0f30449bcCaCCaA7221B3f7C3304c4AaD68068E8",
           "commit_store": "0x17a5746c9cf7eAf23533F060F395B2E38eb976ea",
@@ -136,74 +85,29 @@ Data = """
     "Optimism Sepolia": {
       "is_mock_arm": true,
       "fee_token": "0xE4aB69C077896252FAFBD49EFD26B5D171A32410",
-      "bridge_tokens": null,
-      "bridge_tokens_pools": null,
-      "price_aggregators": null,
-      "arm": "0x2aE6d5495fc20226F433be50e37D59c05D186AaA",
-      "router": "0x0fF6b6F3Ad10D66600Fd5CC25b98542A05Aa7Bc2",
-      "price_registry": "0x3B80b7Ef5c00Eb892CBe72800C028C47AD6380EF",
+      "arm": "0xb665817485727D670dABD0F03A155401778C26ea",
+      "router": "0xF66f5c1417159eb38F622006eDE421BbF5262905",
+      "price_registry": "0x2dF2c61821A7BCcC851B15ee26BB06307d3bEE2d",
       "wrapped_native": "0x4200000000000000000000000000000000000006",
       "src_contracts": {
         "Arbitrum Sepolia": {
-          "on_ramp": "0x622CB640F52bFfA68b78b2BD12c1940Ca4899621",
-          "deployed_at": 8020540
+          "on_ramp": "0x21ce68614782BF139bF21d7D2566A0d900c8638C",
+          "deployed_at": 18379535
         },
         "Base Sepolia": {
           "on_ramp": "0x12c164d0778E215873A062cEE2814507417339cB",
           "deployed_at": 13590651
-        },
-        "Sepolia Testnet": {
-          "on_ramp": "0x0c2c8D4266C98f1b9333D5E1a42f3f775A0005d4",
-          "deployed_at": 8020948
         }
       },
       "dest_contracts": {
         "Arbitrum Sepolia": {
-          "off_ramp": "0x37004c1245a2D5541377e87cA29699492a4114D5",
-          "commit_store": "0x51158Ca439feA9E809Bc063CfA6701747b05254e",
+          "off_ramp": "0xbeBD1F1f92a739810C102E5E5dc844E7efDbd747",
+          "commit_store": "0x39DEf7c3E3F2306012B96C1a4Cb1D574CA912CCa",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Base Sepolia": {
           "off_ramp": "0xB3F3f362FbeD49fA0086B434051C822B55BaADbD",
           "commit_store": "0xD4995B99c484CCABc868b26c0B2C2Ef10ecde3d7",
-          "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
-        },
-        "Sepolia Testnet": {
-          "off_ramp": "0x80C2aa80F202FeFdFEEF80f516cFd89768c54057",
-          "commit_store": "0xc1fE981A040D679511ccb9139ca107aCA67520ef",
-          "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
-        }
-      }
-    },
-    "Sepolia Testnet": {
-      "is_mock_arm": true,
-      "fee_token": "0x779877A7B0D9E8603169DdbD7836e478b4624789",
-      "bridge_tokens": null,
-      "bridge_tokens_pools": null,
-      "price_aggregators": null,
-      "arm": "0x9912a7389382ff55f85A29C9378B38F7B992c4aE",
-      "router": "0x1E1F3d8Ac7Df65fCcFcc52dbF03929cEE95430ac",
-      "price_registry": "0x4358e81f88bB27222779c1BC85003A11A1c66f6F",
-      "wrapped_native": "0x097D90c9d3E0B50Ca60e1ae45F6A81010f9FB534",
-      "src_contracts": {
-        "Arbitrum Sepolia": {
-          "on_ramp": "0x420a7B5ABB8CF27A70E1906F797e24509B11093D",
-          "deployed_at": 5275652
-        },
-        "Optimism Sepolia": {
-          "on_ramp": "0xEb4EBC1930bA81416A48a59142D89722163D85ae",
-          "deployed_at": 5281150
-        }
-      },
-      "dest_contracts": {
-        "Arbitrum Sepolia": {
-          "off_ramp": "0x224D1eB3aB2b7F23b66f093F9cBBC68dA77a1986",
-          "commit_store": "0x35c54cF12FF9B29dBa60dc23EdD1de0F13CC7fc5",
-          "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
-        },
-        "Optimism Sepolia": {
-          "off_ramp": "0xF21d01D6Ef822FBC56FC6c8F23f74fE3A0cb39aa",
-          "commit_store": "0x7F6AF440Bcc54f70Fd8AC2E534d37196c0bA1A38",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -219,10 +123,8 @@ TTL = '8h'
 selected_networks = [
   'ARBITRUM_SEPOLIA',
   'AVALANCHE_FUJI',
-  'BASE_SEPOLIA',
-  'BSC_TESTNET',
+#  'BASE_SEPOLIA',
   'OPTIMISM_SEPOLIA',
-  'SEPOLIA'
 ]
 
 
@@ -230,12 +132,14 @@ selected_networks = [
 [CCIP.Groups.smoke]
 # these are all the valid network pairs
 NetworkPairs = [
-  'BSC_TESTNET,AVALANCHE_FUJI',
-  'SEPOLIA,ARBITRUM_SEPOLIA',
-  'BASE_SEPOLIA,OPTIMISM_SEPOLIA'
+#  'ARBITRUM_SEPOLIA,AVALANCHE_FUJI',
+  'ARBITRUM_SEPOLIA,OPTIMISM_SEPOLIA',
+  'OPTIMISM_SEPOLIA,ARBITRUM_SEPOLIA',
+  'AVALANCHE_FUJI,ARBITRUM_SEPOLIA',
+#  'BASE_SEPOLIA,OPTIMISM_SEPOLIA'
 ]
 
-BiDirectionalLane = true
+BiDirectionalLane = false
 PhaseTimeout = '40m'
 LocalCluster = false
 ExistingDeployment = true
@@ -255,8 +159,7 @@ AmountPerToken = 1
 
 [CCIP.Groups.load]
 NetworkPairs = [
-  'AVALANCHE_FUJI,BSC_TESTNET',
-  'SEPOLIA,ARBITRUM_SEPOLIA',
+  'ARBITRUM_SEPOLIA,AVALANCHE_FUJI',
   'BASE_SEPOLIA,OPTIMISM_SEPOLIA'
 ]
 
@@ -272,7 +175,7 @@ NoOfTokensPerChain = 1
 RequestPerUnitTime = [1]
 TimeUnit = '6m'
 TestDuration = '3h'
-TestRunName = 'BetaSoakTest_CCIPV1dot5'
+TestRunName = 'BetaSoakTest_CCIPV1dot5dot4'
 FailOnFirstErrorInLoad = true
 
 [[CCIP.Groups.load.LoadProfile.MsgProfile.MsgDetails]]

--- a/integration-tests/ccip-tests/testconfig/tomls/beta-testnet/testnet-beta-workinglane_native.toml
+++ b/integration-tests/ccip-tests/testconfig/tomls/beta-testnet/testnet-beta-workinglane_native.toml
@@ -11,129 +11,73 @@ Data = """
 {
   "lane_configs": {
     "Arbitrum Sepolia": {
-      "is_native_fee_token": true,
       "is_mock_arm": true,
+      "is_native_fee_token": true,
       "fee_token": "0xE591bf0A0CF924A0674d7792db046B23CEbF5f34",
-      "bridge_tokens": null,
-      "bridge_tokens_pools": null,
-      "price_aggregators": null,
-      "arm": "0x2aE6d5495fc20226F433be50e37D59c05D186AaA",
-      "router": "0x0fF6b6F3Ad10D66600Fd5CC25b98542A05Aa7Bc2",
-      "price_registry": "0x25d997d8618e1299418b3D905E40bC353ec89F61",
+      "arm": "0x5261Eac6b2A158b1eafed0144B4894f41b67b01f",
+      "router": "0x32C3C32B1b3858e45AFc53e1D0D4607463d47d1C",
+      "price_registry": "0x845A8190d31602fD0862467880468339E04d885b",
       "wrapped_native": "0xE591bf0A0CF924A0674d7792db046B23CEbF5f34",
       "src_contracts": {
-        "Base Sepolia": {
-          "on_ramp": "0x6BD0f1efA261Ea84DB219c1284b538A65E530ea1",
-          "deployed_at": 29428386
+        "Avalanche Fuji": {
+          "on_ramp": "0x59f2492ebDfdD3E99b9198A2313AB0A4113014c8",
+          "deployed_at": 85949437
         },
         "Optimism Sepolia": {
-          "on_ramp": "0x94cd0d171eF08924F0008305e5Bb90b0fC1b61AB",
-          "deployed_at": 13945916
-        },
-        "Sepolia Testnet": {
-          "on_ramp": "0x44225eb3B73B1b52Dd2ecD258F9b63418eC6Bf79",
-          "deployed_at": 13730868
+          "on_ramp": "0x3FF2852A4597E6Ac363340Cadbf1666C4246b4B9",
+          "deployed_at": 87452680
         }
       },
       "dest_contracts": {
-        "Base Sepolia": {
-          "off_ramp": "0x21560B4ACAEdb8AA2Dd935618F15da43197bdc12",
-          "commit_store": "0x27B882c393151ADD910F3557849AF0bb09c7d5A6",
+        "Avalanche Fuji": {
+          "off_ramp": "0x1b3841f8923195F1E438B471D0415bBE8b3c133D",
+          "commit_store": "0x55F4a33AC60D994c2F1A3b400Fc2C40140CF50D9",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Optimism Sepolia": {
-          "off_ramp": "0xAE32FD8Ae148BD88E3da6FaE8Cd7561Eed3ec5Cc",
-          "commit_store": "0x1f1160Ac7828B647A85c9a6b3A58A232C59D67Ab",
-          "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
-        },
-        "Sepolia Testnet": {
-          "off_ramp": "0xc136114F379b812345bb7e467ECDdb6D0c87De8b",
-          "commit_store": "0x42b3EbEA14F6CB803e3C7df84392Efb85CE90168",
+          "off_ramp": "0x695C84498573AEE9A2Be410Aaf7C275535A337D7",
+          "commit_store": "0xCBDdCEaE1d51F9C40640fa17fb7a2FeEB51DB702",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
     },
     "Avalanche Fuji": {
-      "is_native_fee_token": true,
       "is_mock_arm": true,
+      "is_native_fee_token": true,
       "fee_token": "0xd00ae08403B9bbb9124bB305C09058E32C39A48c",
-      "bridge_tokens": [
-        "0x0b9d5D9136855f6FEc3c0993feE6E9CE8a297846"
-      ],
-      "bridge_tokens_pools": [
-        "0x156943ae87AaF63eA9272902Cb05407ec7bc9464"
-      ],
-      "price_aggregators": null,
-      "arm": "0xD4A51dC0F5C680A8A18eA4Ec3A2f25C6db9424B7",
-      "router": "0xa62e685aDFF45f38eC94378513D128F168964E99",
-      "price_registry": "0xdbeA1a10AC6a2B729bF128aE9281Ed420dbE7113",
+      "arm": "0xd550342aE3f8d5D3D38509900034C8b01f556f0e",
+      "router": "0x13b766d0fe3e01fa5b02b378DF31724dD5368B37",
+      "price_registry": "0xAEc164EDF7Be32c6d38565BD09c24DAAA5b5887f",
       "wrapped_native": "0xd00ae08403B9bbb9124bB305C09058E32C39A48c",
       "src_contracts": {
-        "BSC Testnet": {
-          "on_ramp": "0xe4f1F7750352f1c37C15C4A314554d6A79d7d146",
-          "deployed_at": 31437550
+        "Arbitrum Sepolia": {
+          "on_ramp": "0x2Df17a22794499963EC0DDD43699B1020fdDD4d3",
+          "deployed_at": 36151865
         }
       },
       "dest_contracts": {
-        "BSC Testnet": {
-          "off_ramp": "0x796D720ea9D4326ff356eadE13b123B267C03C80",
-          "commit_store": "0xaDb37cFd91fa9b6Df1DaAcbAfB4cDFF41e06c956",
-          "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
-        }
-      }
-    },
-    "BSC Testnet": {
-      "is_native_fee_token": true,
-      "is_mock_arm": true,
-      "fee_token": "0xae13d989daC2f0dEbFf460aC112a837C89BAa7cd",
-      "bridge_tokens": null,
-      "bridge_tokens_pools": null,
-      "price_aggregators": null,
-      "arm": "0xbBF534D89d9640e3886db25FE1ffE603Fe160D75",
-      "router": "0x9CdA5b77eA23459eBaf2e3092c570a6B5605850A",
-      "price_registry": "0x9213967a47FC3F15A16A0b813208e8Ccb63Dbba6",
-      "wrapped_native": "0xae13d989daC2f0dEbFf460aC112a837C89BAa7cd",
-      "src_contracts": {
-        "Avalanche Fuji": {
-          "on_ramp": "0x0B4F541a7fcE5c251993Bc19D5A40B661e0463f5",
-          "deployed_at": 39097639
-        }
-      },
-      "dest_contracts": {
-        "Avalanche Fuji": {
-          "off_ramp": "0x41E59DCdDec18d7f79DA5F76Ce567d2c5e301E6B",
-          "commit_store": "0x9487C01D4b3Ae1c9Ac8740A07f3862D646548A14",
+        "Arbitrum Sepolia": {
+          "off_ramp": "0xFFBf82f59e5A7E1f92CE3565A6d6C835dEA19D1A",
+          "commit_store": "0x79357546378F29Ffcf3B7f3492Ee2Bcb9dB4d847",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
     },
     "Base Sepolia": {
-      "is_native_fee_token": true,
       "is_mock_arm": true,
+      "is_native_fee_token": true,
       "fee_token": "0x4200000000000000000000000000000000000006",
-      "bridge_tokens": null,
-      "bridge_tokens_pools": null,
-      "price_aggregators": null,
       "arm": "0x866faB92E04bAE5EDa238A9cbFf1e56E09508Ade",
       "router": "0x2aE6d5495fc20226F433be50e37D59c05D186AaA",
       "price_registry": "0xD886E2286Fd1073df82462ea1822119600Af80b6",
       "wrapped_native": "0x4200000000000000000000000000000000000006",
       "src_contracts": {
-        "Arbitrum Sepolia": {
-          "on_ramp": "0xAE32FD8Ae148BD88E3da6FaE8Cd7561Eed3ec5Cc",
-          "deployed_at": 8133125
-        },
         "Optimism Sepolia": {
           "on_ramp": "0x9213967a47FC3F15A16A0b813208e8Ccb63Dbba6",
           "deployed_at": 11607777
         }
       },
       "dest_contracts": {
-        "Arbitrum Sepolia": {
-          "off_ramp": "0x34433469A4d6c8b1B0a1a7B91a5C5C2Dd74c67Fb",
-          "commit_store": "0xFEE7c8E229F538a98437b9A7D0Dd8fCd8A1Ab569",
-          "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
-        },
         "Optimism Sepolia": {
           "off_ramp": "0x0f30449bcCaCCaA7221B3f7C3304c4AaD68068E8",
           "commit_store": "0x17a5746c9cf7eAf23533F060F395B2E38eb976ea",
@@ -142,78 +86,32 @@ Data = """
       }
     },
     "Optimism Sepolia": {
-      "is_native_fee_token": true,
       "is_mock_arm": true,
+      "is_native_fee_token": true,
       "fee_token": "0x4200000000000000000000000000000000000006",
-      "bridge_tokens": null,
-      "bridge_tokens_pools": null,
-      "price_aggregators": null,
-      "arm": "0x2aE6d5495fc20226F433be50e37D59c05D186AaA",
-      "router": "0x0fF6b6F3Ad10D66600Fd5CC25b98542A05Aa7Bc2",
-      "price_registry": "0x3B80b7Ef5c00Eb892CBe72800C028C47AD6380EF",
+      "arm": "0xb665817485727D670dABD0F03A155401778C26ea",
+      "router": "0xF66f5c1417159eb38F622006eDE421BbF5262905",
+      "price_registry": "0x2dF2c61821A7BCcC851B15ee26BB06307d3bEE2d",
       "wrapped_native": "0x4200000000000000000000000000000000000006",
       "src_contracts": {
         "Arbitrum Sepolia": {
-          "on_ramp": "0x622CB640F52bFfA68b78b2BD12c1940Ca4899621",
-          "deployed_at": 8020540
+          "on_ramp": "0x21ce68614782BF139bF21d7D2566A0d900c8638C",
+          "deployed_at": 18379535
         },
         "Base Sepolia": {
           "on_ramp": "0x12c164d0778E215873A062cEE2814507417339cB",
           "deployed_at": 13590651
-        },
-        "Sepolia Testnet": {
-          "on_ramp": "0x0c2c8D4266C98f1b9333D5E1a42f3f775A0005d4",
-          "deployed_at": 8020948
         }
       },
       "dest_contracts": {
         "Arbitrum Sepolia": {
-          "off_ramp": "0x37004c1245a2D5541377e87cA29699492a4114D5",
-          "commit_store": "0x51158Ca439feA9E809Bc063CfA6701747b05254e",
+          "off_ramp": "0xbeBD1F1f92a739810C102E5E5dc844E7efDbd747",
+          "commit_store": "0x39DEf7c3E3F2306012B96C1a4Cb1D574CA912CCa",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Base Sepolia": {
           "off_ramp": "0xB3F3f362FbeD49fA0086B434051C822B55BaADbD",
           "commit_store": "0xD4995B99c484CCABc868b26c0B2C2Ef10ecde3d7",
-          "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
-        },
-        "Sepolia Testnet": {
-          "off_ramp": "0x80C2aa80F202FeFdFEEF80f516cFd89768c54057",
-          "commit_store": "0xc1fE981A040D679511ccb9139ca107aCA67520ef",
-          "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
-        }
-      }
-    },
-    "Sepolia Testnet": {
-      "is_native_fee_token": true,
-      "is_mock_arm": true,
-      "fee_token": "0x097D90c9d3E0B50Ca60e1ae45F6A81010f9FB534",
-      "bridge_tokens": null,
-      "bridge_tokens_pools": null,
-      "price_aggregators": null,
-      "arm": "0x9912a7389382ff55f85A29C9378B38F7B992c4aE",
-      "router": "0x1E1F3d8Ac7Df65fCcFcc52dbF03929cEE95430ac",
-      "price_registry": "0x4358e81f88bB27222779c1BC85003A11A1c66f6F",
-      "wrapped_native": "0x097D90c9d3E0B50Ca60e1ae45F6A81010f9FB534",
-      "src_contracts": {
-        "Arbitrum Sepolia": {
-          "on_ramp": "0x420a7B5ABB8CF27A70E1906F797e24509B11093D",
-          "deployed_at": 5275652
-        },
-        "Optimism Sepolia": {
-          "on_ramp": "0xEb4EBC1930bA81416A48a59142D89722163D85ae",
-          "deployed_at": 5281150
-        }
-      },
-      "dest_contracts": {
-        "Arbitrum Sepolia": {
-          "off_ramp": "0x224D1eB3aB2b7F23b66f093F9cBBC68dA77a1986",
-          "commit_store": "0x35c54cF12FF9B29dBa60dc23EdD1de0F13CC7fc5",
-          "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
-        },
-        "Optimism Sepolia": {
-          "off_ramp": "0xF21d01D6Ef822FBC56FC6c8F23f74fE3A0cb39aa",
-          "commit_store": "0x7F6AF440Bcc54f70Fd8AC2E534d37196c0bA1A38",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -229,26 +127,24 @@ TTL = '8h'
 selected_networks = [
   'ARBITRUM_SEPOLIA',
   'AVALANCHE_FUJI',
-  'BASE_SEPOLIA',
-  'BSC_TESTNET',
+  #  'BASE_SEPOLIA',
   'OPTIMISM_SEPOLIA',
-  'SEPOLIA',
 ]
 
 
-[CCIP.Env.NewCLCluster.Common.ChainlinkImage]
-version = "sha-17ce920"
 
 [CCIP.Groups.smoke]
 # these are all the valid network pairs
 NetworkPairs = [
-  'AVALANCHE_FUJI,BSC_TESTNET',
-  'SEPOLIA,ARBITRUM_SEPOLIA',
-  'BASE_SEPOLIA,OPTIMISM_SEPOLIA',
+  #  'ARBITRUM_SEPOLIA,AVALANCHE_FUJI',
+  'ARBITRUM_SEPOLIA,OPTIMISM_SEPOLIA',
+  'OPTIMISM_SEPOLIA,ARBITRUM_SEPOLIA',
+  'AVALANCHE_FUJI,ARBITRUM_SEPOLIA',
+  #  'BASE_SEPOLIA,OPTIMISM_SEPOLIA'
 ]
 
-BiDirectionalLane = true
-PhaseTimeout = '30m'
+BiDirectionalLane = false
+PhaseTimeout = '40m'
 LocalCluster = false
 ExistingDeployment = true
 ReuseContracts = true
@@ -267,8 +163,7 @@ AmountPerToken = 1
 
 [CCIP.Groups.load]
 NetworkPairs = [
-  'AVALANCHE_FUJI,BSC_TESTNET',
-  'SEPOLIA,ARBITRUM_SEPOLIA',
+  'ARBITRUM_SEPOLIA,AVALANCHE_FUJI',
   'BASE_SEPOLIA,OPTIMISM_SEPOLIA'
 ]
 
@@ -284,7 +179,7 @@ NoOfTokensPerChain = 1
 RequestPerUnitTime = [1]
 TimeUnit = '6m'
 TestDuration = '3h'
-TestRunName = 'BetaSoakTest_V2.14.0-1.5.1'
+TestRunName = 'BetaSoakTest_CCIPV1dot5dot4'
 FailOnFirstErrorInLoad = true
 
 [[CCIP.Groups.load.LoadProfile.MsgProfile.MsgDetails]]

--- a/integration-tests/ccip-tests/testconfig/tomls/prod-testnet/load-prod-testnet.toml
+++ b/integration-tests/ccip-tests/testconfig/tomls/prod-testnet/load-prod-testnet.toml
@@ -1,10 +1,10 @@
 [CCIP]
 [CCIP.ContractVersions]
-PriceRegistry = '1.2.0'
-OffRamp = '1.2.0'
-OnRamp = '1.2.0'
-TokenPool = '1.4.0'
-CommitStore = '1.2.0'
+PriceRegistry = 'latest'
+OffRamp = 'latest'
+OnRamp = 'latest'
+CommitStore = 'latest'
+TokenPool = 'latest'
 
 
 [CCIP.Deployments]
@@ -20,32 +20,32 @@ Data = """
       "wrapped_native": "0xd00ae08403B9bbb9124bB305C09058E32C39A48c",
       "src_contracts": {
         "Base Sepolia": {
-          "on_ramp": "0x1A674645f3EB4147543FCA7d40C5719cbd997362",
+          "on_ramp": "0x0aEc1AC9F6D0c21332d7a66dDF1Fbcb32cF3B0B3",
           "deployed_at": 0
         },
         "Optimism Sepolia": {
-          "on_ramp": "0xC334DE5b020e056d0fE766dE46e8d9f306Ffa1E2",
+          "on_ramp": "0x2a9EFdc9F93D9b822129038EFCa4B63Adf3f7FB5",
           "deployed_at": 0
         },
         "Sepolia Testnet": {
-          "on_ramp": "0x5724B4Cc39a9690135F7273b44Dfd3BA6c0c69aD",
+          "on_ramp": "0x75b9a75Ee1fFef6BE7c4F842a041De7c6153CF4E",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Base Sepolia": {
-          "off_ramp": "0xdBdE8510226d1E060A3bf982b67705C67f5697e2",
-          "commit_store": "0x8Ee73BC9492b4182D289E5C1e66e40CD876CC00F",
+          "off_ramp": "0xf8de9d5924CFD28e31a53B63B4903436D9818d69",
+          "commit_store": "0xDD7CfECE1bb4e8aC2E8b8281CFE1D44247119471",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Optimism Sepolia": {
-          "off_ramp": "0x3d7CbC95DCC33257F14D6Eb780c88Bd56C6335BB",
-          "commit_store": "0x1fcDC02edDfb405f378ba53cF9E6104feBcB7542",
+          "off_ramp": "0x1DF9D94C6916918C935E60d2Cb4Ed265Bf778005",
+          "commit_store": "0xE7eeBE5882609d28C015d0A89DE1ba4f506F4a03",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Sepolia Testnet": {
-          "off_ramp": "0x9e5e4324F8608D54A50a317832d456a392E4F8C2",
-          "commit_store": "0x92A51eD3F041B39EbD1e464C1f7cb1e8f8A8c63f",
+          "off_ramp": "0x01e3D835b4C4697D7F81B9d7Abc89A6E478E4a2f",
+          "commit_store": "0x4EC313c1Eb620432f42FB5f4Df27f8A566523c1C",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -59,32 +59,32 @@ Data = """
       "wrapped_native": "0x4200000000000000000000000000000000000006",
       "src_contracts": {
         "Avalanche Fuji": {
-          "on_ramp": "0xAbA09a1b7b9f13E05A6241292a66793Ec7d43357",
+          "on_ramp": "0x212e8Fd9cCC330ab54E8141FA7d33967eF1eDafF",
           "deployed_at": 0
         },
         "Optimism Sepolia": {
-          "on_ramp": "0x3b39Cd9599137f892Ad57A4f54158198D445D147",
+          "on_ramp": "0x2945D35F428CE564F5455AD0AF28BDFCa67e76Ab",
           "deployed_at": 0
         },
         "Sepolia Testnet": {
-          "on_ramp": "0x6486906bB2d85A6c0cCEf2A2831C11A2059ebfea",
+          "on_ramp": "0x29A1F4ecE9246F0042A9062FB89803fA8B1830cB",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Avalanche Fuji": {
-          "off_ramp": "0xAd91214efFee446500940c764DF77AF18427294F",
-          "commit_store": "0x1242b6c5e0e349b8d4BCf0938f961C4B4f7EA3Fa",
+          "off_ramp": "0x3Ab3a3d35cAC95FfcFCcc127eF01eA8D87b0A64e",
+          "commit_store": "0x51313B8C068B5227fa7364E6eCB1382Fb751976F",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Optimism Sepolia": {
-          "off_ramp": "0x86a3910908eCaAA31Fcd9F0fC8841D8E98f1511d",
-          "commit_store": "0xE99a87C9b5ed4D2b6060195DEea5106ffF655736",
+          "off_ramp": "0x8718d1cc138421Dbc1B489CB7884FF68DE7ad867",
+          "commit_store": "0x3291D453c880E5b59EEd04E600c85268Cd378b7f",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Sepolia Testnet": {
-          "off_ramp": "0x189F61D9B886Dd2975D5Abc893c8Cf5f5effda71",
-          "commit_store": "0xEE7e27346DCD1e711348D0F7f7ECB53a9a3a08a7",
+          "off_ramp": "0x0ecA23Ef70B828fEDd0A84d2692cB0527B52396A",
+          "commit_store": "0xA7F84Ec616F8e9Fa593339944E76bda90A9737fE",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -98,32 +98,32 @@ Data = """
       "wrapped_native": "0x4200000000000000000000000000000000000006",
       "src_contracts": {
         "Avalanche Fuji": {
-          "on_ramp": "0x6b38CC6Fa938D5AB09Bdf0CFe580E226fDD793cE",
+          "on_ramp": "0x91a144F570ABA7FB7079Fb187A267390E0cc7367",
           "deployed_at": 0
         },
         "Base Sepolia": {
-          "on_ramp": "0xe284D2315a28c4d62C419e8474dC457b219DB969",
+          "on_ramp": "0x6D22953cdEf8B0C9F0976Cfa52c33B198fEc5881",
           "deployed_at": 0
         },
         "Sepolia Testnet": {
-          "on_ramp": "0xC8b93b46BF682c39B3F65Aa1c135bC8A95A5E43a",
+          "on_ramp": "0x54b32C2aCb4451c6cF66bcbd856d8A7Cc2263531",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Avalanche Fuji": {
-          "off_ramp": "0x1F350718e015EB20E5065C09F4A7a3f66888aEeD",
-          "commit_store": "0x98650A8EB59f75D93563aB34FcF603b1A30e4CBF",
+          "off_ramp": "0xCb2266c2118b1f30D15CBeB3a885531ABaA1b556",
+          "commit_store": "0x5Ded92E2CF71a8fF7644a67850F061c38B31BfB4",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Base Sepolia": {
-          "off_ramp": "0x0a750ca77369e03613d7640548F4b2b1c695c3Bb",
-          "commit_store": "0x8fEBC74C26129C8d7E60288C6dCCc75eb494aA3C",
+          "off_ramp": "0x960c62A491C30d0a60fD74a59d35B9C02697AdaA",
+          "commit_store": "0x06963745B3839B998288D1a46a46Ec25991A3D5E",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Sepolia Testnet": {
-          "off_ramp": "0x260AF9b83e0d2Bb6C9015fC9f0BfF8858A0CCE68",
-          "commit_store": "0x7a0bB92Bc8663abe6296d0162A9b41a2Cb2E0358",
+          "off_ramp": "0x2aF9B10A5972D0c36f4d8F85773052c104E319B2",
+          "commit_store": "0x82FCF55b9e9bAb3066c2863F12a02bBc2Ba33F2F",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -137,32 +137,32 @@ Data = """
       "wrapped_native": "0x097D90c9d3E0B50Ca60e1ae45F6A81010f9FB534",
       "src_contracts": {
         "Avalanche Fuji": {
-          "on_ramp": "0x0477cA0a35eE05D3f9f424d88bC0977ceCf339D4",
+          "on_ramp": "0x12492154714fBD28F28219f6fc4315d19de1025B",
           "deployed_at": 0
         },
         "Base Sepolia": {
-          "on_ramp": "0x2B70a05320cB069e0fB55084D402343F832556E7",
+          "on_ramp": "0x8F35B097022135E0F46831f798a240Cc8c4b0B01",
           "deployed_at": 0
         },
         "Optimism Sepolia": {
-          "on_ramp": "0x69CaB5A0a08a12BaFD8f5B195989D709E396Ed4d",
+          "on_ramp": "0xACDfd7a98d853FA3914047Cd46e7f5D53BBC9FbB",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Avalanche Fuji": {
-          "off_ramp": "0x000b26f604eAadC3D874a4404bde6D64a97d95ca",
-          "commit_store": "0x2dD9273F8208B8393350508131270A6574A69784",
+          "off_ramp": "0x1DEBa99dC8e2A77832461BD386d83D9FCb133137",
+          "commit_store": "0x139E06b6dBB1a0C41A1686C091795879c943765A",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Base Sepolia": {
-          "off_ramp": "0x31c0B81832B333419f0DfD36A69F502cF9094aed",
-          "commit_store": "0xDFcde9d698a2B32DB2537DC9B752Cadd1D846a52",
+          "off_ramp": "0x662738DC7DE4f7eC63d9f73Cdf9BeA5A58DdcC15",
+          "commit_store": "0x1e46bAC486Dd878cD57B62845530A52343e39693",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Optimism Sepolia": {
-          "off_ramp": "0xD50590D4438411EDe47029b0FD7901A7145E5Df6",
-          "commit_store": "0xe85EEE9Fd434A7b8a586Ee086E828abF41839479",
+          "off_ramp": "0xbfa6f6AAE31acB3A285e80026d6475C1a50d1d0F",
+          "commit_store": "0xB5FbA97Dc61ec68771a92a15360d9C32c9d054E7",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }

--- a/integration-tests/ccip-tests/testconfig/tomls/prod-testnet/smoke-release-testing_native.toml
+++ b/integration-tests/ccip-tests/testconfig/tomls/prod-testnet/smoke-release-testing_native.toml
@@ -14,71 +14,74 @@ Data = """
     "Arbitrum Sepolia": {
       "is_native_fee_token": true,
       "fee_token": "0xE591bf0A0CF924A0674d7792db046B23CEbF5f34",
-      "bridge_tokens": [
-        "0xA8C0c11bf64AF62CDCA6f93D3769B88BdD7cb93D"
-      ],
-      "bridge_tokens_pools": [
-        "0x99685281Ec520a003F1A726A5a8078c2124c1477"
-      ],
       "arm": "0xbcBDf0aDEDC9a33ED5338Bdb4B6F7CE664DC2e8B",
       "router": "0x2a9C5afB0d0e4BAb2BCdaE109EC4b0c4Be15a165",
       "price_registry": "0x89D5b13908b9063abCC6791dc724bF7B7c93634C",
       "wrapped_native": "0xE591bf0A0CF924A0674d7792db046B23CEbF5f34",
       "src_contracts": {
         "Avalanche Fuji": {
-          "on_ramp": "0x1Cb56374296ED19E86F68fA437ee679FD7798DaA",
+          "on_ramp": "0x20C8c9F13C6AA402F2545AD15fB7a9CdE9108618",
           "deployed_at": 0
         },
         "Base Sepolia": {
-          "on_ramp": "0x7854E73C73e7F9bb5b0D5B4861E997f4C6E8dcC6",
+          "on_ramp": "0xF1623862e4c9f9Fba1Ac0181C4fF53B4f958F065",
           "deployed_at": 0
         },
         "Gnosis Chiado": {
-          "on_ramp": "0x973CbE752258D32AE82b60CD1CB656Eebb588dF0",
+          "on_ramp": "0xEfe02eB139D2A82e38184d28E3b65bb176F26ebD",
+          "deployed_at": 0
+        },
+        "Metis Sepolia": {
+          "on_ramp": "0x46a79a6a4B07FD3FC14ea8299A99FE29576776E2",
           "deployed_at": 0
         },
         "Optimism Sepolia": {
-          "on_ramp": "0x701Fe16916dd21EFE2f535CA59611D818B017877",
+          "on_ramp": "0x0B0c08Bb2fA2EbDe25817009ee39eA1ad9bCaC58",
           "deployed_at": 0
         },
         "Sepolia Testnet": {
-          "on_ramp": "0x4205E1Ca0202A248A5D42F5975A8FE56F3E302e9",
+          "on_ramp": "0x64d78F20aD987c7D52FdCB8FB0777bD00de53210",
           "deployed_at": 0
         },
         "WeMix Testnet": {
-          "on_ramp": "0xBD4106fBE4699FE212A34Cc21b10BFf22b02d959",
+          "on_ramp": "0x2F3Daf77A663603826c7750E956b6555DE6f8250",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Avalanche Fuji": {
-          "off_ramp": "0xcab0EF91Bee323d1A617c0a027eE753aFd6997E4",
-          "commit_store": "0x0d90b9b96cBFa0D01635ce12982ccE1b70827c7a",
+          "off_ramp": "0x7245a5947E2F32B66aF74F4dAF91718ea19afaDf",
+          "commit_store": "0x490AC77BbB26f4FFf876Ded07bCAE6DBe685be98",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Base Sepolia": {
-          "off_ramp": "0xc1982985720B959E66c19b64F783361Eb9B60F26",
-          "commit_store": "0x28F66bB336f6db713d6ad2a3bd1B7a531282A159",
+          "off_ramp": "0xF2aB55Ed448A6fAD75013900568B6a927f52e5e0",
+          "commit_store": "0x833E5995A7422120f445f9B8dD1b9BD1037c68E5",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Gnosis Chiado": {
-          "off_ramp": "0x935C26F9a9122E5F9a27f2d3803e74c75B94f5a3",
-          "commit_store": "0xEdb963Ec5c2E5AbdFdCF137eF44A445a7fa4787A",
+          "off_ramp": "0xc1Cb31493fB2386aDC1Ea01F935F2bd8a8dCA388",
+          "commit_store": "0xe21896657A65c8959F16E1c3Ee5713E85d9EA020",
+          "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
+        },
+        "Metis Sepolia": {
+          "off_ramp": "0xc47143147Fd62A09618C695c7C03714aCe8db1Cf",
+          "commit_store": "0x2F42e7B22eE5885158916624Ff00608f4C82313D",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Optimism Sepolia": {
-          "off_ramp": "0xfD404A89e1d195F0c65be1A9042C77745197659e",
-          "commit_store": "0x84B7B012c95f8A152B44Ab3e952f2dEE424fA8e1",
+          "off_ramp": "0x4a7E91EF68758aaC66AeD656267bbCD0f9b6c019",
+          "commit_store": "0xb0A09D6A15FF7A0142DF3F62b2C4D1e11D763Ed0",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Sepolia Testnet": {
-          "off_ramp": "0x1c71f141b4630EBE52d6aF4894812960abE207eB",
-          "commit_store": "0xaB0c8Ba51E7Fa3E5693a4Fbb39473520FD85d173",
+          "off_ramp": "0xBed6e9131916d724418C8a6FE810F727302a5c00",
+          "commit_store": "0xdDb61B6bDa1B46d88f556440fABFe219F6da4F3a",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "WeMix Testnet": {
-          "off_ramp": "0x262e16C8D42aa07bE13e58F81e7D9F62F6DE2830",
-          "commit_store": "0xc132eFAf929299E5ee704Fa6D9796CFa23Bb8b2C",
+          "off_ramp": "0x11d486E92d291704D1E25cDbAeee687237247826",
+          "commit_store": "0xece9353095aC79Db9DD5bf2022690Fa6BffeBCAc",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -86,89 +89,83 @@ Data = """
     "Avalanche Fuji": {
       "is_native_fee_token": true,
       "fee_token": "0xd00ae08403B9bbb9124bB305C09058E32C39A48c",
-      "bridge_tokens": [
-        "0xD21341536c5cF5EB1bcb58f6723cE26e8D8E90e4"
-      ],
-      "bridge_tokens_pools": [
-        "0xEC1062cbDf4fBf31B3A6Aac62B6F6F123bb70E12"
-      ],
       "arm": "0x7e28DD790214139798446A121cFe950B51304684",
       "router": "0xF694E193200268f9a4868e4Aa017A0118C9a8177",
       "price_registry": "0x19e157E5fb1DAec1aE4BaB113fdf077F980704AA",
       "wrapped_native": "0xd00ae08403B9bbb9124bB305C09058E32C39A48c",
       "src_contracts": {
         "Arbitrum Sepolia": {
-          "on_ramp": "0x8bB16BEDbFd62D1f905ACe8DBBF2954c8EEB4f66",
+          "on_ramp": "0xa9946BA30DAeC98745755e4410d6e8E894Edc53B",
           "deployed_at": 0
         },
         "BSC Testnet": {
-          "on_ramp": "0xF25ECF1Aad9B2E43EDc2960cF66f325783245535",
+          "on_ramp": "0x906BC7D10947A94ba0252e8C2E34868A466c03ED",
           "deployed_at": 0
         },
         "Base Sepolia": {
-          "on_ramp": "0x1A674645f3EB4147543FCA7d40C5719cbd997362",
+          "on_ramp": "0x0aEc1AC9F6D0c21332d7a66dDF1Fbcb32cF3B0B3",
           "deployed_at": 0
         },
         "Gnosis Chiado": {
-          "on_ramp": "0x1532e5b204ee2b2244170c78E743CB9c168F4DF9",
+          "on_ramp": "0x3dda45E731EC1db18B95651d1AF1868aa878468D",
           "deployed_at": 0
         },
         "Optimism Sepolia": {
-          "on_ramp": "0xC334DE5b020e056d0fE766dE46e8d9f306Ffa1E2",
+          "on_ramp": "0x2a9EFdc9F93D9b822129038EFCa4B63Adf3f7FB5",
           "deployed_at": 0
         },
         "Polygon Amoy": {
-          "on_ramp": "0x610F76A35E17DA4542518D85FfEa12645eF111Fc",
+          "on_ramp": "0xA82b9ACAcFA6FaB1FD721e7a748A30E3001351F9",
           "deployed_at": 0
         },
         "Sepolia Testnet": {
-          "on_ramp": "0x5724B4Cc39a9690135F7273b44Dfd3BA6c0c69aD",
+          "on_ramp": "0x75b9a75Ee1fFef6BE7c4F842a041De7c6153CF4E",
           "deployed_at": 0
         },
         "WeMix Testnet": {
-          "on_ramp": "0x677B5ab5C8522d929166c064d5700F147b15fa33",
+          "on_ramp": "0x1ff99E67986E83bb5BA34143BaA2735853e5738c",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Arbitrum Sepolia": {
-          "off_ramp": "0x90A74072e7B0c2d59e13aB4d8f93c8198c413194",
-          "commit_store": "0xf3458CFd2fdf4a6CF0Ce296d520DD21eB194828b",
+          "off_ramp": "0xd88CBA0612f2Ce611BF6d073A94C8FD7E70B4fBd",
+          "commit_store": "0x9b8279E352bC167F714eef96A4C436bE996643cE",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "BSC Testnet": {
-          "off_ramp": "0x10b28009E5D776F1f5AAA73941CE8953B8f42d26",
-          "commit_store": "0xacDD582F271eCF22FAd6764cCDe1c4a534b732A8",
+          "off_ramp": "0x9c40A73F5C7454BB7C178AFa56Ee30bFB2DCf7E6",
+          "commit_store": "0xE5611af1d63340b711B0468a976651Fb79B17870",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Base Sepolia": {
-          "off_ramp": "0xdBdE8510226d1E060A3bf982b67705C67f5697e2",
-          "commit_store": "0x8Ee73BC9492b4182D289E5C1e66e40CD876CC00F",
+          "off_ramp": "0xf8de9d5924CFD28e31a53B63B4903436D9818d69",
+          "commit_store": "0xDD7CfECE1bb4e8aC2E8b8281CFE1D44247119471",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Gnosis Chiado": {
-          "off_ramp": "0x56dF55aF5F0A4689f3364230587a68eD6A314fAd",
-          "commit_store": "0xabA7ff98094c4cc7A075812EefF2CD21f6400235",
+          "off_ramp": "0x3F5035039C23cDAF032C64c084Dc70F811E62ddD",
+          "commit_store": "0xf5B0245c7B9e15f0cB0B85FF2B6799a45D61CbaA",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Optimism Sepolia": {
-          "off_ramp": "0x3d7CbC95DCC33257F14D6Eb780c88Bd56C6335BB",
-          "commit_store": "0x1fcDC02edDfb405f378ba53cF9E6104feBcB7542",
+          "off_ramp": "0x1DF9D94C6916918C935E60d2Cb4Ed265Bf778005",
+          "commit_store": "0xE7eeBE5882609d28C015d0A89DE1ba4f506F4a03",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Polygon Amoy": {
-          "off_ramp": "0x3e33290B90fD0FF30a3FA138934DF028E4eCA348",
-          "commit_store": "0xCFe3556Aa42d40be09BD23aa80448a19443BE5B1",
+          "off_ramp": "0xbeD7F478Ef5627FB2B891fDA29Ca0131f6796D9D",
+          "commit_store": "0x27a319f58c01380056c86938798aCEAA1AC529e2",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Sepolia Testnet": {
-          "off_ramp": "0x9e5e4324F8608D54A50a317832d456a392E4F8C2",
-          "commit_store": "0x92A51eD3F041B39EbD1e464C1f7cb1e8f8A8c63f",
+          "off_ramp": "0x01e3D835b4C4697D7F81B9d7Abc89A6E478E4a2f",
+          "commit_store": "0x4EC313c1Eb620432f42FB5f4Df27f8A566523c1C",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "WeMix Testnet": {
-          "off_ramp": "0xD0D338318bC6837b091FC7AB5F2a94B7783507d5",
-          "commit_store": "0xd9D479208235c7355848ff4aF26eB5aacfDC30c6",
+          "off_ramp": "0x15CcAbf0e3484D4872e25b883163D8cB724d4832",
+          "commit_store": "0x859f3477B7b4ECc19aDD8cCb19740932F21bD76b",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -176,71 +173,74 @@ Data = """
     "BSC Testnet": {
       "is_native_fee_token": true,
       "fee_token": "0xae13d989daC2f0dEbFf460aC112a837C89BAa7cd",
-      "bridge_tokens": [
-        "0xbFA2ACd33ED6EEc0ed3Cc06bF1ac38d22b36B9e9"
-      ],
-      "bridge_tokens_pools": [
-        "0x31eDe84776DA37e2404eE88d71c234e92cB672e5"
-      ],
       "arm": "0x7D899D26F2E94fFcd4b440C3008B0C6BEfcD3cca",
       "router": "0xE1053aE1857476f36A3C62580FF9b016E8EE8F6f",
       "price_registry": "0xCCDf022c9d31DC26Ebab4FB92432724a5b79809a",
       "wrapped_native": "0xae13d989daC2f0dEbFf460aC112a837C89BAa7cd",
       "src_contracts": {
         "Avalanche Fuji": {
-          "on_ramp": "0xa2515683E99F50ADbE177519A46bb20FfdBaA5de",
+          "on_ramp": "0x2A6f8Ed2e7b222163ef6EcC2327171B479399ab2",
           "deployed_at": 0
         },
         "Base Sepolia": {
-          "on_ramp": "0x3E807220Ca84b997c0d1928162227b46C618e0c5",
+          "on_ramp": "0x97856Bf888F6eEDBBd322B28133BCcF9CA9038f6",
+          "deployed_at": 0
+        },
+        "Blast Sepolia": {
+          "on_ramp": "0xd0049BfFc8e2689Df9236FfA393Ccbf7eae4FbbC",
           "deployed_at": 0
         },
         "Gnosis Chiado": {
-          "on_ramp": "0x8735f991d41eA9cA9D2CC75cD201e4B7C866E63e",
+          "on_ramp": "0x98dEa9e498F2A7aF6c74C915c88A17FbA09b73C2",
           "deployed_at": 0
         },
         "Polygon Amoy": {
-          "on_ramp": "0xf37CcbfC04adc1B56a46B36F811D52C744a1AF78",
+          "on_ramp": "0x363EB789fE31F08547a847D8C38d9b55C7Cf1903",
           "deployed_at": 0
         },
         "Sepolia Testnet": {
-          "on_ramp": "0xB1DE44B04C00eaFe9915a3C07a0CaeA4410537dF",
+          "on_ramp": "0xC1C6438D60AbE9bF4b1F10460184CE9bD312e328",
           "deployed_at": 0
         },
         "WeMix Testnet": {
-          "on_ramp": "0x89268Afc1BEA0782a27ba84124E3F42b196af927",
+          "on_ramp": "0xbc85704EDb79ea84E9D3C18965F7f6A16B0a0440",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Avalanche Fuji": {
-          "off_ramp": "0x6e6fFCb6B4BED91ff0CC8C2e57EC029dA7DB80C2",
-          "commit_store": "0x38Bc38Bd824b6eE87571f9D3CFbe6D6E28E3Dc62",
+          "off_ramp": "0x95b66acfaaDF122f4EccE52C0aD4Fd997DD1150C",
+          "commit_store": "0x3af04b1c1e79A6B8A4577Bb47EC33eD2E66AeB47",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Base Sepolia": {
-          "off_ramp": "0x2C61FD7E93Dc79422861282145c59B56dFbc3a8c",
-          "commit_store": "0x42fAe5B3605804CF6d08632d7A25864e24F792Ae",
+          "off_ramp": "0x0a5147e1Ac38C79c77031194ef64C8B5353F6EE9",
+          "commit_store": "0x103864D60b33a479EA7D0e23a37e0ce07198f0A9",
+          "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
+        },
+        "Blast Sepolia": {
+          "off_ramp": "0xe1e8473218acCB82FBc24Ccd3C5D2dF166cd04f3",
+          "commit_store": "0x020B047A5Ca88fDB1ad3bAD9A082760fC7F770b6",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Gnosis Chiado": {
-          "off_ramp": "0x71a44a60832B0F8B63232C9516e7E6aEc3A373Dc",
-          "commit_store": "0xAC24299a91b72d1Cb5B31147e3CF54964D896974",
+          "off_ramp": "0x1F7FEBCBb10420E039C333A60A444c1a442d826C",
+          "commit_store": "0x23Ae763a64D39d6038431a64Bbc4A670C89d82b9",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Polygon Amoy": {
-          "off_ramp": "0x63440C7747d37bc6154b5538AE32b54FE0965AfA",
-          "commit_store": "0xAD22fA198CECfC534927aE1D480c460d5bB3460F",
+          "off_ramp": "0xAAe325adbc9C5a28e4e94Fef170D55de2CA9aA01",
+          "commit_store": "0xD173Df3A1b23ec42eA5C4669b9c956Bef230efd1",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Sepolia Testnet": {
-          "off_ramp": "0xf1c128Fe52Ea78CcAAB407509292E61ce38C1523",
-          "commit_store": "0x59dFD870dC4bd76A7B879A4f705Fdcd2595f85f9",
+          "off_ramp": "0xB513523aee87f838e78b32d2Bacaaf2e94D9f0f9",
+          "commit_store": "0x21A49164890576504C1f1c4DC9442c42C98771D7",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "WeMix Testnet": {
-          "off_ramp": "0xfd9B19c3725da5B517aA705B848ff3f21F98280e",
-          "commit_store": "0x3c1F1412563188aBc8FE3fd53E8F1Cb601CaB4f9",
+          "off_ramp": "0xc985571900DCa62387f93F882AB550472531f5DB",
+          "commit_store": "0xac5DACfAb1a512E33c49EFE42502863FC1a4BAB3",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -248,80 +248,74 @@ Data = """
     "Base Sepolia": {
       "is_native_fee_token": true,
       "fee_token": "0x4200000000000000000000000000000000000006",
-      "bridge_tokens": [
-        "0x88A2d74F47a237a62e7A51cdDa67270CE381555e"
-      ],
-      "bridge_tokens_pools": [
-        "0x875207858c691F192C606068f417dCf666b2EC6B"
-      ],
       "arm": "0x7827dD0481EE18DB646bD250d20A8eA43da52146",
       "router": "0xD3b06cEbF099CE7DA4AcCf578aaebFDBd6e88a93",
       "price_registry": "0x4D20536e60832bE579Cd38E89Dc03d11E1741FbA",
       "wrapped_native": "0x4200000000000000000000000000000000000006",
       "src_contracts": {
         "Arbitrum Sepolia": {
-          "on_ramp": "0x58622a80c6DdDc072F2b527a99BE1D0934eb2b50",
+          "on_ramp": "0xb52eF669d3fCeBee1f31418Facc02a16A6F6B0e5",
           "deployed_at": 0
         },
         "Avalanche Fuji": {
-          "on_ramp": "0xAbA09a1b7b9f13E05A6241292a66793Ec7d43357",
+          "on_ramp": "0x212e8Fd9cCC330ab54E8141FA7d33967eF1eDafF",
           "deployed_at": 0
         },
         "BSC Testnet": {
-          "on_ramp": "0xD806966beAB5A3C75E5B90CDA4a6922C6A9F0c9d",
+          "on_ramp": "0xd54B44811AE99a18Cb95B4704ba04a65C0163751",
           "deployed_at": 0
         },
         "Gnosis Chiado": {
-          "on_ramp": "0x2Eff2d1BF5C557d6289D208a7a43608f5E3FeCc2",
+          "on_ramp": "0xdd0Ee1F20E93a93634AAcE56105E19423881Df56",
           "deployed_at": 0
         },
         "Mode Sepolia": {
-          "on_ramp": "0x3d0115386C01436870a2c47e6297962284E70BA6",
+          "on_ramp": "0xc59689dFDEF9D953cEFbb58912b304bb38408476",
           "deployed_at": 0
         },
         "Optimism Sepolia": {
-          "on_ramp": "0x3b39Cd9599137f892Ad57A4f54158198D445D147",
+          "on_ramp": "0x2945D35F428CE564F5455AD0AF28BDFCa67e76Ab",
           "deployed_at": 0
         },
         "Sepolia Testnet": {
-          "on_ramp": "0x6486906bB2d85A6c0cCEf2A2831C11A2059ebfea",
+          "on_ramp": "0x29A1F4ecE9246F0042A9062FB89803fA8B1830cB",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Arbitrum Sepolia": {
-          "off_ramp": "0xd364C06ac99a82a00d3eFF9F2F78E4Abe4b9baAA",
-          "commit_store": "0xdE8d0f47a71eA3fDFBD3162271652f2847939097",
+          "off_ramp": "0x814E735c5DD19240c85E2513DD926Bc3a39f7140",
+          "commit_store": "0xFc24B204bfA5C65eD8e2Fc02fDe4FeCb62eA8Ac5",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Avalanche Fuji": {
-          "off_ramp": "0xAd91214efFee446500940c764DF77AF18427294F",
-          "commit_store": "0x1242b6c5e0e349b8d4BCf0938f961C4B4f7EA3Fa",
+          "off_ramp": "0x3Ab3a3d35cAC95FfcFCcc127eF01eA8D87b0A64e",
+          "commit_store": "0x51313B8C068B5227fa7364E6eCB1382Fb751976F",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "BSC Testnet": {
-          "off_ramp": "0xd5E9508921434e8758f4540D55c1c066b7cc1598",
-          "commit_store": "0x1a86b29364D1B3fA3386329A361aA98A104b2742",
+          "off_ramp": "0x827CF69409307Cd4c979e652894C297ad5124ab7",
+          "commit_store": "0x547eBe6077305c3fdF8dA66c66cc14b0779CE00C",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Gnosis Chiado": {
-          "off_ramp": "0x9Bb7e398ef9Acfe9cA584C39B1E233Cba62BB9f7",
-          "commit_store": "0x1F4B82cDebaC5e3a0Dd53183D47e51808B4a64cB",
+          "off_ramp": "0x8bB08Bc19771C69E739a2078894523b3DC05a05e",
+          "commit_store": "0xf163Da63bDB8b9C355d41C755E03125988650109",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Mode Sepolia": {
-          "off_ramp": "0xB26647A23e8b4284375e5C74b77c9557aE709D03",
-          "commit_store": "0x4b4fEB401d3E613e1D6242E155C83A80BF9ac2C9",
+          "off_ramp": "0x11E16c71D76E43acbcb496A70966380d905B1E32",
+          "commit_store": "0xEe19f039FaE3EF0F94971f0B7B187223D952ac13",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Optimism Sepolia": {
-          "off_ramp": "0x86a3910908eCaAA31Fcd9F0fC8841D8E98f1511d",
-          "commit_store": "0xE99a87C9b5ed4D2b6060195DEea5106ffF655736",
+          "off_ramp": "0x8718d1cc138421Dbc1B489CB7884FF68DE7ad867",
+          "commit_store": "0x3291D453c880E5b59EEd04E600c85268Cd378b7f",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Sepolia Testnet": {
-          "off_ramp": "0x189F61D9B886Dd2975D5Abc893c8Cf5f5effda71",
-          "commit_store": "0xEE7e27346DCD1e711348D0F7f7ECB53a9a3a08a7",
+          "off_ramp": "0x0ecA23Ef70B828fEDd0A84d2692cB0527B52396A",
+          "commit_store": "0xA7F84Ec616F8e9Fa593339944E76bda90A9737fE",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -329,26 +323,29 @@ Data = """
     "Blast Sepolia": {
       "is_native_fee_token": true,
       "fee_token": "0x4200000000000000000000000000000000000023",
-      "bridge_tokens": [
-        "0x8D122C3e8ce9C8B62b87d3551bDfD8C259Bb0771"
-      ],
-      "bridge_tokens_pools": [
-        "0xFb04129aD1EEDB741CC705ebC1978a7aB63e51f6"
-      ],
       "arm": "0x09c1Ed4b112Fb33e594F2aACfEF407e2F14d7F9b",
       "router": "0xfb2f2A207dC428da81fbAFfDDe121761f8Be1194",
       "price_registry": "0xc8acE9dF450FaD007755C6C9AB4f0e9c8626E29C",
       "wrapped_native": "0x4200000000000000000000000000000000000023",
       "src_contracts": {
+        "BSC Testnet": {
+          "on_ramp": "0x6eA6f63b689b5597A0C06a5Eb8DcDFD86383857A",
+          "deployed_at": 0
+        },
         "Sepolia Testnet": {
-          "on_ramp": "0x85Ef19FC4C63c70744995DC38CAAEC185E0c619f",
+          "on_ramp": "0x154aDEF773a848da8229D81De73a7b0844400ebd",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
+        "BSC Testnet": {
+          "off_ramp": "0xd9dE4aCD27E814bfe70CA33d2A4d079e740626Bd",
+          "commit_store": "0xe8fF7e22c54f76F453d6072A9d3a12B1D9AbA137",
+          "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
+        },
         "Sepolia Testnet": {
-          "off_ramp": "0x92cD24C278D34C726f377703E50875d8f9535dC2",
-          "commit_store": "0xcE1b4D50CeD56850182Bd58Ace91171cB249B873",
+          "off_ramp": "0x46DD4e3e2b8a18409646F1C15bf3799a481e67f6",
+          "commit_store": "0x8250f9E992dda66791dd8b5d356B867ae53382cF",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -356,26 +353,20 @@ Data = """
     "Celo Alfajores": {
       "is_native_fee_token": true,
       "fee_token": "0x99604d0e2EfE7ABFb58BdE565b5330Bb46Ab3Dca",
-      "bridge_tokens": [
-        "0x7e503dd1dAF90117A1b79953321043d9E6815C72"
-      ],
-      "bridge_tokens_pools": [
-        "0xC6683ac4a0F62803Bec89a5355B36495ddF2C38b"
-      ],
       "arm": "0xEbe35aA4F5e707485484c992AF2069a457b9bBB1",
       "router": "0xb00E95b773528E2Ea724DB06B75113F239D15Dca",
       "price_registry": "0x8F048206D11B2c69b8963E2EBd5968D141e022f4",
       "wrapped_native": "0x99604d0e2EfE7ABFb58BdE565b5330Bb46Ab3Dca",
       "src_contracts": {
         "Sepolia Testnet": {
-          "on_ramp": "0x16a020c4bbdE363FaB8481262D30516AdbcfcFc8",
+          "on_ramp": "0x68A4f57A499563192C606a898BAf503A43fcDB4D",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Sepolia Testnet": {
-          "off_ramp": "0xa1b97F92D806BA040daf419AFC2765DC723683a4",
-          "commit_store": "0xcd92C0599Ac515e7588865cC45Eee21A74816aFc",
+          "off_ramp": "0xF6dB68333D14f6a0c1123cc420ea60980aEDA0Eb",
+          "commit_store": "0x8f9B63c40891CdF7d1C795625d4260a29bE2bBa0",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -383,80 +374,74 @@ Data = """
     "Gnosis Chiado": {
       "is_native_fee_token": true,
       "fee_token": "0x18c8a7ec7897177E4529065a7E7B0878358B3BfF",
-      "bridge_tokens": [
-        "0xA189971a2c5AcA0DFC5Ee7a2C44a2Ae27b3CF389"
-      ],
-      "bridge_tokens_pools": [
-        "0xF9a21B587111e7E8745Fb8b13750014f19DB0014"
-      ],
       "arm": "0xfE4fB161D870D0F672Ed9C5A898569603f77983F",
       "router": "0x19b1bac554111517831ACadc0FD119D23Bb14391",
       "price_registry": "0x2F4ACd1f8986c6B1788159C4c9a5fC3fceCCE363",
       "wrapped_native": "0x18c8a7ec7897177E4529065a7E7B0878358B3BfF",
       "src_contracts": {
         "Arbitrum Sepolia": {
-          "on_ramp": "0x473b49fb592B54a4BfCD55d40E048431982879C9",
+          "on_ramp": "0x94967Ea06C6543Aaba5B90C52B655003ef82e521",
           "deployed_at": 0
         },
         "Avalanche Fuji": {
-          "on_ramp": "0x610F76A35E17DA4542518D85FfEa12645eF111Fc",
+          "on_ramp": "0x4f3576585e7fCCE5Fc502Bcf3CAdaD22E1194834",
           "deployed_at": 0
         },
         "BSC Testnet": {
-          "on_ramp": "0xE48E6AA1fc7D0411acEA95F8C6CaD972A37721D4",
+          "on_ramp": "0xB2642B54580140C375c9024e273C575a5f53d02d",
           "deployed_at": 0
         },
         "Base Sepolia": {
-          "on_ramp": "0x41b4A51cAfb699D9504E89d19D71F92E886028a8",
+          "on_ramp": "0x0E9504907be794620229C196F82CB062A66B7480",
           "deployed_at": 0
         },
         "Optimism Sepolia": {
-          "on_ramp": "0xAae733212981e06D9C978Eb5148F8af03F54b6EF",
+          "on_ramp": "0xeb86B5b6f5C66eCb58e4Cf98E607b238126505DC",
           "deployed_at": 0
         },
         "Polygon Amoy": {
-          "on_ramp": "0x01800fCDd892e37f7829937271840A6F041bE62E",
+          "on_ramp": "0xd86F5DF82A2500137Ddeef963028d60E3b5A354D",
           "deployed_at": 0
         },
         "Sepolia Testnet": {
-          "on_ramp": "0x4ac7FBEc2A7298AbDf0E0F4fDC45015836C4bAFe",
+          "on_ramp": "0x03691D63C687D09368360e957AFB2F7B4d1651d4",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Arbitrum Sepolia": {
-          "off_ramp": "0x9aA82DBB53bf02096B771D40e9432A323a78fB26",
-          "commit_store": "0x5CdbA91aBC0cD81FC56bc10Ad1835C9E5fB38e5F",
+          "off_ramp": "0x3633Cce99186217d4C7ed64FD455d218b8Cd5D4c",
+          "commit_store": "0x6e096286548451828c97F1B3E49C402a4934F39a",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Avalanche Fuji": {
-          "off_ramp": "0x3e33290B90fD0FF30a3FA138934DF028E4eCA348",
-          "commit_store": "0xCFe3556Aa42d40be09BD23aa80448a19443BE5B1",
+          "off_ramp": "0x5E4DB2A3c965B9B2A850a75697Bb6a00b4e35ac5",
+          "commit_store": "0x2489c5a802fE63943f7E3185A0362327B55DDF67",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "BSC Testnet": {
-          "off_ramp": "0xbc4AD54e91b213D4279af92c0C5518c0b96cf62D",
-          "commit_store": "0xff84e8Dd4Fd17eaBb23b6AeA6e1981830e54389C",
+          "off_ramp": "0x2BA72Ba392C08750328635E36757A2c29a9165CA",
+          "commit_store": "0x08ebd7Cf4ABDC819c74cB45CbA4e291728538D7C",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Base Sepolia": {
-          "off_ramp": "0x4117953A5ceeF12f5B8C1E973b470ab83a8CebA6",
-          "commit_store": "0x94ad41296186E81f31e1ed0B1BcF5fa9e1721C27",
+          "off_ramp": "0x269D28B25Ee081ae5340e2BFE99850E92F1cd522",
+          "commit_store": "0x8dC9329BD221C89c4989d98c38Ff2Cc3dF92d14b",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Optimism Sepolia": {
-          "off_ramp": "0x33d2898F8fb7714FD1661791766f40754982a343",
-          "commit_store": "0x55d6Df194472f02CD481e506A277c4A29D0D1bCc",
+          "off_ramp": "0xd93B571ae9CaF43d70b2b53fFD55e035Db641e31",
+          "commit_store": "0x42C1093b9DdE8d0CD58859C610dc239B66bE26de",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Polygon Amoy": {
-          "off_ramp": "0x450543b1d85ca79885851D7b74dc982981b78229",
-          "commit_store": "0x23B79d940A769FE31b4C867A8BAE80117f24Ca81",
+          "off_ramp": "0x87F9b8382611ACD01d5696a1f5b05B888e55B0Cc",
+          "commit_store": "0x29AC46227908d31A9BdDe82c0A4a6c52D802f145",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Sepolia Testnet": {
-          "off_ramp": "0xbf9036529123DE264bFA0FC7362fE25B650D4B16",
-          "commit_store": "0x5f7F1abD5c5EdaF2636D58B980e85355AF0Ef80d",
+          "off_ramp": "0x9aa734100C425309091dAE18154e0356B82d477a",
+          "commit_store": "0x7cDd533B82f4c32FAE7f551C37b1490909817C45",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -464,26 +449,20 @@ Data = """
     "Kroma Sepolia": {
       "is_native_fee_token": true,
       "fee_token": "0x4200000000000000000000000000000000000001",
-      "bridge_tokens": [
-        "0x6AC3e353D1DDda24d5A5416024d6E436b8817A4e"
-      ],
-      "bridge_tokens_pools": [
-        "0x0eE8add19554C7bb1920A183Ed47b4FAB9Eb7601"
-      ],
       "arm": "0x08f9Af992368FAc58C936A2c5eBc9092894CEa9b",
       "router": "0xA8C0c11bf64AF62CDCA6f93D3769B88BdD7cb93D",
       "price_registry": "0xa1ed3A3aA29166C9c8448654A8cA6b7916BC8379",
       "wrapped_native": "0x4200000000000000000000000000000000000001",
       "src_contracts": {
         "WeMix Testnet": {
-          "on_ramp": "0x6ea155Fc77566D9dcE01B8aa5D7968665dc4f0C5",
+          "on_ramp": "0xa81418c332d3E04338B058Ab39b1baf53029F638",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "WeMix Testnet": {
-          "off_ramp": "0xB602B6E5Caf08ac0C920EAE585aed100a8cF6f3B",
-          "commit_store": "0x89D5b13908b9063abCC6791dc724bF7B7c93634C",
+          "off_ramp": "0x42Dde725C4f05C237a00B582Bb7457e208d3A17C",
+          "commit_store": "0xb116E9a90534354dA59CF93a87c1E9711c0Aaa2c",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -491,26 +470,29 @@ Data = """
     "Metis Sepolia": {
       "is_native_fee_token": true,
       "fee_token": "0x5c48e07062aC4E2Cf4b9A768a711Aef18e8fbdA0",
-      "bridge_tokens": [
-        "0x20Aa09AAb761e2E600d65c6929A9fd1E59821D3f"
-      ],
-      "bridge_tokens_pools": [
-        "0xdE8451E952Eb43350614839cCAA84f7C8701a09C"
-      ],
       "arm": "0xf0607A9BDdB5F54dB59ACaA0837aFec2D1c95df6",
       "router": "0xaCdaBa07ECad81dc634458b98673931DD9d3Bc14",
       "price_registry": "0x5DCE866b3ae6E0Ed153f0e149D7203A1B266cdF5",
       "wrapped_native": "0x5c48e07062aC4E2Cf4b9A768a711Aef18e8fbdA0",
       "src_contracts": {
+        "Arbitrum Sepolia": {
+          "on_ramp": "0x2eb69889cc979c0Be120813FcE2f1558efF4ceB5",
+          "deployed_at": 0
+        },
         "Sepolia Testnet": {
-          "on_ramp": "0x2Eff2d1BF5C557d6289D208a7a43608f5E3FeCc2",
+          "on_ramp": "0xE0dFc15C0CDf607b2088D0B641E00eA0B418124C",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
+        "Arbitrum Sepolia": {
+          "off_ramp": "0x839b5dEA3e084790F580E9DfCE8CCfDf49c5835e",
+          "commit_store": "0xdF38C8aD34C379165f98A75a6894790bB5a16b1D",
+          "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
+        },
         "Sepolia Testnet": {
-          "off_ramp": "0x9Bb7e398ef9Acfe9cA584C39B1E233Cba62BB9f7",
-          "commit_store": "0x1F4B82cDebaC5e3a0Dd53183D47e51808B4a64cB",
+          "off_ramp": "0x72130De9A85e9C61151253aFF8801Bb3242A00a9",
+          "commit_store": "0x8F6D64280C379F680Ff0c3278f340D72a465FAAc",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -518,35 +500,29 @@ Data = """
     "Mode Sepolia": {
       "is_native_fee_token": true,
       "fee_token": "0x4200000000000000000000000000000000000006",
-      "bridge_tokens": [
-        "0xB9d4e1141E67ECFedC8A8139b5229b7FF2BF16F5"
-      ],
-      "bridge_tokens_pools": [
-        "0x20bBc874bE3Cd94C3E4689EDD5D89dD1cE8Cb7C4"
-      ],
       "arm": "0x9eC8a0AbC75ce08978FAf67958482461bCd93B18",
       "router": "0xc49ec0eB4beb48B8Da4cceC51AA9A5bD0D0A4c43",
       "price_registry": "0xa733ce82a84335b2E9D864312225B0F3D5d80600",
       "wrapped_native": "0x4200000000000000000000000000000000000006",
       "src_contracts": {
         "Base Sepolia": {
-          "on_ramp": "0x73f7E074bd7291706a0C5412f51DB46441B1aDCB",
+          "on_ramp": "0x48ACE2319f643584B77C21476a6c664D7F13a107",
           "deployed_at": 0
         },
         "Sepolia Testnet": {
-          "on_ramp": "0xfFdE9E8c34A27BEBeaCcAcB7b3044A0A364455C9",
+          "on_ramp": "0xb821885731414497d705dc56325f18AA33e612dC",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Base Sepolia": {
-          "off_ramp": "0x137a38c6b1Ad20101F93516aB2159Df525309168",
-          "commit_store": "0x8F43d867969F14619895d71E0A5b89E0bb20bF70",
+          "off_ramp": "0xC6b69Fa9eeBc55e64eBc68371Fbd41ff73756F17",
+          "commit_store": "0xaA6691EA9110409a29C2E665174b4b2fe694cE67",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Sepolia Testnet": {
-          "off_ramp": "0xcD44cec849B6a8eBd5551D6DFeEcA452257Dfe4d",
-          "commit_store": "0xbA66f08733E6715D33edDfb5a5947676bb45d0e0",
+          "off_ramp": "0x35dE2C381a2fF8a26c8ae94145be3A9cA8C83600",
+          "commit_store": "0xE7e60DAee094416b8ab2083047a893c4c4290c48",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -554,80 +530,74 @@ Data = """
     "Optimism Sepolia": {
       "is_native_fee_token": true,
       "fee_token": "0x4200000000000000000000000000000000000006",
-      "bridge_tokens": [
-        "0x8aF4204e30565DF93352fE8E1De78925F6664dA7"
-      ],
-      "bridge_tokens_pools": [
-        "0x3Cc9364260D80F09ccAC1eE6B07366dB598900E6"
-      ],
       "arm": "0xF51366F72184E22cF4a7a8362508DB0d3370392d",
       "router": "0x114A20A10b43D4115e5aeef7345a1A71d2a60C57",
       "price_registry": "0x782a7Ba95215f2F7c3dD4C153cbB2Ae3Ec2d3215",
       "wrapped_native": "0x4200000000000000000000000000000000000006",
       "src_contracts": {
         "Arbitrum Sepolia": {
-          "on_ramp": "0x1a86b29364D1B3fA3386329A361aA98A104b2742",
+          "on_ramp": "0x6B36c9CD74E760088817a047C3460dEdFfe9a11A",
           "deployed_at": 0
         },
         "Avalanche Fuji": {
-          "on_ramp": "0x6b38CC6Fa938D5AB09Bdf0CFe580E226fDD793cE",
+          "on_ramp": "0x91a144F570ABA7FB7079Fb187A267390E0cc7367",
           "deployed_at": 0
         },
         "Base Sepolia": {
-          "on_ramp": "0xe284D2315a28c4d62C419e8474dC457b219DB969",
+          "on_ramp": "0x6D22953cdEf8B0C9F0976Cfa52c33B198fEc5881",
           "deployed_at": 0
         },
         "Gnosis Chiado": {
-          "on_ramp": "0x835a5b8e6CA17c2bB5A336c93a4E22478E6F1C8A",
+          "on_ramp": "0xec7D9A84A6d4556056975BE50Cdc97bAa9313632",
           "deployed_at": 0
         },
         "Polygon Amoy": {
-          "on_ramp": "0x2Cf26fb01E9ccDb831414B766287c0A9e4551089",
+          "on_ramp": "0x9E09C2A7D6B9F88c62f0E2Af4cd62dF3F4c326F1",
           "deployed_at": 0
         },
         "Sepolia Testnet": {
-          "on_ramp": "0xC8b93b46BF682c39B3F65Aa1c135bC8A95A5E43a",
+          "on_ramp": "0x54b32C2aCb4451c6cF66bcbd856d8A7Cc2263531",
           "deployed_at": 0
         },
         "WeMix Testnet": {
-          "on_ramp": "0xc7E53f6aB982af7A7C3e470c8cCa283d3399BDAd",
+          "on_ramp": "0xB9Ef21C04d8340b223e9C1d7a09f332609c70300",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Arbitrum Sepolia": {
-          "off_ramp": "0xDc2c7A3d8068C6F09F0F3648d24C84e372F6014d",
-          "commit_store": "0xb1aFb5cbE3c29b5Db71F21442BA9EfD450BC23C3",
+          "off_ramp": "0xF35e2d1457749374453e44B06268aD3f78b133b3",
+          "commit_store": "0x4bd755d86E25dD4093CAa5639CfDab81571259CA",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Avalanche Fuji": {
-          "off_ramp": "0x1F350718e015EB20E5065C09F4A7a3f66888aEeD",
-          "commit_store": "0x98650A8EB59f75D93563aB34FcF603b1A30e4CBF",
+          "off_ramp": "0xCb2266c2118b1f30D15CBeB3a885531ABaA1b556",
+          "commit_store": "0x5Ded92E2CF71a8fF7644a67850F061c38B31BfB4",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Base Sepolia": {
-          "off_ramp": "0x0a750ca77369e03613d7640548F4b2b1c695c3Bb",
-          "commit_store": "0x8fEBC74C26129C8d7E60288C6dCCc75eb494aA3C",
+          "off_ramp": "0x960c62A491C30d0a60fD74a59d35B9C02697AdaA",
+          "commit_store": "0x06963745B3839B998288D1a46a46Ec25991A3D5E",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Gnosis Chiado": {
-          "off_ramp": "0xCE2CE7F940B7c839384e5D7e079A6aE80e8AD6dB",
-          "commit_store": "0x1b9D78Ec1CEEC439F0b7eA6C428A1a607D9FA7e4",
+          "off_ramp": "0x7d6721c2E85560F0A233255D3d332AcF6f850d96",
+          "commit_store": "0xaC00661cAB5161d9B4746DFb7A028d97981aB2c5",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Polygon Amoy": {
-          "off_ramp": "0xD667b5706592D0b040C78fEe5EE17D243b7dCB41",
-          "commit_store": "0x96101BA5250EE9295c193693C1e08A55bC593664",
+          "off_ramp": "0x4cEeFa55AF23dFD27Cf926e8eFB1D1bCcD24526E",
+          "commit_store": "0xaD3943BdECbf4ae7d6E51aB0FD06bbC604bB7b95",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Sepolia Testnet": {
-          "off_ramp": "0x260AF9b83e0d2Bb6C9015fC9f0BfF8858A0CCE68",
-          "commit_store": "0x7a0bB92Bc8663abe6296d0162A9b41a2Cb2E0358",
+          "off_ramp": "0x2aF9B10A5972D0c36f4d8F85773052c104E319B2",
+          "commit_store": "0x82FCF55b9e9bAb3066c2863F12a02bBc2Ba33F2F",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "WeMix Testnet": {
-          "off_ramp": "0x9C08B7712af0344188aa5087D9e6aD0f47191037",
-          "commit_store": "0x4BE6DB0B884169a6A207fe5cad01eB4C025a13dB",
+          "off_ramp": "0x0FA15Bc42D4999d964CBf0161489Bd392DEE834e",
+          "commit_store": "0x37760F99a5b91884C9D89a06408f532aEbb0e674",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -635,71 +605,65 @@ Data = """
     "Polygon Amoy": {
       "is_native_fee_token": true,
       "fee_token": "0x360ad4f9a9A8EFe9A8DCB5f461c4Cc1047E1Dcf9",
-      "bridge_tokens": [
-        "0xcab0EF91Bee323d1A617c0a027eE753aFd6997E4"
-      ],
-      "bridge_tokens_pools": [
-        "0x3064fB3EA546EE09A63AB3bD93E83D8B8525C636"
-      ],
       "arm": "0x8b88C39D2875157aB4CE4AD3814409523d539ee1",
       "router": "0x9C32fCB86BF0f4a1A8921a9Fe46de3198bb884B2",
       "price_registry": "0xfb2f2A207dC428da81fbAFfDDe121761f8Be1194",
       "wrapped_native": "0x360ad4f9a9A8EFe9A8DCB5f461c4Cc1047E1Dcf9",
       "src_contracts": {
         "Avalanche Fuji": {
-          "on_ramp": "0x8Fb98b3837578aceEA32b454f3221FE18D7Ce903",
+          "on_ramp": "0xad6A94CFB51e7DE30FD21F417E4cBf70D3AdaD30",
           "deployed_at": 0
         },
         "BSC Testnet": {
-          "on_ramp": "0xC6683ac4a0F62803Bec89a5355B36495ddF2C38b",
+          "on_ramp": "0x28EC0a9C90360F55C2a9DaD5901b074C257904ca",
           "deployed_at": 0
         },
         "Gnosis Chiado": {
-          "on_ramp": "0x2331F6D614C9Fd613Ff59a1aB727f1EDf6c37A68",
+          "on_ramp": "0x9DF611536f124278Ce968c476BDb10A66E54ecfE",
           "deployed_at": 0
         },
         "Optimism Sepolia": {
-          "on_ramp": "0xA52cDAeb43803A80B3c0C2296f5cFe57e695BE11",
+          "on_ramp": "0x600f00aef9b8ED8EDBd7284B5F04a1932c3408aF",
           "deployed_at": 0
         },
         "Sepolia Testnet": {
-          "on_ramp": "0x35347A2fC1f2a4c5Eae03339040d0b83b09e6FDA",
+          "on_ramp": "0x719Aef2C63376AdeCD62D2b59D54682aFBde914a",
           "deployed_at": 0
         },
         "WeMix Testnet": {
-          "on_ramp": "0x26546096F64B5eF9A1DcDAe70Df6F4f8c2E10C61",
+          "on_ramp": "0x7D6c93E49E46cc983a677c283EAb27CbbC94e3C4",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Avalanche Fuji": {
-          "off_ramp": "0xa733ce82a84335b2E9D864312225B0F3D5d80600",
-          "commit_store": "0x09B0F93fC2111aE439e853884173AC5b2F809885",
+          "off_ramp": "0xAc56Df7F5fbde0DeeB1C0d397A150EDD5EE68625",
+          "commit_store": "0x8AF56D1c76B8c8CeE451a0a654D130e4050B993e",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "BSC Testnet": {
-          "off_ramp": "0x948dfaa4842fc23e0e362Fe8D4396AaE4E6DF7EA",
-          "commit_store": "0x7F4e739D40E58BBd59dAD388171d18e37B26326f",
+          "off_ramp": "0x40Ba47ea59D80DDd35E3a997AA520FBa0553dddc",
+          "commit_store": "0x8afe532517b39bA109d1A768E1Ad8b5C6485abF5",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Gnosis Chiado": {
-          "off_ramp": "0x17c542a28e08AEF5697251601C7b2B621d153D42",
-          "commit_store": "0x811250c20fAB9a1b7ca245453aC214ba637fBEB5",
+          "off_ramp": "0x7B968B2aDFd31765dAAD80d66c83F9D7006BFFd5",
+          "commit_store": "0xBc70551B5624BaF8cdCB84136198561C9cf5C176",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Optimism Sepolia": {
-          "off_ramp": "0xfFdE9E8c34A27BEBeaCcAcB7b3044A0A364455C9",
-          "commit_store": "0x74ED442ad211050e9C05Dc9A267E037E3d74A03B",
+          "off_ramp": "0xAA755Ef570986feEb6522377077e549e3013843E",
+          "commit_store": "0x5C7827EcE6a51AdaC36ef71aC01706deb1C7130d",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Sepolia Testnet": {
-          "off_ramp": "0xFb04129aD1EEDB741CC705ebC1978a7aB63e51f6",
-          "commit_store": "0x63f875240149d29136053C954Ca164a9BfA81F77",
+          "off_ramp": "0x7Ad494C173f5845c6B4028a06cDcC6d3108bc960",
+          "commit_store": "0x104A1c8b05D37fE732094595Fe696AFc7EAB8668",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "WeMix Testnet": {
-          "off_ramp": "0xdE8451E952Eb43350614839cCAA84f7C8701a09C",
-          "commit_store": "0xaCdaBa07ECad81dc634458b98673931DD9d3Bc14",
+          "off_ramp": "0xa85481273f8C112e96ED7476202F06D6131cf069",
+          "commit_store": "0x9FdF1D555e37dB09B0d151FEa53c134C88C4DeFd",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -707,134 +671,128 @@ Data = """
     "Sepolia Testnet": {
       "is_native_fee_token": true,
       "fee_token": "0x097D90c9d3E0B50Ca60e1ae45F6A81010f9FB534",
-      "bridge_tokens": [
-        "0xFd57b4ddBf88a4e07fF4e34C487b99af2Fe82a05"
-      ],
-      "bridge_tokens_pools": [
-        "0x38d1ef9619Cd40cf5482C045660Ae7C82Ada062c"
-      ],
       "arm": "0x27Da8735d8d1402cEc072C234759fbbB4dABBC4A",
       "router": "0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59",
       "price_registry": "0x9EF7D57a4ea30b9e37794E55b0C75F2A70275dCc",
       "wrapped_native": "0x097D90c9d3E0B50Ca60e1ae45F6A81010f9FB534",
       "src_contracts": {
         "Arbitrum Sepolia": {
-          "on_ramp": "0xe4Dd3B16E09c016402585a8aDFdB4A18f772a07e",
+          "on_ramp": "0xBc09627e58989Ba8F1eDA775e486467d2A00944F",
           "deployed_at": 0
         },
         "Avalanche Fuji": {
-          "on_ramp": "0x0477cA0a35eE05D3f9f424d88bC0977ceCf339D4",
+          "on_ramp": "0x12492154714fBD28F28219f6fc4315d19de1025B",
           "deployed_at": 0
         },
         "BSC Testnet": {
-          "on_ramp": "0xD990f8aFA5BCB02f95eEd88ecB7C68f5998bD618",
+          "on_ramp": "0x7a75b3818412fe0028590feE8270ba9E3fd01DBe",
           "deployed_at": 0
         },
         "Base Sepolia": {
-          "on_ramp": "0x2B70a05320cB069e0fB55084D402343F832556E7",
+          "on_ramp": "0x8F35B097022135E0F46831f798a240Cc8c4b0B01",
           "deployed_at": 0
         },
         "Blast Sepolia": {
-          "on_ramp": "0xDB75E9D9ca7577CcBd7232741be954cf26194a66",
+          "on_ramp": "0x4ADA60556dA05FcF53a79359e37a3E13FebA22Bf",
           "deployed_at": 0
         },
         "Celo Alfajores": {
-          "on_ramp": "0x3C86d16F52C10B2ff6696a0e1b8E0BcfCC085948",
+          "on_ramp": "0x1163D1F7D75eEb1C4f4c6912d3cF9642027aFD30",
           "deployed_at": 0
         },
         "Gnosis Chiado": {
-          "on_ramp": "0x3E842E3A79A00AFdd03B52390B1caC6306Ea257E",
+          "on_ramp": "0x831A7DbE6af8601427A0ADa89b642d4b59007eED",
           "deployed_at": 0
         },
         "Metis Sepolia": {
-          "on_ramp": "0x1C4640914cd57c5f02a68048A0fbb0E12d904223",
+          "on_ramp": "0xabB5A4f99DFEb4a3912e8Acc0660A008c76dA8c3",
           "deployed_at": 0
         },
         "Mode Sepolia": {
-          "on_ramp": "0xc630fbD4D0F6AEB00aD0793FB827b54fBB78e981",
+          "on_ramp": "0x2Eb0842925fb7aA6045e951e98e8b4b3aFFaBB54",
           "deployed_at": 0
         },
         "Optimism Sepolia": {
-          "on_ramp": "0x69CaB5A0a08a12BaFD8f5B195989D709E396Ed4d",
+          "on_ramp": "0xACDfd7a98d853FA3914047Cd46e7f5D53BBC9FbB",
           "deployed_at": 0
         },
         "Polygon Amoy": {
-          "on_ramp": "0x9f656e0361Fb5Df2ac446102c8aB31855B591692",
+          "on_ramp": "0xf9765c80F6448e6d4d02BeF4a6b4152131A2F513",
           "deployed_at": 0
         },
         "WeMix Testnet": {
-          "on_ramp": "0xedFc22336Eb0B9B11Ff37C07777db27BCcDe3C65",
+          "on_ramp": "0xd72c3c132B76F5D232C37dF3bF8f04392D552e0F",
           "deployed_at": 0
         },
         "ZKSync Sepolia": {
-          "on_ramp": "0x1Acb3A885feA37bdA30AB99b99327b14391f500F",
+          "on_ramp": "0xA2865E4f36760f5fa5c8F958336120f2DF0d974b",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Arbitrum Sepolia": {
-          "off_ramp": "0xF18896AB20a09A29e64fdEbA99FDb8EC328f43b1",
-          "commit_store": "0x93Ff9Dd39Dc01eac1fc4d2c9211D95Ee458CAB94",
+          "off_ramp": "0xD2f5edfD4561d6E7599F6c6888Bd353cAFd0c55E",
+          "commit_store": "0x240420BC6bCDc067e668c7492D69fe06B3CF80cE",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Avalanche Fuji": {
-          "off_ramp": "0x000b26f604eAadC3D874a4404bde6D64a97d95ca",
-          "commit_store": "0x2dD9273F8208B8393350508131270A6574A69784",
+          "off_ramp": "0x1DEBa99dC8e2A77832461BD386d83D9FCb133137",
+          "commit_store": "0x139E06b6dBB1a0C41A1686C091795879c943765A",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "BSC Testnet": {
-          "off_ramp": "0xdE2d8E126e08d675fCD7fFa5a6CE49925f3Dc692",
-          "commit_store": "0x0050ac355a82caB31194507f94174297bf0655A7",
+          "off_ramp": "0x04305BD9D9CA6730517f79c3D9c6828BC2D25Ecb",
+          "commit_store": "0x32edD59840CD9e474A280cf1707439F2Bd5872d4",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Base Sepolia": {
-          "off_ramp": "0x31c0B81832B333419f0DfD36A69F502cF9094aed",
-          "commit_store": "0xDFcde9d698a2B32DB2537DC9B752Cadd1D846a52",
+          "off_ramp": "0x662738DC7DE4f7eC63d9f73Cdf9BeA5A58DdcC15",
+          "commit_store": "0x1e46bAC486Dd878cD57B62845530A52343e39693",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Blast Sepolia": {
-          "off_ramp": "0x4e897e5cF3aC307F0541B2151A88bCD781c153a3",
-          "commit_store": "0xB656652841F347178e193951C4663652aCe36B74",
+          "off_ramp": "0x049A424cF894709f044bc70177F8F6b792adc3F6",
+          "commit_store": "0x496fE96E440Fc683478a08Df92A1c5E23E412b1C",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Celo Alfajores": {
-          "off_ramp": "0xB435E0f73c18C5a12C324CA1d02F81F2C3e6e761",
-          "commit_store": "0xbc5d74957F171e75F92c8F0E1C317A25a56a416D",
+          "off_ramp": "0x4F146d34Be5E273e576ef158Bd7070eC22708D20",
+          "commit_store": "0xEeB665281c7ab51d25423898f730Ab078c69dd42",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Gnosis Chiado": {
-          "off_ramp": "0x7db0115A0b3AAb01d30bf81123c5DD7B0C41Add5",
-          "commit_store": "0x6640723Ea801178c4383FA016b9781e7ef1016EF",
+          "off_ramp": "0xB424365EEEEA58A36C7EC858f926f4e8275dDEb3",
+          "commit_store": "0xE95c2135e3330E953BB49068d32Fcba368Acd456",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Metis Sepolia": {
-          "off_ramp": "0x4DB693A93E9d5196ECD42EC56CDEAe99dFC652ED",
-          "commit_store": "0xBfACd78F1412B6f93Ac23409bf456aFec1ABd845",
+          "off_ramp": "0x46DE6201c258f5948135cd0262f91e48Cb8e3828",
+          "commit_store": "0x3A27Fd059A4eF0e96B0643283A44a56A8d6CF34A",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Mode Sepolia": {
-          "off_ramp": "0xbEfd8D65F6643De54F0b1268A3bf4618ff85dcB4",
-          "commit_store": "0x0C161D3470b45Cc677661654C30ce4AdE6aCD288",
+          "off_ramp": "0x052E52fdd48719A6084366eA184FC44cb8C25DC2",
+          "commit_store": "0xBBb9baA314eB023E3F9291Aaf4107B6708341B50",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Optimism Sepolia": {
-          "off_ramp": "0xD50590D4438411EDe47029b0FD7901A7145E5Df6",
-          "commit_store": "0xe85EEE9Fd434A7b8a586Ee086E828abF41839479",
+          "off_ramp": "0xbfa6f6AAE31acB3A285e80026d6475C1a50d1d0F",
+          "commit_store": "0xB5FbA97Dc61ec68771a92a15360d9C32c9d054E7",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Polygon Amoy": {
-          "off_ramp": "0x5032cbC0C4aEeD25bb6E45D8B3fAF05DB0688C5d",
-          "commit_store": "0xe6201C9996Cc7B6E828E10CbE937E693d577D318",
+          "off_ramp": "0xC3e550B6aaFA5539df8bbCc5B0991e587f438e75",
+          "commit_store": "0xd57866D97ca26dfaE34088a3EeE4657BAFaac5f9",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "WeMix Testnet": {
-          "off_ramp": "0x46b639a3C1a4CBfD326b94a2dB7415c27157282f",
-          "commit_store": "0x7b74554678816b045c1e7409327E086bD436aa46",
+          "off_ramp": "0x445F41C6aa7e910021786e860d7cfe3E7fcC6640",
+          "commit_store": "0x307dDE3c696E399b5837456FbCe03b1Ad76D46E3",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "ZKSync Sepolia": {
-          "off_ramp": "0xBaABd4166C892a1081a26535875A8fA3f22937b2",
-          "commit_store": "0xfda2e83F4D3f42B7629134ecD6E4b29FB8A7A07B",
+          "off_ramp": "0x9f5dC467A5c97068A1c2987486B8b768275627eD",
+          "commit_store": "0x6e4601DA99a046e4bde60d051568E3E1F35E3097",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -842,80 +800,74 @@ Data = """
     "WeMix Testnet": {
       "is_native_fee_token": true,
       "fee_token": "0xbE3686643c05f00eC46e73da594c78098F7a9Ae7",
-      "bridge_tokens": [
-        "0xF4E4057FbBc86915F4b2d63EEFFe641C03294ffc"
-      ],
-      "bridge_tokens_pools": [
-        "0x82A92B2863F93Be70D20660088Ec060720bA2fdb"
-      ],
       "arm": "0x8f6cb63eD5e379722580DFF0A051C140C64F9619",
       "router": "0xA8C0c11bf64AF62CDCA6f93D3769B88BdD7cb93D",
       "price_registry": "0x89D17571DB7C9540eeB36760E3c749C8fb984569",
       "wrapped_native": "0xbE3686643c05f00eC46e73da594c78098F7a9Ae7",
       "src_contracts": {
         "Arbitrum Sepolia": {
-          "on_ramp": "0xA9DE3F7A617D67bC50c56baaCb9E0373C15EbfC6",
+          "on_ramp": "0xa5Be8C619F61505548992D9820c5c485b030C7B0",
           "deployed_at": 0
         },
         "Avalanche Fuji": {
-          "on_ramp": "0xC4aC84da458ba8e40210D2dF94C76E9a41f70069",
+          "on_ramp": "0x7802B6804bbE7486229ac6D3519f0057c50b40a9",
           "deployed_at": 0
         },
         "BSC Testnet": {
-          "on_ramp": "0x5AD6eed6Be0ffaDCA4105050CF0E584D87E0c2F1",
+          "on_ramp": "0xd25B8c70CB43022Bdc3aC417E2Cf5159294d95A1",
           "deployed_at": 0
         },
         "Kroma Sepolia": {
-          "on_ramp": "0x428C4dc89b6Bf908B82d77C9CBceA786ea8cc7D0",
+          "on_ramp": "0x1De2Ca07eEee7F524Fe5edA6C8FFFb79F67b05E9",
           "deployed_at": 0
         },
         "Optimism Sepolia": {
-          "on_ramp": "0x1961a7De751451F410391c251D4D4F98D71B767D",
+          "on_ramp": "0xB37607C6BD4562F32967dE87D14663D59e3f655d",
           "deployed_at": 0
         },
         "Polygon Amoy": {
-          "on_ramp": "0xd55148e841e76265B484d399eC71b7076ecB1216",
+          "on_ramp": "0x0c972752F9aC3255cE45b440f9bBC6500676c4e6",
           "deployed_at": 0
         },
         "Sepolia Testnet": {
-          "on_ramp": "0x4d57C6d8037C65fa66D6231844785a428310a735",
+          "on_ramp": "0x1CD55c65f85681Dfae47c62e6D93340D25006BbB",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Arbitrum Sepolia": {
-          "off_ramp": "0xeB1dFaB2464Bf0574D43e764E0c758f92e7ecAFb",
-          "commit_store": "0xcEaCa2B7890065c485f3E58657358a185Ad33791",
+          "off_ramp": "0xB5492C8A71130B486fAD1091Db683584767A3957",
+          "commit_store": "0x1e151ED27E2F48EcFBd5b4374d0fc4869e07c397",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Avalanche Fuji": {
-          "off_ramp": "0x98e811Df9D2512f1aaf58D534607F583D6c54A4F",
-          "commit_store": "0x8e538351F6E5B2daF3c90C565C3738bca69a2716",
+          "off_ramp": "0x60536c757c2BBf72cC68A1933F7e336d03Bb68fe",
+          "commit_store": "0x2fF725556A04b47eB40BbA11d9F51e8fbbee9F07",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "BSC Testnet": {
-          "off_ramp": "0xB0e7f0fCcD3c961C473E7c44D939C1cDb4Cec1cB",
-          "commit_store": "0x4B56D8d53f1A6e0117B09700067De99581aA5542",
+          "off_ramp": "0xb858077FbE1E55cD7a9092Eb6d5403e068c14EAf",
+          "commit_store": "0x0EF13C7c95C27A9EA477363a26a09Cff44ba38F9",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Kroma Sepolia": {
-          "off_ramp": "0xD685D2d224dd6D0Db2D56497db6270D77D9a7966",
-          "commit_store": "0x7e062D6880779a0347e7742058C1b1Ee4AA0B137",
+          "off_ramp": "0x78d8154e1216F4791086bFa078Aaf07dcD2bD3C6",
+          "commit_store": "0xe67AAfbE6025e730Cf47a414BEFf2106FF231dB1",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Optimism Sepolia": {
-          "off_ramp": "0xA5f97Bc69Bf06e7C37B93265c5457420A92c5F4b",
-          "commit_store": "0xd48b9213583074f518D8f4336FDf35370D450132",
+          "off_ramp": "0x995Fc17FC12b67f75D3cBf3bC71BD9af65671E78",
+          "commit_store": "0xD0825e3D8e61b67a06A93426749d38bCF73Ddb02",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Polygon Amoy": {
-          "off_ramp": "0x6c8f5999B06FDE17B11E4e3C1062b761766F960f",
-          "commit_store": "0x957c3c2056192e58A8485eF31165fC490d474239",
+          "off_ramp": "0xd7b5B4F8FF7a87cC92f7B3058365862859d9E057",
+          "commit_store": "0xa8f2bb4e831caA5E2794AaD014030E378208d4Bc",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Sepolia Testnet": {
-          "off_ramp": "0x8AB103843ED9D28D2C5DAf5FdB9c3e1CE2B6c876",
-          "commit_store": "0x7d5297c5506ee2A7Ef121Da9bE02b6a6AD30b392",
+          "off_ramp": "0xa7E2F97Be7798327A49CACD022f33c0E7EfD4897",
+          "commit_store": "0x6fe69eE4eC9FD768193a40129A3Ba3dF140b2208",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -929,14 +881,14 @@ Data = """
       "wrapped_native": "0x4317b2eCD41851173175005783322D29E9bAee9E",
       "src_contracts": {
         "Sepolia Testnet": {
-          "on_ramp": "0x79a9a5e9e318e8e109776569574814bbf935125a",
+          "on_ramp": "0xC38536521fde8556351aB7C4D3ea23b64AFbBbab",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Sepolia Testnet": {
-          "off_ramp": "0x18FF69051479796175852578725Fc74F58E963F8",
-          "commit_store": "0xF694b4FD7889480dca3CD41244e8e3395a9EFBa0",
+          "off_ramp": "0x19Ea9A42cd3682928aF19990dDb3904250D00a1D",
+          "commit_store": "0x20BF9037927bFadaF028D43ae07d1afccfB8fa85",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -1006,7 +958,7 @@ NetworkPairs = [
   'BASE_SEPOLIA,OPTIMISM_SEPOLIA',
   'BASE_SEPOLIA,GNOSIS_CHIADO',
 
-  'KROMA_SEPOLIA,WEMIX_TESTNET',
+#  'KROMA_SEPOLIA,WEMIX_TESTNET',
 
   'OPTIMISM_SEPOLIA,POLYGON_AMOY',
   'OPTIMISM_SEPOLIA,WEMIX_TESTNET',

--- a/integration-tests/ccip-tests/testconfig/tomls/prod-testnet/smoke-release-testing_token_transfer_native.toml
+++ b/integration-tests/ccip-tests/testconfig/tomls/prod-testnet/smoke-release-testing_token_transfer_native.toml
@@ -26,59 +26,68 @@ Data = """
       "wrapped_native": "0xE591bf0A0CF924A0674d7792db046B23CEbF5f34",
       "src_contracts": {
         "Avalanche Fuji": {
-          "on_ramp": "0x1Cb56374296ED19E86F68fA437ee679FD7798DaA",
+          "on_ramp": "0x20C8c9F13C6AA402F2545AD15fB7a9CdE9108618",
           "deployed_at": 0
         },
         "Base Sepolia": {
-          "on_ramp": "0x7854E73C73e7F9bb5b0D5B4861E997f4C6E8dcC6",
+          "on_ramp": "0xF1623862e4c9f9Fba1Ac0181C4fF53B4f958F065",
           "deployed_at": 0
         },
         "Gnosis Chiado": {
-          "on_ramp": "0x973CbE752258D32AE82b60CD1CB656Eebb588dF0",
+          "on_ramp": "0xEfe02eB139D2A82e38184d28E3b65bb176F26ebD",
+          "deployed_at": 0
+        },
+        "Metis Sepolia": {
+          "on_ramp": "0x46a79a6a4B07FD3FC14ea8299A99FE29576776E2",
           "deployed_at": 0
         },
         "Optimism Sepolia": {
-          "on_ramp": "0x701Fe16916dd21EFE2f535CA59611D818B017877",
+          "on_ramp": "0x0B0c08Bb2fA2EbDe25817009ee39eA1ad9bCaC58",
           "deployed_at": 0
         },
         "Sepolia Testnet": {
-          "on_ramp": "0x4205E1Ca0202A248A5D42F5975A8FE56F3E302e9",
+          "on_ramp": "0x64d78F20aD987c7D52FdCB8FB0777bD00de53210",
           "deployed_at": 0
         },
         "WeMix Testnet": {
-          "on_ramp": "0xBD4106fBE4699FE212A34Cc21b10BFf22b02d959",
+          "on_ramp": "0x2F3Daf77A663603826c7750E956b6555DE6f8250",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Avalanche Fuji": {
-          "off_ramp": "0xcab0EF91Bee323d1A617c0a027eE753aFd6997E4",
-          "commit_store": "0x0d90b9b96cBFa0D01635ce12982ccE1b70827c7a",
+          "off_ramp": "0x7245a5947E2F32B66aF74F4dAF91718ea19afaDf",
+          "commit_store": "0x490AC77BbB26f4FFf876Ded07bCAE6DBe685be98",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Base Sepolia": {
-          "off_ramp": "0xc1982985720B959E66c19b64F783361Eb9B60F26",
-          "commit_store": "0x28F66bB336f6db713d6ad2a3bd1B7a531282A159",
+          "off_ramp": "0xF2aB55Ed448A6fAD75013900568B6a927f52e5e0",
+          "commit_store": "0x833E5995A7422120f445f9B8dD1b9BD1037c68E5",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Gnosis Chiado": {
-          "off_ramp": "0x935C26F9a9122E5F9a27f2d3803e74c75B94f5a3",
-          "commit_store": "0xEdb963Ec5c2E5AbdFdCF137eF44A445a7fa4787A",
+          "off_ramp": "0xc1Cb31493fB2386aDC1Ea01F935F2bd8a8dCA388",
+          "commit_store": "0xe21896657A65c8959F16E1c3Ee5713E85d9EA020",
+          "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
+        },
+        "Metis Sepolia": {
+          "off_ramp": "0xc47143147Fd62A09618C695c7C03714aCe8db1Cf",
+          "commit_store": "0x2F42e7B22eE5885158916624Ff00608f4C82313D",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Optimism Sepolia": {
-          "off_ramp": "0xfD404A89e1d195F0c65be1A9042C77745197659e",
-          "commit_store": "0x84B7B012c95f8A152B44Ab3e952f2dEE424fA8e1",
+          "off_ramp": "0x4a7E91EF68758aaC66AeD656267bbCD0f9b6c019",
+          "commit_store": "0xb0A09D6A15FF7A0142DF3F62b2C4D1e11D763Ed0",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Sepolia Testnet": {
-          "off_ramp": "0x1c71f141b4630EBE52d6aF4894812960abE207eB",
-          "commit_store": "0xaB0c8Ba51E7Fa3E5693a4Fbb39473520FD85d173",
+          "off_ramp": "0xBed6e9131916d724418C8a6FE810F727302a5c00",
+          "commit_store": "0xdDb61B6bDa1B46d88f556440fABFe219F6da4F3a",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "WeMix Testnet": {
-          "off_ramp": "0x262e16C8D42aa07bE13e58F81e7D9F62F6DE2830",
-          "commit_store": "0xc132eFAf929299E5ee704Fa6D9796CFa23Bb8b2C",
+          "off_ramp": "0x11d486E92d291704D1E25cDbAeee687237247826",
+          "commit_store": "0xece9353095aC79Db9DD5bf2022690Fa6BffeBCAc",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -98,77 +107,77 @@ Data = """
       "wrapped_native": "0xd00ae08403B9bbb9124bB305C09058E32C39A48c",
       "src_contracts": {
         "Arbitrum Sepolia": {
-          "on_ramp": "0x8bB16BEDbFd62D1f905ACe8DBBF2954c8EEB4f66",
+          "on_ramp": "0xa9946BA30DAeC98745755e4410d6e8E894Edc53B",
           "deployed_at": 0
         },
         "BSC Testnet": {
-          "on_ramp": "0xF25ECF1Aad9B2E43EDc2960cF66f325783245535",
+          "on_ramp": "0x906BC7D10947A94ba0252e8C2E34868A466c03ED",
           "deployed_at": 0
         },
         "Base Sepolia": {
-          "on_ramp": "0x1A674645f3EB4147543FCA7d40C5719cbd997362",
+          "on_ramp": "0x0aEc1AC9F6D0c21332d7a66dDF1Fbcb32cF3B0B3",
           "deployed_at": 0
         },
         "Gnosis Chiado": {
-          "on_ramp": "0x1532e5b204ee2b2244170c78E743CB9c168F4DF9",
+          "on_ramp": "0x3dda45E731EC1db18B95651d1AF1868aa878468D",
           "deployed_at": 0
         },
         "Optimism Sepolia": {
-          "on_ramp": "0xC334DE5b020e056d0fE766dE46e8d9f306Ffa1E2",
+          "on_ramp": "0x2a9EFdc9F93D9b822129038EFCa4B63Adf3f7FB5",
           "deployed_at": 0
         },
         "Polygon Amoy": {
-          "on_ramp": "0x610F76A35E17DA4542518D85FfEa12645eF111Fc",
+          "on_ramp": "0xA82b9ACAcFA6FaB1FD721e7a748A30E3001351F9",
           "deployed_at": 0
         },
         "Sepolia Testnet": {
-          "on_ramp": "0x5724B4Cc39a9690135F7273b44Dfd3BA6c0c69aD",
+          "on_ramp": "0x75b9a75Ee1fFef6BE7c4F842a041De7c6153CF4E",
           "deployed_at": 0
         },
         "WeMix Testnet": {
-          "on_ramp": "0x677B5ab5C8522d929166c064d5700F147b15fa33",
+          "on_ramp": "0x1ff99E67986E83bb5BA34143BaA2735853e5738c",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Arbitrum Sepolia": {
-          "off_ramp": "0x90A74072e7B0c2d59e13aB4d8f93c8198c413194",
-          "commit_store": "0xf3458CFd2fdf4a6CF0Ce296d520DD21eB194828b",
+          "off_ramp": "0xd88CBA0612f2Ce611BF6d073A94C8FD7E70B4fBd",
+          "commit_store": "0x9b8279E352bC167F714eef96A4C436bE996643cE",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "BSC Testnet": {
-          "off_ramp": "0x10b28009E5D776F1f5AAA73941CE8953B8f42d26",
-          "commit_store": "0xacDD582F271eCF22FAd6764cCDe1c4a534b732A8",
+          "off_ramp": "0x9c40A73F5C7454BB7C178AFa56Ee30bFB2DCf7E6",
+          "commit_store": "0xE5611af1d63340b711B0468a976651Fb79B17870",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Base Sepolia": {
-          "off_ramp": "0xdBdE8510226d1E060A3bf982b67705C67f5697e2",
-          "commit_store": "0x8Ee73BC9492b4182D289E5C1e66e40CD876CC00F",
+          "off_ramp": "0xf8de9d5924CFD28e31a53B63B4903436D9818d69",
+          "commit_store": "0xDD7CfECE1bb4e8aC2E8b8281CFE1D44247119471",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Gnosis Chiado": {
-          "off_ramp": "0x56dF55aF5F0A4689f3364230587a68eD6A314fAd",
-          "commit_store": "0xabA7ff98094c4cc7A075812EefF2CD21f6400235",
+          "off_ramp": "0x3F5035039C23cDAF032C64c084Dc70F811E62ddD",
+          "commit_store": "0xf5B0245c7B9e15f0cB0B85FF2B6799a45D61CbaA",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Optimism Sepolia": {
-          "off_ramp": "0x3d7CbC95DCC33257F14D6Eb780c88Bd56C6335BB",
-          "commit_store": "0x1fcDC02edDfb405f378ba53cF9E6104feBcB7542",
+          "off_ramp": "0x1DF9D94C6916918C935E60d2Cb4Ed265Bf778005",
+          "commit_store": "0xE7eeBE5882609d28C015d0A89DE1ba4f506F4a03",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Polygon Amoy": {
-          "off_ramp": "0x3e33290B90fD0FF30a3FA138934DF028E4eCA348",
-          "commit_store": "0xCFe3556Aa42d40be09BD23aa80448a19443BE5B1",
+          "off_ramp": "0xbeD7F478Ef5627FB2B891fDA29Ca0131f6796D9D",
+          "commit_store": "0x27a319f58c01380056c86938798aCEAA1AC529e2",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Sepolia Testnet": {
-          "off_ramp": "0x9e5e4324F8608D54A50a317832d456a392E4F8C2",
-          "commit_store": "0x92A51eD3F041B39EbD1e464C1f7cb1e8f8A8c63f",
+          "off_ramp": "0x01e3D835b4C4697D7F81B9d7Abc89A6E478E4a2f",
+          "commit_store": "0x4EC313c1Eb620432f42FB5f4Df27f8A566523c1C",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "WeMix Testnet": {
-          "off_ramp": "0xD0D338318bC6837b091FC7AB5F2a94B7783507d5",
-          "commit_store": "0xd9D479208235c7355848ff4aF26eB5aacfDC30c6",
+          "off_ramp": "0x15CcAbf0e3484D4872e25b883163D8cB724d4832",
+          "commit_store": "0x859f3477B7b4ECc19aDD8cCb19740932F21bD76b",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -188,59 +197,68 @@ Data = """
       "wrapped_native": "0xae13d989daC2f0dEbFf460aC112a837C89BAa7cd",
       "src_contracts": {
         "Avalanche Fuji": {
-          "on_ramp": "0xa2515683E99F50ADbE177519A46bb20FfdBaA5de",
+          "on_ramp": "0x2A6f8Ed2e7b222163ef6EcC2327171B479399ab2",
           "deployed_at": 0
         },
         "Base Sepolia": {
-          "on_ramp": "0x3E807220Ca84b997c0d1928162227b46C618e0c5",
+          "on_ramp": "0x97856Bf888F6eEDBBd322B28133BCcF9CA9038f6",
+          "deployed_at": 0
+        },
+        "Blast Sepolia": {
+          "on_ramp": "0xd0049BfFc8e2689Df9236FfA393Ccbf7eae4FbbC",
           "deployed_at": 0
         },
         "Gnosis Chiado": {
-          "on_ramp": "0x8735f991d41eA9cA9D2CC75cD201e4B7C866E63e",
+          "on_ramp": "0x98dEa9e498F2A7aF6c74C915c88A17FbA09b73C2",
           "deployed_at": 0
         },
         "Polygon Amoy": {
-          "on_ramp": "0xf37CcbfC04adc1B56a46B36F811D52C744a1AF78",
+          "on_ramp": "0x363EB789fE31F08547a847D8C38d9b55C7Cf1903",
           "deployed_at": 0
         },
         "Sepolia Testnet": {
-          "on_ramp": "0xB1DE44B04C00eaFe9915a3C07a0CaeA4410537dF",
+          "on_ramp": "0xC1C6438D60AbE9bF4b1F10460184CE9bD312e328",
           "deployed_at": 0
         },
         "WeMix Testnet": {
-          "on_ramp": "0x89268Afc1BEA0782a27ba84124E3F42b196af927",
+          "on_ramp": "0xbc85704EDb79ea84E9D3C18965F7f6A16B0a0440",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Avalanche Fuji": {
-          "off_ramp": "0x6e6fFCb6B4BED91ff0CC8C2e57EC029dA7DB80C2",
-          "commit_store": "0x38Bc38Bd824b6eE87571f9D3CFbe6D6E28E3Dc62",
+          "off_ramp": "0x95b66acfaaDF122f4EccE52C0aD4Fd997DD1150C",
+          "commit_store": "0x3af04b1c1e79A6B8A4577Bb47EC33eD2E66AeB47",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Base Sepolia": {
-          "off_ramp": "0x2C61FD7E93Dc79422861282145c59B56dFbc3a8c",
-          "commit_store": "0x42fAe5B3605804CF6d08632d7A25864e24F792Ae",
+          "off_ramp": "0x0a5147e1Ac38C79c77031194ef64C8B5353F6EE9",
+          "commit_store": "0x103864D60b33a479EA7D0e23a37e0ce07198f0A9",
+          "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
+        },
+        "Blast Sepolia": {
+          "off_ramp": "0xe1e8473218acCB82FBc24Ccd3C5D2dF166cd04f3",
+          "commit_store": "0x020B047A5Ca88fDB1ad3bAD9A082760fC7F770b6",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Gnosis Chiado": {
-          "off_ramp": "0x71a44a60832B0F8B63232C9516e7E6aEc3A373Dc",
-          "commit_store": "0xAC24299a91b72d1Cb5B31147e3CF54964D896974",
+          "off_ramp": "0x1F7FEBCBb10420E039C333A60A444c1a442d826C",
+          "commit_store": "0x23Ae763a64D39d6038431a64Bbc4A670C89d82b9",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Polygon Amoy": {
-          "off_ramp": "0x63440C7747d37bc6154b5538AE32b54FE0965AfA",
-          "commit_store": "0xAD22fA198CECfC534927aE1D480c460d5bB3460F",
+          "off_ramp": "0xAAe325adbc9C5a28e4e94Fef170D55de2CA9aA01",
+          "commit_store": "0xD173Df3A1b23ec42eA5C4669b9c956Bef230efd1",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Sepolia Testnet": {
-          "off_ramp": "0xf1c128Fe52Ea78CcAAB407509292E61ce38C1523",
-          "commit_store": "0x59dFD870dC4bd76A7B879A4f705Fdcd2595f85f9",
+          "off_ramp": "0xB513523aee87f838e78b32d2Bacaaf2e94D9f0f9",
+          "commit_store": "0x21A49164890576504C1f1c4DC9442c42C98771D7",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "WeMix Testnet": {
-          "off_ramp": "0xfd9B19c3725da5B517aA705B848ff3f21F98280e",
-          "commit_store": "0x3c1F1412563188aBc8FE3fd53E8F1Cb601CaB4f9",
+          "off_ramp": "0xc985571900DCa62387f93F882AB550472531f5DB",
+          "commit_store": "0xac5DACfAb1a512E33c49EFE42502863FC1a4BAB3",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -260,68 +278,68 @@ Data = """
       "wrapped_native": "0x4200000000000000000000000000000000000006",
       "src_contracts": {
         "Arbitrum Sepolia": {
-          "on_ramp": "0x58622a80c6DdDc072F2b527a99BE1D0934eb2b50",
+          "on_ramp": "0xb52eF669d3fCeBee1f31418Facc02a16A6F6B0e5",
           "deployed_at": 0
         },
         "Avalanche Fuji": {
-          "on_ramp": "0xAbA09a1b7b9f13E05A6241292a66793Ec7d43357",
+          "on_ramp": "0x212e8Fd9cCC330ab54E8141FA7d33967eF1eDafF",
           "deployed_at": 0
         },
         "BSC Testnet": {
-          "on_ramp": "0xD806966beAB5A3C75E5B90CDA4a6922C6A9F0c9d",
+          "on_ramp": "0xd54B44811AE99a18Cb95B4704ba04a65C0163751",
           "deployed_at": 0
         },
         "Gnosis Chiado": {
-          "on_ramp": "0x2Eff2d1BF5C557d6289D208a7a43608f5E3FeCc2",
+          "on_ramp": "0xdd0Ee1F20E93a93634AAcE56105E19423881Df56",
           "deployed_at": 0
         },
         "Mode Sepolia": {
-          "on_ramp": "0x3d0115386C01436870a2c47e6297962284E70BA6",
+          "on_ramp": "0xc59689dFDEF9D953cEFbb58912b304bb38408476",
           "deployed_at": 0
         },
         "Optimism Sepolia": {
-          "on_ramp": "0x3b39Cd9599137f892Ad57A4f54158198D445D147",
+          "on_ramp": "0x2945D35F428CE564F5455AD0AF28BDFCa67e76Ab",
           "deployed_at": 0
         },
         "Sepolia Testnet": {
-          "on_ramp": "0x6486906bB2d85A6c0cCEf2A2831C11A2059ebfea",
+          "on_ramp": "0x29A1F4ecE9246F0042A9062FB89803fA8B1830cB",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Arbitrum Sepolia": {
-          "off_ramp": "0xd364C06ac99a82a00d3eFF9F2F78E4Abe4b9baAA",
-          "commit_store": "0xdE8d0f47a71eA3fDFBD3162271652f2847939097",
+          "off_ramp": "0x814E735c5DD19240c85E2513DD926Bc3a39f7140",
+          "commit_store": "0xFc24B204bfA5C65eD8e2Fc02fDe4FeCb62eA8Ac5",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Avalanche Fuji": {
-          "off_ramp": "0xAd91214efFee446500940c764DF77AF18427294F",
-          "commit_store": "0x1242b6c5e0e349b8d4BCf0938f961C4B4f7EA3Fa",
+          "off_ramp": "0x3Ab3a3d35cAC95FfcFCcc127eF01eA8D87b0A64e",
+          "commit_store": "0x51313B8C068B5227fa7364E6eCB1382Fb751976F",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "BSC Testnet": {
-          "off_ramp": "0xd5E9508921434e8758f4540D55c1c066b7cc1598",
-          "commit_store": "0x1a86b29364D1B3fA3386329A361aA98A104b2742",
+          "off_ramp": "0x827CF69409307Cd4c979e652894C297ad5124ab7",
+          "commit_store": "0x547eBe6077305c3fdF8dA66c66cc14b0779CE00C",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Gnosis Chiado": {
-          "off_ramp": "0x9Bb7e398ef9Acfe9cA584C39B1E233Cba62BB9f7",
-          "commit_store": "0x1F4B82cDebaC5e3a0Dd53183D47e51808B4a64cB",
+          "off_ramp": "0x8bB08Bc19771C69E739a2078894523b3DC05a05e",
+          "commit_store": "0xf163Da63bDB8b9C355d41C755E03125988650109",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Mode Sepolia": {
-          "off_ramp": "0xB26647A23e8b4284375e5C74b77c9557aE709D03",
-          "commit_store": "0x4b4fEB401d3E613e1D6242E155C83A80BF9ac2C9",
+          "off_ramp": "0x11E16c71D76E43acbcb496A70966380d905B1E32",
+          "commit_store": "0xEe19f039FaE3EF0F94971f0B7B187223D952ac13",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Optimism Sepolia": {
-          "off_ramp": "0x86a3910908eCaAA31Fcd9F0fC8841D8E98f1511d",
-          "commit_store": "0xE99a87C9b5ed4D2b6060195DEea5106ffF655736",
+          "off_ramp": "0x8718d1cc138421Dbc1B489CB7884FF68DE7ad867",
+          "commit_store": "0x3291D453c880E5b59EEd04E600c85268Cd378b7f",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Sepolia Testnet": {
-          "off_ramp": "0x189F61D9B886Dd2975D5Abc893c8Cf5f5effda71",
-          "commit_store": "0xEE7e27346DCD1e711348D0F7f7ECB53a9a3a08a7",
+          "off_ramp": "0x0ecA23Ef70B828fEDd0A84d2692cB0527B52396A",
+          "commit_store": "0xA7F84Ec616F8e9Fa593339944E76bda90A9737fE",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -340,15 +358,24 @@ Data = """
       "price_registry": "0xc8acE9dF450FaD007755C6C9AB4f0e9c8626E29C",
       "wrapped_native": "0x4200000000000000000000000000000000000023",
       "src_contracts": {
+        "BSC Testnet": {
+          "on_ramp": "0x6eA6f63b689b5597A0C06a5Eb8DcDFD86383857A",
+          "deployed_at": 0
+        },
         "Sepolia Testnet": {
-          "on_ramp": "0x85Ef19FC4C63c70744995DC38CAAEC185E0c619f",
+          "on_ramp": "0x154aDEF773a848da8229D81De73a7b0844400ebd",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
+        "BSC Testnet": {
+          "off_ramp": "0xd9dE4aCD27E814bfe70CA33d2A4d079e740626Bd",
+          "commit_store": "0xe8fF7e22c54f76F453d6072A9d3a12B1D9AbA137",
+          "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
+        },
         "Sepolia Testnet": {
-          "off_ramp": "0x92cD24C278D34C726f377703E50875d8f9535dC2",
-          "commit_store": "0xcE1b4D50CeD56850182Bd58Ace91171cB249B873",
+          "off_ramp": "0x46DD4e3e2b8a18409646F1C15bf3799a481e67f6",
+          "commit_store": "0x8250f9E992dda66791dd8b5d356B867ae53382cF",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -368,14 +395,14 @@ Data = """
       "wrapped_native": "0x99604d0e2EfE7ABFb58BdE565b5330Bb46Ab3Dca",
       "src_contracts": {
         "Sepolia Testnet": {
-          "on_ramp": "0x16a020c4bbdE363FaB8481262D30516AdbcfcFc8",
+          "on_ramp": "0x68A4f57A499563192C606a898BAf503A43fcDB4D",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Sepolia Testnet": {
-          "off_ramp": "0xa1b97F92D806BA040daf419AFC2765DC723683a4",
-          "commit_store": "0xcd92C0599Ac515e7588865cC45Eee21A74816aFc",
+          "off_ramp": "0xF6dB68333D14f6a0c1123cc420ea60980aEDA0Eb",
+          "commit_store": "0x8f9B63c40891CdF7d1C795625d4260a29bE2bBa0",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -395,68 +422,68 @@ Data = """
       "wrapped_native": "0x18c8a7ec7897177E4529065a7E7B0878358B3BfF",
       "src_contracts": {
         "Arbitrum Sepolia": {
-          "on_ramp": "0x473b49fb592B54a4BfCD55d40E048431982879C9",
+          "on_ramp": "0x94967Ea06C6543Aaba5B90C52B655003ef82e521",
           "deployed_at": 0
         },
         "Avalanche Fuji": {
-          "on_ramp": "0x610F76A35E17DA4542518D85FfEa12645eF111Fc",
+          "on_ramp": "0x4f3576585e7fCCE5Fc502Bcf3CAdaD22E1194834",
           "deployed_at": 0
         },
         "BSC Testnet": {
-          "on_ramp": "0xE48E6AA1fc7D0411acEA95F8C6CaD972A37721D4",
+          "on_ramp": "0xB2642B54580140C375c9024e273C575a5f53d02d",
           "deployed_at": 0
         },
         "Base Sepolia": {
-          "on_ramp": "0x41b4A51cAfb699D9504E89d19D71F92E886028a8",
+          "on_ramp": "0x0E9504907be794620229C196F82CB062A66B7480",
           "deployed_at": 0
         },
         "Optimism Sepolia": {
-          "on_ramp": "0xAae733212981e06D9C978Eb5148F8af03F54b6EF",
+          "on_ramp": "0xeb86B5b6f5C66eCb58e4Cf98E607b238126505DC",
           "deployed_at": 0
         },
         "Polygon Amoy": {
-          "on_ramp": "0x01800fCDd892e37f7829937271840A6F041bE62E",
+          "on_ramp": "0xd86F5DF82A2500137Ddeef963028d60E3b5A354D",
           "deployed_at": 0
         },
         "Sepolia Testnet": {
-          "on_ramp": "0x4ac7FBEc2A7298AbDf0E0F4fDC45015836C4bAFe",
+          "on_ramp": "0x03691D63C687D09368360e957AFB2F7B4d1651d4",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Arbitrum Sepolia": {
-          "off_ramp": "0x9aA82DBB53bf02096B771D40e9432A323a78fB26",
-          "commit_store": "0x5CdbA91aBC0cD81FC56bc10Ad1835C9E5fB38e5F",
+          "off_ramp": "0x3633Cce99186217d4C7ed64FD455d218b8Cd5D4c",
+          "commit_store": "0x6e096286548451828c97F1B3E49C402a4934F39a",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Avalanche Fuji": {
-          "off_ramp": "0x3e33290B90fD0FF30a3FA138934DF028E4eCA348",
-          "commit_store": "0xCFe3556Aa42d40be09BD23aa80448a19443BE5B1",
+          "off_ramp": "0x5E4DB2A3c965B9B2A850a75697Bb6a00b4e35ac5",
+          "commit_store": "0x2489c5a802fE63943f7E3185A0362327B55DDF67",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "BSC Testnet": {
-          "off_ramp": "0xbc4AD54e91b213D4279af92c0C5518c0b96cf62D",
-          "commit_store": "0xff84e8Dd4Fd17eaBb23b6AeA6e1981830e54389C",
+          "off_ramp": "0x2BA72Ba392C08750328635E36757A2c29a9165CA",
+          "commit_store": "0x08ebd7Cf4ABDC819c74cB45CbA4e291728538D7C",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Base Sepolia": {
-          "off_ramp": "0x4117953A5ceeF12f5B8C1E973b470ab83a8CebA6",
-          "commit_store": "0x94ad41296186E81f31e1ed0B1BcF5fa9e1721C27",
+          "off_ramp": "0x269D28B25Ee081ae5340e2BFE99850E92F1cd522",
+          "commit_store": "0x8dC9329BD221C89c4989d98c38Ff2Cc3dF92d14b",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Optimism Sepolia": {
-          "off_ramp": "0x33d2898F8fb7714FD1661791766f40754982a343",
-          "commit_store": "0x55d6Df194472f02CD481e506A277c4A29D0D1bCc",
+          "off_ramp": "0xd93B571ae9CaF43d70b2b53fFD55e035Db641e31",
+          "commit_store": "0x42C1093b9DdE8d0CD58859C610dc239B66bE26de",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Polygon Amoy": {
-          "off_ramp": "0x450543b1d85ca79885851D7b74dc982981b78229",
-          "commit_store": "0x23B79d940A769FE31b4C867A8BAE80117f24Ca81",
+          "off_ramp": "0x87F9b8382611ACD01d5696a1f5b05B888e55B0Cc",
+          "commit_store": "0x29AC46227908d31A9BdDe82c0A4a6c52D802f145",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Sepolia Testnet": {
-          "off_ramp": "0xbf9036529123DE264bFA0FC7362fE25B650D4B16",
-          "commit_store": "0x5f7F1abD5c5EdaF2636D58B980e85355AF0Ef80d",
+          "off_ramp": "0x9aa734100C425309091dAE18154e0356B82d477a",
+          "commit_store": "0x7cDd533B82f4c32FAE7f551C37b1490909817C45",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -476,14 +503,14 @@ Data = """
       "wrapped_native": "0x4200000000000000000000000000000000000001",
       "src_contracts": {
         "WeMix Testnet": {
-          "on_ramp": "0x6ea155Fc77566D9dcE01B8aa5D7968665dc4f0C5",
+          "on_ramp": "0xa81418c332d3E04338B058Ab39b1baf53029F638",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "WeMix Testnet": {
-          "off_ramp": "0xB602B6E5Caf08ac0C920EAE585aed100a8cF6f3B",
-          "commit_store": "0x89D5b13908b9063abCC6791dc724bF7B7c93634C",
+          "off_ramp": "0x42Dde725C4f05C237a00B582Bb7457e208d3A17C",
+          "commit_store": "0xb116E9a90534354dA59CF93a87c1E9711c0Aaa2c",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -502,15 +529,24 @@ Data = """
       "price_registry": "0x5DCE866b3ae6E0Ed153f0e149D7203A1B266cdF5",
       "wrapped_native": "0x5c48e07062aC4E2Cf4b9A768a711Aef18e8fbdA0",
       "src_contracts": {
+        "Arbitrum Sepolia": {
+          "on_ramp": "0x2eb69889cc979c0Be120813FcE2f1558efF4ceB5",
+          "deployed_at": 0
+        },
         "Sepolia Testnet": {
-          "on_ramp": "0x2Eff2d1BF5C557d6289D208a7a43608f5E3FeCc2",
+          "on_ramp": "0xE0dFc15C0CDf607b2088D0B641E00eA0B418124C",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
+        "Arbitrum Sepolia": {
+          "off_ramp": "0x839b5dEA3e084790F580E9DfCE8CCfDf49c5835e",
+          "commit_store": "0xdF38C8aD34C379165f98A75a6894790bB5a16b1D",
+          "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
+        },
         "Sepolia Testnet": {
-          "off_ramp": "0x9Bb7e398ef9Acfe9cA584C39B1E233Cba62BB9f7",
-          "commit_store": "0x1F4B82cDebaC5e3a0Dd53183D47e51808B4a64cB",
+          "off_ramp": "0x72130De9A85e9C61151253aFF8801Bb3242A00a9",
+          "commit_store": "0x8F6D64280C379F680Ff0c3278f340D72a465FAAc",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -530,23 +566,23 @@ Data = """
       "wrapped_native": "0x4200000000000000000000000000000000000006",
       "src_contracts": {
         "Base Sepolia": {
-          "on_ramp": "0x73f7E074bd7291706a0C5412f51DB46441B1aDCB",
+          "on_ramp": "0x48ACE2319f643584B77C21476a6c664D7F13a107",
           "deployed_at": 0
         },
         "Sepolia Testnet": {
-          "on_ramp": "0xfFdE9E8c34A27BEBeaCcAcB7b3044A0A364455C9",
+          "on_ramp": "0xb821885731414497d705dc56325f18AA33e612dC",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Base Sepolia": {
-          "off_ramp": "0x137a38c6b1Ad20101F93516aB2159Df525309168",
-          "commit_store": "0x8F43d867969F14619895d71E0A5b89E0bb20bF70",
+          "off_ramp": "0xC6b69Fa9eeBc55e64eBc68371Fbd41ff73756F17",
+          "commit_store": "0xaA6691EA9110409a29C2E665174b4b2fe694cE67",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Sepolia Testnet": {
-          "off_ramp": "0xcD44cec849B6a8eBd5551D6DFeEcA452257Dfe4d",
-          "commit_store": "0xbA66f08733E6715D33edDfb5a5947676bb45d0e0",
+          "off_ramp": "0x35dE2C381a2fF8a26c8ae94145be3A9cA8C83600",
+          "commit_store": "0xE7e60DAee094416b8ab2083047a893c4c4290c48",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -566,68 +602,68 @@ Data = """
       "wrapped_native": "0x4200000000000000000000000000000000000006",
       "src_contracts": {
         "Arbitrum Sepolia": {
-          "on_ramp": "0x1a86b29364D1B3fA3386329A361aA98A104b2742",
+          "on_ramp": "0x6B36c9CD74E760088817a047C3460dEdFfe9a11A",
           "deployed_at": 0
         },
         "Avalanche Fuji": {
-          "on_ramp": "0x6b38CC6Fa938D5AB09Bdf0CFe580E226fDD793cE",
+          "on_ramp": "0x91a144F570ABA7FB7079Fb187A267390E0cc7367",
           "deployed_at": 0
         },
         "Base Sepolia": {
-          "on_ramp": "0xe284D2315a28c4d62C419e8474dC457b219DB969",
+          "on_ramp": "0x6D22953cdEf8B0C9F0976Cfa52c33B198fEc5881",
           "deployed_at": 0
         },
         "Gnosis Chiado": {
-          "on_ramp": "0x835a5b8e6CA17c2bB5A336c93a4E22478E6F1C8A",
+          "on_ramp": "0xec7D9A84A6d4556056975BE50Cdc97bAa9313632",
           "deployed_at": 0
         },
         "Polygon Amoy": {
-          "on_ramp": "0x2Cf26fb01E9ccDb831414B766287c0A9e4551089",
+          "on_ramp": "0x9E09C2A7D6B9F88c62f0E2Af4cd62dF3F4c326F1",
           "deployed_at": 0
         },
         "Sepolia Testnet": {
-          "on_ramp": "0xC8b93b46BF682c39B3F65Aa1c135bC8A95A5E43a",
+          "on_ramp": "0x54b32C2aCb4451c6cF66bcbd856d8A7Cc2263531",
           "deployed_at": 0
         },
         "WeMix Testnet": {
-          "on_ramp": "0xc7E53f6aB982af7A7C3e470c8cCa283d3399BDAd",
+          "on_ramp": "0xB9Ef21C04d8340b223e9C1d7a09f332609c70300",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Arbitrum Sepolia": {
-          "off_ramp": "0xDc2c7A3d8068C6F09F0F3648d24C84e372F6014d",
-          "commit_store": "0xb1aFb5cbE3c29b5Db71F21442BA9EfD450BC23C3",
+          "off_ramp": "0xF35e2d1457749374453e44B06268aD3f78b133b3",
+          "commit_store": "0x4bd755d86E25dD4093CAa5639CfDab81571259CA",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Avalanche Fuji": {
-          "off_ramp": "0x1F350718e015EB20E5065C09F4A7a3f66888aEeD",
-          "commit_store": "0x98650A8EB59f75D93563aB34FcF603b1A30e4CBF",
+          "off_ramp": "0xCb2266c2118b1f30D15CBeB3a885531ABaA1b556",
+          "commit_store": "0x5Ded92E2CF71a8fF7644a67850F061c38B31BfB4",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Base Sepolia": {
-          "off_ramp": "0x0a750ca77369e03613d7640548F4b2b1c695c3Bb",
-          "commit_store": "0x8fEBC74C26129C8d7E60288C6dCCc75eb494aA3C",
+          "off_ramp": "0x960c62A491C30d0a60fD74a59d35B9C02697AdaA",
+          "commit_store": "0x06963745B3839B998288D1a46a46Ec25991A3D5E",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Gnosis Chiado": {
-          "off_ramp": "0xCE2CE7F940B7c839384e5D7e079A6aE80e8AD6dB",
-          "commit_store": "0x1b9D78Ec1CEEC439F0b7eA6C428A1a607D9FA7e4",
+          "off_ramp": "0x7d6721c2E85560F0A233255D3d332AcF6f850d96",
+          "commit_store": "0xaC00661cAB5161d9B4746DFb7A028d97981aB2c5",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Polygon Amoy": {
-          "off_ramp": "0xD667b5706592D0b040C78fEe5EE17D243b7dCB41",
-          "commit_store": "0x96101BA5250EE9295c193693C1e08A55bC593664",
+          "off_ramp": "0x4cEeFa55AF23dFD27Cf926e8eFB1D1bCcD24526E",
+          "commit_store": "0xaD3943BdECbf4ae7d6E51aB0FD06bbC604bB7b95",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Sepolia Testnet": {
-          "off_ramp": "0x260AF9b83e0d2Bb6C9015fC9f0BfF8858A0CCE68",
-          "commit_store": "0x7a0bB92Bc8663abe6296d0162A9b41a2Cb2E0358",
+          "off_ramp": "0x2aF9B10A5972D0c36f4d8F85773052c104E319B2",
+          "commit_store": "0x82FCF55b9e9bAb3066c2863F12a02bBc2Ba33F2F",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "WeMix Testnet": {
-          "off_ramp": "0x9C08B7712af0344188aa5087D9e6aD0f47191037",
-          "commit_store": "0x4BE6DB0B884169a6A207fe5cad01eB4C025a13dB",
+          "off_ramp": "0x0FA15Bc42D4999d964CBf0161489Bd392DEE834e",
+          "commit_store": "0x37760F99a5b91884C9D89a06408f532aEbb0e674",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -647,59 +683,59 @@ Data = """
       "wrapped_native": "0x360ad4f9a9A8EFe9A8DCB5f461c4Cc1047E1Dcf9",
       "src_contracts": {
         "Avalanche Fuji": {
-          "on_ramp": "0x8Fb98b3837578aceEA32b454f3221FE18D7Ce903",
+          "on_ramp": "0xad6A94CFB51e7DE30FD21F417E4cBf70D3AdaD30",
           "deployed_at": 0
         },
         "BSC Testnet": {
-          "on_ramp": "0xC6683ac4a0F62803Bec89a5355B36495ddF2C38b",
+          "on_ramp": "0x28EC0a9C90360F55C2a9DaD5901b074C257904ca",
           "deployed_at": 0
         },
         "Gnosis Chiado": {
-          "on_ramp": "0x2331F6D614C9Fd613Ff59a1aB727f1EDf6c37A68",
+          "on_ramp": "0x9DF611536f124278Ce968c476BDb10A66E54ecfE",
           "deployed_at": 0
         },
         "Optimism Sepolia": {
-          "on_ramp": "0xA52cDAeb43803A80B3c0C2296f5cFe57e695BE11",
+          "on_ramp": "0x600f00aef9b8ED8EDBd7284B5F04a1932c3408aF",
           "deployed_at": 0
         },
         "Sepolia Testnet": {
-          "on_ramp": "0x35347A2fC1f2a4c5Eae03339040d0b83b09e6FDA",
+          "on_ramp": "0x719Aef2C63376AdeCD62D2b59D54682aFBde914a",
           "deployed_at": 0
         },
         "WeMix Testnet": {
-          "on_ramp": "0x26546096F64B5eF9A1DcDAe70Df6F4f8c2E10C61",
+          "on_ramp": "0x7D6c93E49E46cc983a677c283EAb27CbbC94e3C4",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Avalanche Fuji": {
-          "off_ramp": "0xa733ce82a84335b2E9D864312225B0F3D5d80600",
-          "commit_store": "0x09B0F93fC2111aE439e853884173AC5b2F809885",
+          "off_ramp": "0xAc56Df7F5fbde0DeeB1C0d397A150EDD5EE68625",
+          "commit_store": "0x8AF56D1c76B8c8CeE451a0a654D130e4050B993e",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "BSC Testnet": {
-          "off_ramp": "0x948dfaa4842fc23e0e362Fe8D4396AaE4E6DF7EA",
-          "commit_store": "0x7F4e739D40E58BBd59dAD388171d18e37B26326f",
+          "off_ramp": "0x40Ba47ea59D80DDd35E3a997AA520FBa0553dddc",
+          "commit_store": "0x8afe532517b39bA109d1A768E1Ad8b5C6485abF5",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Gnosis Chiado": {
-          "off_ramp": "0x17c542a28e08AEF5697251601C7b2B621d153D42",
-          "commit_store": "0x811250c20fAB9a1b7ca245453aC214ba637fBEB5",
+          "off_ramp": "0x7B968B2aDFd31765dAAD80d66c83F9D7006BFFd5",
+          "commit_store": "0xBc70551B5624BaF8cdCB84136198561C9cf5C176",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Optimism Sepolia": {
-          "off_ramp": "0xfFdE9E8c34A27BEBeaCcAcB7b3044A0A364455C9",
-          "commit_store": "0x74ED442ad211050e9C05Dc9A267E037E3d74A03B",
+          "off_ramp": "0xAA755Ef570986feEb6522377077e549e3013843E",
+          "commit_store": "0x5C7827EcE6a51AdaC36ef71aC01706deb1C7130d",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Sepolia Testnet": {
-          "off_ramp": "0xFb04129aD1EEDB741CC705ebC1978a7aB63e51f6",
-          "commit_store": "0x63f875240149d29136053C954Ca164a9BfA81F77",
+          "off_ramp": "0x7Ad494C173f5845c6B4028a06cDcC6d3108bc960",
+          "commit_store": "0x104A1c8b05D37fE732094595Fe696AFc7EAB8668",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "WeMix Testnet": {
-          "off_ramp": "0xdE8451E952Eb43350614839cCAA84f7C8701a09C",
-          "commit_store": "0xaCdaBa07ECad81dc634458b98673931DD9d3Bc14",
+          "off_ramp": "0xa85481273f8C112e96ED7476202F06D6131cf069",
+          "commit_store": "0x9FdF1D555e37dB09B0d151FEa53c134C88C4DeFd",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -719,122 +755,122 @@ Data = """
       "wrapped_native": "0x097D90c9d3E0B50Ca60e1ae45F6A81010f9FB534",
       "src_contracts": {
         "Arbitrum Sepolia": {
-          "on_ramp": "0xe4Dd3B16E09c016402585a8aDFdB4A18f772a07e",
+          "on_ramp": "0xBc09627e58989Ba8F1eDA775e486467d2A00944F",
           "deployed_at": 0
         },
         "Avalanche Fuji": {
-          "on_ramp": "0x0477cA0a35eE05D3f9f424d88bC0977ceCf339D4",
+          "on_ramp": "0x12492154714fBD28F28219f6fc4315d19de1025B",
           "deployed_at": 0
         },
         "BSC Testnet": {
-          "on_ramp": "0xD990f8aFA5BCB02f95eEd88ecB7C68f5998bD618",
+          "on_ramp": "0x7a75b3818412fe0028590feE8270ba9E3fd01DBe",
           "deployed_at": 0
         },
         "Base Sepolia": {
-          "on_ramp": "0x2B70a05320cB069e0fB55084D402343F832556E7",
+          "on_ramp": "0x8F35B097022135E0F46831f798a240Cc8c4b0B01",
           "deployed_at": 0
         },
         "Blast Sepolia": {
-          "on_ramp": "0xDB75E9D9ca7577CcBd7232741be954cf26194a66",
+          "on_ramp": "0x4ADA60556dA05FcF53a79359e37a3E13FebA22Bf",
           "deployed_at": 0
         },
         "Celo Alfajores": {
-          "on_ramp": "0x3C86d16F52C10B2ff6696a0e1b8E0BcfCC085948",
+          "on_ramp": "0x1163D1F7D75eEb1C4f4c6912d3cF9642027aFD30",
           "deployed_at": 0
         },
         "Gnosis Chiado": {
-          "on_ramp": "0x3E842E3A79A00AFdd03B52390B1caC6306Ea257E",
+          "on_ramp": "0x831A7DbE6af8601427A0ADa89b642d4b59007eED",
           "deployed_at": 0
         },
         "Metis Sepolia": {
-          "on_ramp": "0x1C4640914cd57c5f02a68048A0fbb0E12d904223",
+          "on_ramp": "0xabB5A4f99DFEb4a3912e8Acc0660A008c76dA8c3",
           "deployed_at": 0
         },
         "Mode Sepolia": {
-          "on_ramp": "0xc630fbD4D0F6AEB00aD0793FB827b54fBB78e981",
+          "on_ramp": "0x2Eb0842925fb7aA6045e951e98e8b4b3aFFaBB54",
           "deployed_at": 0
         },
         "Optimism Sepolia": {
-          "on_ramp": "0x69CaB5A0a08a12BaFD8f5B195989D709E396Ed4d",
+          "on_ramp": "0xACDfd7a98d853FA3914047Cd46e7f5D53BBC9FbB",
           "deployed_at": 0
         },
         "Polygon Amoy": {
-          "on_ramp": "0x9f656e0361Fb5Df2ac446102c8aB31855B591692",
+          "on_ramp": "0xf9765c80F6448e6d4d02BeF4a6b4152131A2F513",
           "deployed_at": 0
         },
         "WeMix Testnet": {
-          "on_ramp": "0xedFc22336Eb0B9B11Ff37C07777db27BCcDe3C65",
+          "on_ramp": "0xd72c3c132B76F5D232C37dF3bF8f04392D552e0F",
           "deployed_at": 0
         },
         "ZKSync Sepolia": {
-          "on_ramp": "0x1Acb3A885feA37bdA30AB99b99327b14391f500F",
+          "on_ramp": "0xA2865E4f36760f5fa5c8F958336120f2DF0d974b",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Arbitrum Sepolia": {
-          "off_ramp": "0xF18896AB20a09A29e64fdEbA99FDb8EC328f43b1",
-          "commit_store": "0x93Ff9Dd39Dc01eac1fc4d2c9211D95Ee458CAB94",
+          "off_ramp": "0xD2f5edfD4561d6E7599F6c6888Bd353cAFd0c55E",
+          "commit_store": "0x240420BC6bCDc067e668c7492D69fe06B3CF80cE",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Avalanche Fuji": {
-          "off_ramp": "0x000b26f604eAadC3D874a4404bde6D64a97d95ca",
-          "commit_store": "0x2dD9273F8208B8393350508131270A6574A69784",
+          "off_ramp": "0x1DEBa99dC8e2A77832461BD386d83D9FCb133137",
+          "commit_store": "0x139E06b6dBB1a0C41A1686C091795879c943765A",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "BSC Testnet": {
-          "off_ramp": "0xdE2d8E126e08d675fCD7fFa5a6CE49925f3Dc692",
-          "commit_store": "0x0050ac355a82caB31194507f94174297bf0655A7",
+          "off_ramp": "0x04305BD9D9CA6730517f79c3D9c6828BC2D25Ecb",
+          "commit_store": "0x32edD59840CD9e474A280cf1707439F2Bd5872d4",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Base Sepolia": {
-          "off_ramp": "0x31c0B81832B333419f0DfD36A69F502cF9094aed",
-          "commit_store": "0xDFcde9d698a2B32DB2537DC9B752Cadd1D846a52",
+          "off_ramp": "0x662738DC7DE4f7eC63d9f73Cdf9BeA5A58DdcC15",
+          "commit_store": "0x1e46bAC486Dd878cD57B62845530A52343e39693",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Blast Sepolia": {
-          "off_ramp": "0x4e897e5cF3aC307F0541B2151A88bCD781c153a3",
-          "commit_store": "0xB656652841F347178e193951C4663652aCe36B74",
+          "off_ramp": "0x049A424cF894709f044bc70177F8F6b792adc3F6",
+          "commit_store": "0x496fE96E440Fc683478a08Df92A1c5E23E412b1C",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Celo Alfajores": {
-          "off_ramp": "0xB435E0f73c18C5a12C324CA1d02F81F2C3e6e761",
-          "commit_store": "0xbc5d74957F171e75F92c8F0E1C317A25a56a416D",
+          "off_ramp": "0x4F146d34Be5E273e576ef158Bd7070eC22708D20",
+          "commit_store": "0xEeB665281c7ab51d25423898f730Ab078c69dd42",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Gnosis Chiado": {
-          "off_ramp": "0x7db0115A0b3AAb01d30bf81123c5DD7B0C41Add5",
-          "commit_store": "0x6640723Ea801178c4383FA016b9781e7ef1016EF",
+          "off_ramp": "0xB424365EEEEA58A36C7EC858f926f4e8275dDEb3",
+          "commit_store": "0xE95c2135e3330E953BB49068d32Fcba368Acd456",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Metis Sepolia": {
-          "off_ramp": "0x4DB693A93E9d5196ECD42EC56CDEAe99dFC652ED",
-          "commit_store": "0xBfACd78F1412B6f93Ac23409bf456aFec1ABd845",
+          "off_ramp": "0x46DE6201c258f5948135cd0262f91e48Cb8e3828",
+          "commit_store": "0x3A27Fd059A4eF0e96B0643283A44a56A8d6CF34A",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Mode Sepolia": {
-          "off_ramp": "0xbEfd8D65F6643De54F0b1268A3bf4618ff85dcB4",
-          "commit_store": "0x0C161D3470b45Cc677661654C30ce4AdE6aCD288",
+          "off_ramp": "0x052E52fdd48719A6084366eA184FC44cb8C25DC2",
+          "commit_store": "0xBBb9baA314eB023E3F9291Aaf4107B6708341B50",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Optimism Sepolia": {
-          "off_ramp": "0xD50590D4438411EDe47029b0FD7901A7145E5Df6",
-          "commit_store": "0xe85EEE9Fd434A7b8a586Ee086E828abF41839479",
+          "off_ramp": "0xbfa6f6AAE31acB3A285e80026d6475C1a50d1d0F",
+          "commit_store": "0xB5FbA97Dc61ec68771a92a15360d9C32c9d054E7",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Polygon Amoy": {
-          "off_ramp": "0x5032cbC0C4aEeD25bb6E45D8B3fAF05DB0688C5d",
-          "commit_store": "0xe6201C9996Cc7B6E828E10CbE937E693d577D318",
+          "off_ramp": "0xC3e550B6aaFA5539df8bbCc5B0991e587f438e75",
+          "commit_store": "0xd57866D97ca26dfaE34088a3EeE4657BAFaac5f9",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "WeMix Testnet": {
-          "off_ramp": "0x46b639a3C1a4CBfD326b94a2dB7415c27157282f",
-          "commit_store": "0x7b74554678816b045c1e7409327E086bD436aa46",
+          "off_ramp": "0x445F41C6aa7e910021786e860d7cfe3E7fcC6640",
+          "commit_store": "0x307dDE3c696E399b5837456FbCe03b1Ad76D46E3",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "ZKSync Sepolia": {
-          "off_ramp": "0xBaABd4166C892a1081a26535875A8fA3f22937b2",
-          "commit_store": "0xfda2e83F4D3f42B7629134ecD6E4b29FB8A7A07B",
+          "off_ramp": "0x9f5dC467A5c97068A1c2987486B8b768275627eD",
+          "commit_store": "0x6e4601DA99a046e4bde60d051568E3E1F35E3097",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -854,68 +890,68 @@ Data = """
       "wrapped_native": "0xbE3686643c05f00eC46e73da594c78098F7a9Ae7",
       "src_contracts": {
         "Arbitrum Sepolia": {
-          "on_ramp": "0xA9DE3F7A617D67bC50c56baaCb9E0373C15EbfC6",
+          "on_ramp": "0xa5Be8C619F61505548992D9820c5c485b030C7B0",
           "deployed_at": 0
         },
         "Avalanche Fuji": {
-          "on_ramp": "0xC4aC84da458ba8e40210D2dF94C76E9a41f70069",
+          "on_ramp": "0x7802B6804bbE7486229ac6D3519f0057c50b40a9",
           "deployed_at": 0
         },
         "BSC Testnet": {
-          "on_ramp": "0x5AD6eed6Be0ffaDCA4105050CF0E584D87E0c2F1",
+          "on_ramp": "0xd25B8c70CB43022Bdc3aC417E2Cf5159294d95A1",
           "deployed_at": 0
         },
         "Kroma Sepolia": {
-          "on_ramp": "0x428C4dc89b6Bf908B82d77C9CBceA786ea8cc7D0",
+          "on_ramp": "0x1De2Ca07eEee7F524Fe5edA6C8FFFb79F67b05E9",
           "deployed_at": 0
         },
         "Optimism Sepolia": {
-          "on_ramp": "0x1961a7De751451F410391c251D4D4F98D71B767D",
+          "on_ramp": "0xB37607C6BD4562F32967dE87D14663D59e3f655d",
           "deployed_at": 0
         },
         "Polygon Amoy": {
-          "on_ramp": "0xd55148e841e76265B484d399eC71b7076ecB1216",
+          "on_ramp": "0x0c972752F9aC3255cE45b440f9bBC6500676c4e6",
           "deployed_at": 0
         },
         "Sepolia Testnet": {
-          "on_ramp": "0x4d57C6d8037C65fa66D6231844785a428310a735",
+          "on_ramp": "0x1CD55c65f85681Dfae47c62e6D93340D25006BbB",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Arbitrum Sepolia": {
-          "off_ramp": "0xeB1dFaB2464Bf0574D43e764E0c758f92e7ecAFb",
-          "commit_store": "0xcEaCa2B7890065c485f3E58657358a185Ad33791",
+          "off_ramp": "0xB5492C8A71130B486fAD1091Db683584767A3957",
+          "commit_store": "0x1e151ED27E2F48EcFBd5b4374d0fc4869e07c397",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Avalanche Fuji": {
-          "off_ramp": "0x98e811Df9D2512f1aaf58D534607F583D6c54A4F",
-          "commit_store": "0x8e538351F6E5B2daF3c90C565C3738bca69a2716",
+          "off_ramp": "0x60536c757c2BBf72cC68A1933F7e336d03Bb68fe",
+          "commit_store": "0x2fF725556A04b47eB40BbA11d9F51e8fbbee9F07",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "BSC Testnet": {
-          "off_ramp": "0xB0e7f0fCcD3c961C473E7c44D939C1cDb4Cec1cB",
-          "commit_store": "0x4B56D8d53f1A6e0117B09700067De99581aA5542",
+          "off_ramp": "0xb858077FbE1E55cD7a9092Eb6d5403e068c14EAf",
+          "commit_store": "0x0EF13C7c95C27A9EA477363a26a09Cff44ba38F9",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Kroma Sepolia": {
-          "off_ramp": "0xD685D2d224dd6D0Db2D56497db6270D77D9a7966",
-          "commit_store": "0x7e062D6880779a0347e7742058C1b1Ee4AA0B137",
+          "off_ramp": "0x78d8154e1216F4791086bFa078Aaf07dcD2bD3C6",
+          "commit_store": "0xe67AAfbE6025e730Cf47a414BEFf2106FF231dB1",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Optimism Sepolia": {
-          "off_ramp": "0xA5f97Bc69Bf06e7C37B93265c5457420A92c5F4b",
-          "commit_store": "0xd48b9213583074f518D8f4336FDf35370D450132",
+          "off_ramp": "0x995Fc17FC12b67f75D3cBf3bC71BD9af65671E78",
+          "commit_store": "0xD0825e3D8e61b67a06A93426749d38bCF73Ddb02",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Polygon Amoy": {
-          "off_ramp": "0x6c8f5999B06FDE17B11E4e3C1062b761766F960f",
-          "commit_store": "0x957c3c2056192e58A8485eF31165fC490d474239",
+          "off_ramp": "0xd7b5B4F8FF7a87cC92f7B3058365862859d9E057",
+          "commit_store": "0xa8f2bb4e831caA5E2794AaD014030E378208d4Bc",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Sepolia Testnet": {
-          "off_ramp": "0x8AB103843ED9D28D2C5DAf5FdB9c3e1CE2B6c876",
-          "commit_store": "0x7d5297c5506ee2A7Ef121Da9bE02b6a6AD30b392",
+          "off_ramp": "0xa7E2F97Be7798327A49CACD022f33c0E7EfD4897",
+          "commit_store": "0x6fe69eE4eC9FD768193a40129A3Ba3dF140b2208",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -923,20 +959,26 @@ Data = """
     "ZKSync Sepolia": {
       "is_native_fee_token": true,
       "fee_token": "0x4317b2eCD41851173175005783322D29E9bAee9E",
+      "bridge_tokens": [
+        "0xFf6d0c1518A8104611f482eb2801CaF4f13c9dEb"
+      ],
+      "bridge_tokens_pools": [
+        "0xA16cfA090aA6888AE8Beb92F8bfD316DD05767C9"
+      ],
       "arm": "0x926b4f90610Aa448f27c8e0Fd0afa4A17B7305F9",
       "router": "0xA1fdA8aa9A8C4b945C45aD30647b01f07D7A0B16",
       "price_registry": "0x648B6BB09bE1C5766C8AC578B9B4aC8497eA671F",
       "wrapped_native": "0x4317b2eCD41851173175005783322D29E9bAee9E",
       "src_contracts": {
         "Sepolia Testnet": {
-          "on_ramp": "0x79a9a5e9e318e8e109776569574814bbf935125a",
+          "on_ramp": "0xC38536521fde8556351aB7C4D3ea23b64AFbBbab",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Sepolia Testnet": {
-          "off_ramp": "0x18FF69051479796175852578725Fc74F58E963F8",
-          "commit_store": "0xF694b4FD7889480dca3CD41244e8e3395a9EFBa0",
+          "off_ramp": "0x19Ea9A42cd3682928aF19990dDb3904250D00a1D",
+          "commit_store": "0x20BF9037927bFadaF028D43ae07d1afccfB8fa85",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -976,7 +1018,7 @@ NetworkPairs = [
   'SEPOLIA,ARBITRUM_SEPOLIA',
   'SEPOLIA,BASE_SEPOLIA',
   'SEPOLIA,BLAST_SEPOLIA',
-  'SEPOLIA,MODE_SEPOLIA',
+#  'SEPOLIA,MODE_SEPOLIA',
   'SEPOLIA,OPTIMISM_SEPOLIA',
   'SEPOLIA,POLYGON_AMOY',
   'SEPOLIA,WEMIX_TESTNET',
@@ -1002,7 +1044,7 @@ NetworkPairs = [
   'ARBITRUM_SEPOLIA,WEMIX_TESTNET',
   'ARBITRUM_SEPOLIA,GNOSIS_CHIADO',
 
-  'BASE_SEPOLIA,MODE_SEPOLIA',
+#  'BASE_SEPOLIA,MODE_SEPOLIA',
   'BASE_SEPOLIA,OPTIMISM_SEPOLIA',
   'BASE_SEPOLIA,GNOSIS_CHIADO',
 

--- a/integration-tests/ccip-tests/testconfig/tomls/prod-testnet/soak-release-testing_token_transfer_with_native_feetoken.toml
+++ b/integration-tests/ccip-tests/testconfig/tomls/prod-testnet/soak-release-testing_token_transfer_with_native_feetoken.toml
@@ -26,59 +26,68 @@ Data = """
       "wrapped_native": "0xE591bf0A0CF924A0674d7792db046B23CEbF5f34",
       "src_contracts": {
         "Avalanche Fuji": {
-          "on_ramp": "0x1Cb56374296ED19E86F68fA437ee679FD7798DaA",
+          "on_ramp": "0x20C8c9F13C6AA402F2545AD15fB7a9CdE9108618",
           "deployed_at": 0
         },
         "Base Sepolia": {
-          "on_ramp": "0x7854E73C73e7F9bb5b0D5B4861E997f4C6E8dcC6",
+          "on_ramp": "0xF1623862e4c9f9Fba1Ac0181C4fF53B4f958F065",
           "deployed_at": 0
         },
         "Gnosis Chiado": {
-          "on_ramp": "0x973CbE752258D32AE82b60CD1CB656Eebb588dF0",
+          "on_ramp": "0xEfe02eB139D2A82e38184d28E3b65bb176F26ebD",
+          "deployed_at": 0
+        },
+        "Metis Sepolia": {
+          "on_ramp": "0x46a79a6a4B07FD3FC14ea8299A99FE29576776E2",
           "deployed_at": 0
         },
         "Optimism Sepolia": {
-          "on_ramp": "0x701Fe16916dd21EFE2f535CA59611D818B017877",
+          "on_ramp": "0x0B0c08Bb2fA2EbDe25817009ee39eA1ad9bCaC58",
           "deployed_at": 0
         },
         "Sepolia Testnet": {
-          "on_ramp": "0x4205E1Ca0202A248A5D42F5975A8FE56F3E302e9",
+          "on_ramp": "0x64d78F20aD987c7D52FdCB8FB0777bD00de53210",
           "deployed_at": 0
         },
         "WeMix Testnet": {
-          "on_ramp": "0xBD4106fBE4699FE212A34Cc21b10BFf22b02d959",
+          "on_ramp": "0x2F3Daf77A663603826c7750E956b6555DE6f8250",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Avalanche Fuji": {
-          "off_ramp": "0xcab0EF91Bee323d1A617c0a027eE753aFd6997E4",
-          "commit_store": "0x0d90b9b96cBFa0D01635ce12982ccE1b70827c7a",
+          "off_ramp": "0x7245a5947E2F32B66aF74F4dAF91718ea19afaDf",
+          "commit_store": "0x490AC77BbB26f4FFf876Ded07bCAE6DBe685be98",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Base Sepolia": {
-          "off_ramp": "0xc1982985720B959E66c19b64F783361Eb9B60F26",
-          "commit_store": "0x28F66bB336f6db713d6ad2a3bd1B7a531282A159",
+          "off_ramp": "0xF2aB55Ed448A6fAD75013900568B6a927f52e5e0",
+          "commit_store": "0x833E5995A7422120f445f9B8dD1b9BD1037c68E5",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Gnosis Chiado": {
-          "off_ramp": "0x935C26F9a9122E5F9a27f2d3803e74c75B94f5a3",
-          "commit_store": "0xEdb963Ec5c2E5AbdFdCF137eF44A445a7fa4787A",
+          "off_ramp": "0xc1Cb31493fB2386aDC1Ea01F935F2bd8a8dCA388",
+          "commit_store": "0xe21896657A65c8959F16E1c3Ee5713E85d9EA020",
+          "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
+        },
+        "Metis Sepolia": {
+          "off_ramp": "0xc47143147Fd62A09618C695c7C03714aCe8db1Cf",
+          "commit_store": "0x2F42e7B22eE5885158916624Ff00608f4C82313D",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Optimism Sepolia": {
-          "off_ramp": "0xfD404A89e1d195F0c65be1A9042C77745197659e",
-          "commit_store": "0x84B7B012c95f8A152B44Ab3e952f2dEE424fA8e1",
+          "off_ramp": "0x4a7E91EF68758aaC66AeD656267bbCD0f9b6c019",
+          "commit_store": "0xb0A09D6A15FF7A0142DF3F62b2C4D1e11D763Ed0",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Sepolia Testnet": {
-          "off_ramp": "0x1c71f141b4630EBE52d6aF4894812960abE207eB",
-          "commit_store": "0xaB0c8Ba51E7Fa3E5693a4Fbb39473520FD85d173",
+          "off_ramp": "0xBed6e9131916d724418C8a6FE810F727302a5c00",
+          "commit_store": "0xdDb61B6bDa1B46d88f556440fABFe219F6da4F3a",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "WeMix Testnet": {
-          "off_ramp": "0x262e16C8D42aa07bE13e58F81e7D9F62F6DE2830",
-          "commit_store": "0xc132eFAf929299E5ee704Fa6D9796CFa23Bb8b2C",
+          "off_ramp": "0x11d486E92d291704D1E25cDbAeee687237247826",
+          "commit_store": "0xece9353095aC79Db9DD5bf2022690Fa6BffeBCAc",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -98,77 +107,77 @@ Data = """
       "wrapped_native": "0xd00ae08403B9bbb9124bB305C09058E32C39A48c",
       "src_contracts": {
         "Arbitrum Sepolia": {
-          "on_ramp": "0x8bB16BEDbFd62D1f905ACe8DBBF2954c8EEB4f66",
+          "on_ramp": "0xa9946BA30DAeC98745755e4410d6e8E894Edc53B",
           "deployed_at": 0
         },
         "BSC Testnet": {
-          "on_ramp": "0xF25ECF1Aad9B2E43EDc2960cF66f325783245535",
+          "on_ramp": "0x906BC7D10947A94ba0252e8C2E34868A466c03ED",
           "deployed_at": 0
         },
         "Base Sepolia": {
-          "on_ramp": "0x1A674645f3EB4147543FCA7d40C5719cbd997362",
+          "on_ramp": "0x0aEc1AC9F6D0c21332d7a66dDF1Fbcb32cF3B0B3",
           "deployed_at": 0
         },
         "Gnosis Chiado": {
-          "on_ramp": "0x1532e5b204ee2b2244170c78E743CB9c168F4DF9",
+          "on_ramp": "0x3dda45E731EC1db18B95651d1AF1868aa878468D",
           "deployed_at": 0
         },
         "Optimism Sepolia": {
-          "on_ramp": "0xC334DE5b020e056d0fE766dE46e8d9f306Ffa1E2",
+          "on_ramp": "0x2a9EFdc9F93D9b822129038EFCa4B63Adf3f7FB5",
           "deployed_at": 0
         },
         "Polygon Amoy": {
-          "on_ramp": "0x610F76A35E17DA4542518D85FfEa12645eF111Fc",
+          "on_ramp": "0xA82b9ACAcFA6FaB1FD721e7a748A30E3001351F9",
           "deployed_at": 0
         },
         "Sepolia Testnet": {
-          "on_ramp": "0x5724B4Cc39a9690135F7273b44Dfd3BA6c0c69aD",
+          "on_ramp": "0x75b9a75Ee1fFef6BE7c4F842a041De7c6153CF4E",
           "deployed_at": 0
         },
         "WeMix Testnet": {
-          "on_ramp": "0x677B5ab5C8522d929166c064d5700F147b15fa33",
+          "on_ramp": "0x1ff99E67986E83bb5BA34143BaA2735853e5738c",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Arbitrum Sepolia": {
-          "off_ramp": "0x90A74072e7B0c2d59e13aB4d8f93c8198c413194",
-          "commit_store": "0xf3458CFd2fdf4a6CF0Ce296d520DD21eB194828b",
+          "off_ramp": "0xd88CBA0612f2Ce611BF6d073A94C8FD7E70B4fBd",
+          "commit_store": "0x9b8279E352bC167F714eef96A4C436bE996643cE",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "BSC Testnet": {
-          "off_ramp": "0x10b28009E5D776F1f5AAA73941CE8953B8f42d26",
-          "commit_store": "0xacDD582F271eCF22FAd6764cCDe1c4a534b732A8",
+          "off_ramp": "0x9c40A73F5C7454BB7C178AFa56Ee30bFB2DCf7E6",
+          "commit_store": "0xE5611af1d63340b711B0468a976651Fb79B17870",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Base Sepolia": {
-          "off_ramp": "0xdBdE8510226d1E060A3bf982b67705C67f5697e2",
-          "commit_store": "0x8Ee73BC9492b4182D289E5C1e66e40CD876CC00F",
+          "off_ramp": "0xf8de9d5924CFD28e31a53B63B4903436D9818d69",
+          "commit_store": "0xDD7CfECE1bb4e8aC2E8b8281CFE1D44247119471",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Gnosis Chiado": {
-          "off_ramp": "0x56dF55aF5F0A4689f3364230587a68eD6A314fAd",
-          "commit_store": "0xabA7ff98094c4cc7A075812EefF2CD21f6400235",
+          "off_ramp": "0x3F5035039C23cDAF032C64c084Dc70F811E62ddD",
+          "commit_store": "0xf5B0245c7B9e15f0cB0B85FF2B6799a45D61CbaA",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Optimism Sepolia": {
-          "off_ramp": "0x3d7CbC95DCC33257F14D6Eb780c88Bd56C6335BB",
-          "commit_store": "0x1fcDC02edDfb405f378ba53cF9E6104feBcB7542",
+          "off_ramp": "0x1DF9D94C6916918C935E60d2Cb4Ed265Bf778005",
+          "commit_store": "0xE7eeBE5882609d28C015d0A89DE1ba4f506F4a03",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Polygon Amoy": {
-          "off_ramp": "0x3e33290B90fD0FF30a3FA138934DF028E4eCA348",
-          "commit_store": "0xCFe3556Aa42d40be09BD23aa80448a19443BE5B1",
+          "off_ramp": "0xbeD7F478Ef5627FB2B891fDA29Ca0131f6796D9D",
+          "commit_store": "0x27a319f58c01380056c86938798aCEAA1AC529e2",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Sepolia Testnet": {
-          "off_ramp": "0x9e5e4324F8608D54A50a317832d456a392E4F8C2",
-          "commit_store": "0x92A51eD3F041B39EbD1e464C1f7cb1e8f8A8c63f",
+          "off_ramp": "0x01e3D835b4C4697D7F81B9d7Abc89A6E478E4a2f",
+          "commit_store": "0x4EC313c1Eb620432f42FB5f4Df27f8A566523c1C",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "WeMix Testnet": {
-          "off_ramp": "0xD0D338318bC6837b091FC7AB5F2a94B7783507d5",
-          "commit_store": "0xd9D479208235c7355848ff4aF26eB5aacfDC30c6",
+          "off_ramp": "0x15CcAbf0e3484D4872e25b883163D8cB724d4832",
+          "commit_store": "0x859f3477B7b4ECc19aDD8cCb19740932F21bD76b",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -188,59 +197,68 @@ Data = """
       "wrapped_native": "0xae13d989daC2f0dEbFf460aC112a837C89BAa7cd",
       "src_contracts": {
         "Avalanche Fuji": {
-          "on_ramp": "0xa2515683E99F50ADbE177519A46bb20FfdBaA5de",
+          "on_ramp": "0x2A6f8Ed2e7b222163ef6EcC2327171B479399ab2",
           "deployed_at": 0
         },
         "Base Sepolia": {
-          "on_ramp": "0x3E807220Ca84b997c0d1928162227b46C618e0c5",
+          "on_ramp": "0x97856Bf888F6eEDBBd322B28133BCcF9CA9038f6",
+          "deployed_at": 0
+        },
+        "Blast Sepolia": {
+          "on_ramp": "0xd0049BfFc8e2689Df9236FfA393Ccbf7eae4FbbC",
           "deployed_at": 0
         },
         "Gnosis Chiado": {
-          "on_ramp": "0x8735f991d41eA9cA9D2CC75cD201e4B7C866E63e",
+          "on_ramp": "0x98dEa9e498F2A7aF6c74C915c88A17FbA09b73C2",
           "deployed_at": 0
         },
         "Polygon Amoy": {
-          "on_ramp": "0xf37CcbfC04adc1B56a46B36F811D52C744a1AF78",
+          "on_ramp": "0x363EB789fE31F08547a847D8C38d9b55C7Cf1903",
           "deployed_at": 0
         },
         "Sepolia Testnet": {
-          "on_ramp": "0xB1DE44B04C00eaFe9915a3C07a0CaeA4410537dF",
+          "on_ramp": "0xC1C6438D60AbE9bF4b1F10460184CE9bD312e328",
           "deployed_at": 0
         },
         "WeMix Testnet": {
-          "on_ramp": "0x89268Afc1BEA0782a27ba84124E3F42b196af927",
+          "on_ramp": "0xbc85704EDb79ea84E9D3C18965F7f6A16B0a0440",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Avalanche Fuji": {
-          "off_ramp": "0x6e6fFCb6B4BED91ff0CC8C2e57EC029dA7DB80C2",
-          "commit_store": "0x38Bc38Bd824b6eE87571f9D3CFbe6D6E28E3Dc62",
+          "off_ramp": "0x95b66acfaaDF122f4EccE52C0aD4Fd997DD1150C",
+          "commit_store": "0x3af04b1c1e79A6B8A4577Bb47EC33eD2E66AeB47",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Base Sepolia": {
-          "off_ramp": "0x2C61FD7E93Dc79422861282145c59B56dFbc3a8c",
-          "commit_store": "0x42fAe5B3605804CF6d08632d7A25864e24F792Ae",
+          "off_ramp": "0x0a5147e1Ac38C79c77031194ef64C8B5353F6EE9",
+          "commit_store": "0x103864D60b33a479EA7D0e23a37e0ce07198f0A9",
+          "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
+        },
+        "Blast Sepolia": {
+          "off_ramp": "0xe1e8473218acCB82FBc24Ccd3C5D2dF166cd04f3",
+          "commit_store": "0x020B047A5Ca88fDB1ad3bAD9A082760fC7F770b6",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Gnosis Chiado": {
-          "off_ramp": "0x71a44a60832B0F8B63232C9516e7E6aEc3A373Dc",
-          "commit_store": "0xAC24299a91b72d1Cb5B31147e3CF54964D896974",
+          "off_ramp": "0x1F7FEBCBb10420E039C333A60A444c1a442d826C",
+          "commit_store": "0x23Ae763a64D39d6038431a64Bbc4A670C89d82b9",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Polygon Amoy": {
-          "off_ramp": "0x63440C7747d37bc6154b5538AE32b54FE0965AfA",
-          "commit_store": "0xAD22fA198CECfC534927aE1D480c460d5bB3460F",
+          "off_ramp": "0xAAe325adbc9C5a28e4e94Fef170D55de2CA9aA01",
+          "commit_store": "0xD173Df3A1b23ec42eA5C4669b9c956Bef230efd1",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Sepolia Testnet": {
-          "off_ramp": "0xf1c128Fe52Ea78CcAAB407509292E61ce38C1523",
-          "commit_store": "0x59dFD870dC4bd76A7B879A4f705Fdcd2595f85f9",
+          "off_ramp": "0xB513523aee87f838e78b32d2Bacaaf2e94D9f0f9",
+          "commit_store": "0x21A49164890576504C1f1c4DC9442c42C98771D7",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "WeMix Testnet": {
-          "off_ramp": "0xfd9B19c3725da5B517aA705B848ff3f21F98280e",
-          "commit_store": "0x3c1F1412563188aBc8FE3fd53E8F1Cb601CaB4f9",
+          "off_ramp": "0xc985571900DCa62387f93F882AB550472531f5DB",
+          "commit_store": "0xac5DACfAb1a512E33c49EFE42502863FC1a4BAB3",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -260,68 +278,68 @@ Data = """
       "wrapped_native": "0x4200000000000000000000000000000000000006",
       "src_contracts": {
         "Arbitrum Sepolia": {
-          "on_ramp": "0x58622a80c6DdDc072F2b527a99BE1D0934eb2b50",
+          "on_ramp": "0xb52eF669d3fCeBee1f31418Facc02a16A6F6B0e5",
           "deployed_at": 0
         },
         "Avalanche Fuji": {
-          "on_ramp": "0xAbA09a1b7b9f13E05A6241292a66793Ec7d43357",
+          "on_ramp": "0x212e8Fd9cCC330ab54E8141FA7d33967eF1eDafF",
           "deployed_at": 0
         },
         "BSC Testnet": {
-          "on_ramp": "0xD806966beAB5A3C75E5B90CDA4a6922C6A9F0c9d",
+          "on_ramp": "0xd54B44811AE99a18Cb95B4704ba04a65C0163751",
           "deployed_at": 0
         },
         "Gnosis Chiado": {
-          "on_ramp": "0x2Eff2d1BF5C557d6289D208a7a43608f5E3FeCc2",
+          "on_ramp": "0xdd0Ee1F20E93a93634AAcE56105E19423881Df56",
           "deployed_at": 0
         },
         "Mode Sepolia": {
-          "on_ramp": "0x3d0115386C01436870a2c47e6297962284E70BA6",
+          "on_ramp": "0xc59689dFDEF9D953cEFbb58912b304bb38408476",
           "deployed_at": 0
         },
         "Optimism Sepolia": {
-          "on_ramp": "0x3b39Cd9599137f892Ad57A4f54158198D445D147",
+          "on_ramp": "0x2945D35F428CE564F5455AD0AF28BDFCa67e76Ab",
           "deployed_at": 0
         },
         "Sepolia Testnet": {
-          "on_ramp": "0x6486906bB2d85A6c0cCEf2A2831C11A2059ebfea",
+          "on_ramp": "0x29A1F4ecE9246F0042A9062FB89803fA8B1830cB",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Arbitrum Sepolia": {
-          "off_ramp": "0xd364C06ac99a82a00d3eFF9F2F78E4Abe4b9baAA",
-          "commit_store": "0xdE8d0f47a71eA3fDFBD3162271652f2847939097",
+          "off_ramp": "0x814E735c5DD19240c85E2513DD926Bc3a39f7140",
+          "commit_store": "0xFc24B204bfA5C65eD8e2Fc02fDe4FeCb62eA8Ac5",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Avalanche Fuji": {
-          "off_ramp": "0xAd91214efFee446500940c764DF77AF18427294F",
-          "commit_store": "0x1242b6c5e0e349b8d4BCf0938f961C4B4f7EA3Fa",
+          "off_ramp": "0x3Ab3a3d35cAC95FfcFCcc127eF01eA8D87b0A64e",
+          "commit_store": "0x51313B8C068B5227fa7364E6eCB1382Fb751976F",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "BSC Testnet": {
-          "off_ramp": "0xd5E9508921434e8758f4540D55c1c066b7cc1598",
-          "commit_store": "0x1a86b29364D1B3fA3386329A361aA98A104b2742",
+          "off_ramp": "0x827CF69409307Cd4c979e652894C297ad5124ab7",
+          "commit_store": "0x547eBe6077305c3fdF8dA66c66cc14b0779CE00C",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Gnosis Chiado": {
-          "off_ramp": "0x9Bb7e398ef9Acfe9cA584C39B1E233Cba62BB9f7",
-          "commit_store": "0x1F4B82cDebaC5e3a0Dd53183D47e51808B4a64cB",
+          "off_ramp": "0x8bB08Bc19771C69E739a2078894523b3DC05a05e",
+          "commit_store": "0xf163Da63bDB8b9C355d41C755E03125988650109",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Mode Sepolia": {
-          "off_ramp": "0xB26647A23e8b4284375e5C74b77c9557aE709D03",
-          "commit_store": "0x4b4fEB401d3E613e1D6242E155C83A80BF9ac2C9",
+          "off_ramp": "0x11E16c71D76E43acbcb496A70966380d905B1E32",
+          "commit_store": "0xEe19f039FaE3EF0F94971f0B7B187223D952ac13",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Optimism Sepolia": {
-          "off_ramp": "0x86a3910908eCaAA31Fcd9F0fC8841D8E98f1511d",
-          "commit_store": "0xE99a87C9b5ed4D2b6060195DEea5106ffF655736",
+          "off_ramp": "0x8718d1cc138421Dbc1B489CB7884FF68DE7ad867",
+          "commit_store": "0x3291D453c880E5b59EEd04E600c85268Cd378b7f",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Sepolia Testnet": {
-          "off_ramp": "0x189F61D9B886Dd2975D5Abc893c8Cf5f5effda71",
-          "commit_store": "0xEE7e27346DCD1e711348D0F7f7ECB53a9a3a08a7",
+          "off_ramp": "0x0ecA23Ef70B828fEDd0A84d2692cB0527B52396A",
+          "commit_store": "0xA7F84Ec616F8e9Fa593339944E76bda90A9737fE",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -340,15 +358,24 @@ Data = """
       "price_registry": "0xc8acE9dF450FaD007755C6C9AB4f0e9c8626E29C",
       "wrapped_native": "0x4200000000000000000000000000000000000023",
       "src_contracts": {
+        "BSC Testnet": {
+          "on_ramp": "0x6eA6f63b689b5597A0C06a5Eb8DcDFD86383857A",
+          "deployed_at": 0
+        },
         "Sepolia Testnet": {
-          "on_ramp": "0x85Ef19FC4C63c70744995DC38CAAEC185E0c619f",
+          "on_ramp": "0x154aDEF773a848da8229D81De73a7b0844400ebd",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
+        "BSC Testnet": {
+          "off_ramp": "0xd9dE4aCD27E814bfe70CA33d2A4d079e740626Bd",
+          "commit_store": "0xe8fF7e22c54f76F453d6072A9d3a12B1D9AbA137",
+          "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
+        },
         "Sepolia Testnet": {
-          "off_ramp": "0x92cD24C278D34C726f377703E50875d8f9535dC2",
-          "commit_store": "0xcE1b4D50CeD56850182Bd58Ace91171cB249B873",
+          "off_ramp": "0x46DD4e3e2b8a18409646F1C15bf3799a481e67f6",
+          "commit_store": "0x8250f9E992dda66791dd8b5d356B867ae53382cF",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -368,14 +395,14 @@ Data = """
       "wrapped_native": "0x99604d0e2EfE7ABFb58BdE565b5330Bb46Ab3Dca",
       "src_contracts": {
         "Sepolia Testnet": {
-          "on_ramp": "0x16a020c4bbdE363FaB8481262D30516AdbcfcFc8",
+          "on_ramp": "0x68A4f57A499563192C606a898BAf503A43fcDB4D",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Sepolia Testnet": {
-          "off_ramp": "0xa1b97F92D806BA040daf419AFC2765DC723683a4",
-          "commit_store": "0xcd92C0599Ac515e7588865cC45Eee21A74816aFc",
+          "off_ramp": "0xF6dB68333D14f6a0c1123cc420ea60980aEDA0Eb",
+          "commit_store": "0x8f9B63c40891CdF7d1C795625d4260a29bE2bBa0",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -395,68 +422,68 @@ Data = """
       "wrapped_native": "0x18c8a7ec7897177E4529065a7E7B0878358B3BfF",
       "src_contracts": {
         "Arbitrum Sepolia": {
-          "on_ramp": "0x473b49fb592B54a4BfCD55d40E048431982879C9",
+          "on_ramp": "0x94967Ea06C6543Aaba5B90C52B655003ef82e521",
           "deployed_at": 0
         },
         "Avalanche Fuji": {
-          "on_ramp": "0x610F76A35E17DA4542518D85FfEa12645eF111Fc",
+          "on_ramp": "0x4f3576585e7fCCE5Fc502Bcf3CAdaD22E1194834",
           "deployed_at": 0
         },
         "BSC Testnet": {
-          "on_ramp": "0xE48E6AA1fc7D0411acEA95F8C6CaD972A37721D4",
+          "on_ramp": "0xB2642B54580140C375c9024e273C575a5f53d02d",
           "deployed_at": 0
         },
         "Base Sepolia": {
-          "on_ramp": "0x41b4A51cAfb699D9504E89d19D71F92E886028a8",
+          "on_ramp": "0x0E9504907be794620229C196F82CB062A66B7480",
           "deployed_at": 0
         },
         "Optimism Sepolia": {
-          "on_ramp": "0xAae733212981e06D9C978Eb5148F8af03F54b6EF",
+          "on_ramp": "0xeb86B5b6f5C66eCb58e4Cf98E607b238126505DC",
           "deployed_at": 0
         },
         "Polygon Amoy": {
-          "on_ramp": "0x01800fCDd892e37f7829937271840A6F041bE62E",
+          "on_ramp": "0xd86F5DF82A2500137Ddeef963028d60E3b5A354D",
           "deployed_at": 0
         },
         "Sepolia Testnet": {
-          "on_ramp": "0x4ac7FBEc2A7298AbDf0E0F4fDC45015836C4bAFe",
+          "on_ramp": "0x03691D63C687D09368360e957AFB2F7B4d1651d4",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Arbitrum Sepolia": {
-          "off_ramp": "0x9aA82DBB53bf02096B771D40e9432A323a78fB26",
-          "commit_store": "0x5CdbA91aBC0cD81FC56bc10Ad1835C9E5fB38e5F",
+          "off_ramp": "0x3633Cce99186217d4C7ed64FD455d218b8Cd5D4c",
+          "commit_store": "0x6e096286548451828c97F1B3E49C402a4934F39a",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Avalanche Fuji": {
-          "off_ramp": "0x3e33290B90fD0FF30a3FA138934DF028E4eCA348",
-          "commit_store": "0xCFe3556Aa42d40be09BD23aa80448a19443BE5B1",
+          "off_ramp": "0x5E4DB2A3c965B9B2A850a75697Bb6a00b4e35ac5",
+          "commit_store": "0x2489c5a802fE63943f7E3185A0362327B55DDF67",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "BSC Testnet": {
-          "off_ramp": "0xbc4AD54e91b213D4279af92c0C5518c0b96cf62D",
-          "commit_store": "0xff84e8Dd4Fd17eaBb23b6AeA6e1981830e54389C",
+          "off_ramp": "0x2BA72Ba392C08750328635E36757A2c29a9165CA",
+          "commit_store": "0x08ebd7Cf4ABDC819c74cB45CbA4e291728538D7C",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Base Sepolia": {
-          "off_ramp": "0x4117953A5ceeF12f5B8C1E973b470ab83a8CebA6",
-          "commit_store": "0x94ad41296186E81f31e1ed0B1BcF5fa9e1721C27",
+          "off_ramp": "0x269D28B25Ee081ae5340e2BFE99850E92F1cd522",
+          "commit_store": "0x8dC9329BD221C89c4989d98c38Ff2Cc3dF92d14b",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Optimism Sepolia": {
-          "off_ramp": "0x33d2898F8fb7714FD1661791766f40754982a343",
-          "commit_store": "0x55d6Df194472f02CD481e506A277c4A29D0D1bCc",
+          "off_ramp": "0xd93B571ae9CaF43d70b2b53fFD55e035Db641e31",
+          "commit_store": "0x42C1093b9DdE8d0CD58859C610dc239B66bE26de",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Polygon Amoy": {
-          "off_ramp": "0x450543b1d85ca79885851D7b74dc982981b78229",
-          "commit_store": "0x23B79d940A769FE31b4C867A8BAE80117f24Ca81",
+          "off_ramp": "0x87F9b8382611ACD01d5696a1f5b05B888e55B0Cc",
+          "commit_store": "0x29AC46227908d31A9BdDe82c0A4a6c52D802f145",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Sepolia Testnet": {
-          "off_ramp": "0xbf9036529123DE264bFA0FC7362fE25B650D4B16",
-          "commit_store": "0x5f7F1abD5c5EdaF2636D58B980e85355AF0Ef80d",
+          "off_ramp": "0x9aa734100C425309091dAE18154e0356B82d477a",
+          "commit_store": "0x7cDd533B82f4c32FAE7f551C37b1490909817C45",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -474,19 +501,8 @@ Data = """
       "router": "0xA8C0c11bf64AF62CDCA6f93D3769B88BdD7cb93D",
       "price_registry": "0xa1ed3A3aA29166C9c8448654A8cA6b7916BC8379",
       "wrapped_native": "0x4200000000000000000000000000000000000001",
-      "src_contracts": {
-        "WeMix Testnet": {
-          "on_ramp": "0x6ea155Fc77566D9dcE01B8aa5D7968665dc4f0C5",
-          "deployed_at": 0
-        }
-      },
-      "dest_contracts": {
-        "WeMix Testnet": {
-          "off_ramp": "0xB602B6E5Caf08ac0C920EAE585aed100a8cF6f3B",
-          "commit_store": "0x89D5b13908b9063abCC6791dc724bF7B7c93634C",
-          "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
-        }
-      }
+      "src_contracts": null,
+      "dest_contracts": null
     },
     "Metis Sepolia": {
       "is_native_fee_token": true,
@@ -502,15 +518,24 @@ Data = """
       "price_registry": "0x5DCE866b3ae6E0Ed153f0e149D7203A1B266cdF5",
       "wrapped_native": "0x5c48e07062aC4E2Cf4b9A768a711Aef18e8fbdA0",
       "src_contracts": {
+        "Arbitrum Sepolia": {
+          "on_ramp": "0x2eb69889cc979c0Be120813FcE2f1558efF4ceB5",
+          "deployed_at": 0
+        },
         "Sepolia Testnet": {
-          "on_ramp": "0x2Eff2d1BF5C557d6289D208a7a43608f5E3FeCc2",
+          "on_ramp": "0xE0dFc15C0CDf607b2088D0B641E00eA0B418124C",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
+        "Arbitrum Sepolia": {
+          "off_ramp": "0x839b5dEA3e084790F580E9DfCE8CCfDf49c5835e",
+          "commit_store": "0xdF38C8aD34C379165f98A75a6894790bB5a16b1D",
+          "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
+        },
         "Sepolia Testnet": {
-          "off_ramp": "0x9Bb7e398ef9Acfe9cA584C39B1E233Cba62BB9f7",
-          "commit_store": "0x1F4B82cDebaC5e3a0Dd53183D47e51808B4a64cB",
+          "off_ramp": "0x72130De9A85e9C61151253aFF8801Bb3242A00a9",
+          "commit_store": "0x8F6D64280C379F680Ff0c3278f340D72a465FAAc",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -530,23 +555,23 @@ Data = """
       "wrapped_native": "0x4200000000000000000000000000000000000006",
       "src_contracts": {
         "Base Sepolia": {
-          "on_ramp": "0x73f7E074bd7291706a0C5412f51DB46441B1aDCB",
+          "on_ramp": "0x48ACE2319f643584B77C21476a6c664D7F13a107",
           "deployed_at": 0
         },
         "Sepolia Testnet": {
-          "on_ramp": "0xfFdE9E8c34A27BEBeaCcAcB7b3044A0A364455C9",
+          "on_ramp": "0xb821885731414497d705dc56325f18AA33e612dC",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Base Sepolia": {
-          "off_ramp": "0x137a38c6b1Ad20101F93516aB2159Df525309168",
-          "commit_store": "0x8F43d867969F14619895d71E0A5b89E0bb20bF70",
+          "off_ramp": "0xC6b69Fa9eeBc55e64eBc68371Fbd41ff73756F17",
+          "commit_store": "0xaA6691EA9110409a29C2E665174b4b2fe694cE67",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Sepolia Testnet": {
-          "off_ramp": "0xcD44cec849B6a8eBd5551D6DFeEcA452257Dfe4d",
-          "commit_store": "0xbA66f08733E6715D33edDfb5a5947676bb45d0e0",
+          "off_ramp": "0x35dE2C381a2fF8a26c8ae94145be3A9cA8C83600",
+          "commit_store": "0xE7e60DAee094416b8ab2083047a893c4c4290c48",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -566,68 +591,68 @@ Data = """
       "wrapped_native": "0x4200000000000000000000000000000000000006",
       "src_contracts": {
         "Arbitrum Sepolia": {
-          "on_ramp": "0x1a86b29364D1B3fA3386329A361aA98A104b2742",
+          "on_ramp": "0x6B36c9CD74E760088817a047C3460dEdFfe9a11A",
           "deployed_at": 0
         },
         "Avalanche Fuji": {
-          "on_ramp": "0x6b38CC6Fa938D5AB09Bdf0CFe580E226fDD793cE",
+          "on_ramp": "0x91a144F570ABA7FB7079Fb187A267390E0cc7367",
           "deployed_at": 0
         },
         "Base Sepolia": {
-          "on_ramp": "0xe284D2315a28c4d62C419e8474dC457b219DB969",
+          "on_ramp": "0x6D22953cdEf8B0C9F0976Cfa52c33B198fEc5881",
           "deployed_at": 0
         },
         "Gnosis Chiado": {
-          "on_ramp": "0x835a5b8e6CA17c2bB5A336c93a4E22478E6F1C8A",
+          "on_ramp": "0xec7D9A84A6d4556056975BE50Cdc97bAa9313632",
           "deployed_at": 0
         },
         "Polygon Amoy": {
-          "on_ramp": "0x2Cf26fb01E9ccDb831414B766287c0A9e4551089",
+          "on_ramp": "0x9E09C2A7D6B9F88c62f0E2Af4cd62dF3F4c326F1",
           "deployed_at": 0
         },
         "Sepolia Testnet": {
-          "on_ramp": "0xC8b93b46BF682c39B3F65Aa1c135bC8A95A5E43a",
+          "on_ramp": "0x54b32C2aCb4451c6cF66bcbd856d8A7Cc2263531",
           "deployed_at": 0
         },
         "WeMix Testnet": {
-          "on_ramp": "0xc7E53f6aB982af7A7C3e470c8cCa283d3399BDAd",
+          "on_ramp": "0xB9Ef21C04d8340b223e9C1d7a09f332609c70300",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Arbitrum Sepolia": {
-          "off_ramp": "0xDc2c7A3d8068C6F09F0F3648d24C84e372F6014d",
-          "commit_store": "0xb1aFb5cbE3c29b5Db71F21442BA9EfD450BC23C3",
+          "off_ramp": "0xF35e2d1457749374453e44B06268aD3f78b133b3",
+          "commit_store": "0x4bd755d86E25dD4093CAa5639CfDab81571259CA",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Avalanche Fuji": {
-          "off_ramp": "0x1F350718e015EB20E5065C09F4A7a3f66888aEeD",
-          "commit_store": "0x98650A8EB59f75D93563aB34FcF603b1A30e4CBF",
+          "off_ramp": "0xCb2266c2118b1f30D15CBeB3a885531ABaA1b556",
+          "commit_store": "0x5Ded92E2CF71a8fF7644a67850F061c38B31BfB4",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Base Sepolia": {
-          "off_ramp": "0x0a750ca77369e03613d7640548F4b2b1c695c3Bb",
-          "commit_store": "0x8fEBC74C26129C8d7E60288C6dCCc75eb494aA3C",
+          "off_ramp": "0x960c62A491C30d0a60fD74a59d35B9C02697AdaA",
+          "commit_store": "0x06963745B3839B998288D1a46a46Ec25991A3D5E",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Gnosis Chiado": {
-          "off_ramp": "0xCE2CE7F940B7c839384e5D7e079A6aE80e8AD6dB",
-          "commit_store": "0x1b9D78Ec1CEEC439F0b7eA6C428A1a607D9FA7e4",
+          "off_ramp": "0x7d6721c2E85560F0A233255D3d332AcF6f850d96",
+          "commit_store": "0xaC00661cAB5161d9B4746DFb7A028d97981aB2c5",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Polygon Amoy": {
-          "off_ramp": "0xD667b5706592D0b040C78fEe5EE17D243b7dCB41",
-          "commit_store": "0x96101BA5250EE9295c193693C1e08A55bC593664",
+          "off_ramp": "0x4cEeFa55AF23dFD27Cf926e8eFB1D1bCcD24526E",
+          "commit_store": "0xaD3943BdECbf4ae7d6E51aB0FD06bbC604bB7b95",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Sepolia Testnet": {
-          "off_ramp": "0x260AF9b83e0d2Bb6C9015fC9f0BfF8858A0CCE68",
-          "commit_store": "0x7a0bB92Bc8663abe6296d0162A9b41a2Cb2E0358",
+          "off_ramp": "0x2aF9B10A5972D0c36f4d8F85773052c104E319B2",
+          "commit_store": "0x82FCF55b9e9bAb3066c2863F12a02bBc2Ba33F2F",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "WeMix Testnet": {
-          "off_ramp": "0x9C08B7712af0344188aa5087D9e6aD0f47191037",
-          "commit_store": "0x4BE6DB0B884169a6A207fe5cad01eB4C025a13dB",
+          "off_ramp": "0x0FA15Bc42D4999d964CBf0161489Bd392DEE834e",
+          "commit_store": "0x37760F99a5b91884C9D89a06408f532aEbb0e674",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -647,59 +672,59 @@ Data = """
       "wrapped_native": "0x360ad4f9a9A8EFe9A8DCB5f461c4Cc1047E1Dcf9",
       "src_contracts": {
         "Avalanche Fuji": {
-          "on_ramp": "0x8Fb98b3837578aceEA32b454f3221FE18D7Ce903",
+          "on_ramp": "0xad6A94CFB51e7DE30FD21F417E4cBf70D3AdaD30",
           "deployed_at": 0
         },
         "BSC Testnet": {
-          "on_ramp": "0xC6683ac4a0F62803Bec89a5355B36495ddF2C38b",
+          "on_ramp": "0x28EC0a9C90360F55C2a9DaD5901b074C257904ca",
           "deployed_at": 0
         },
         "Gnosis Chiado": {
-          "on_ramp": "0x2331F6D614C9Fd613Ff59a1aB727f1EDf6c37A68",
+          "on_ramp": "0x9DF611536f124278Ce968c476BDb10A66E54ecfE",
           "deployed_at": 0
         },
         "Optimism Sepolia": {
-          "on_ramp": "0xA52cDAeb43803A80B3c0C2296f5cFe57e695BE11",
+          "on_ramp": "0x600f00aef9b8ED8EDBd7284B5F04a1932c3408aF",
           "deployed_at": 0
         },
         "Sepolia Testnet": {
-          "on_ramp": "0x35347A2fC1f2a4c5Eae03339040d0b83b09e6FDA",
+          "on_ramp": "0x719Aef2C63376AdeCD62D2b59D54682aFBde914a",
           "deployed_at": 0
         },
         "WeMix Testnet": {
-          "on_ramp": "0x26546096F64B5eF9A1DcDAe70Df6F4f8c2E10C61",
+          "on_ramp": "0x7D6c93E49E46cc983a677c283EAb27CbbC94e3C4",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Avalanche Fuji": {
-          "off_ramp": "0xa733ce82a84335b2E9D864312225B0F3D5d80600",
-          "commit_store": "0x09B0F93fC2111aE439e853884173AC5b2F809885",
+          "off_ramp": "0xAc56Df7F5fbde0DeeB1C0d397A150EDD5EE68625",
+          "commit_store": "0x8AF56D1c76B8c8CeE451a0a654D130e4050B993e",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "BSC Testnet": {
-          "off_ramp": "0x948dfaa4842fc23e0e362Fe8D4396AaE4E6DF7EA",
-          "commit_store": "0x7F4e739D40E58BBd59dAD388171d18e37B26326f",
+          "off_ramp": "0x40Ba47ea59D80DDd35E3a997AA520FBa0553dddc",
+          "commit_store": "0x8afe532517b39bA109d1A768E1Ad8b5C6485abF5",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Gnosis Chiado": {
-          "off_ramp": "0x17c542a28e08AEF5697251601C7b2B621d153D42",
-          "commit_store": "0x811250c20fAB9a1b7ca245453aC214ba637fBEB5",
+          "off_ramp": "0x7B968B2aDFd31765dAAD80d66c83F9D7006BFFd5",
+          "commit_store": "0xBc70551B5624BaF8cdCB84136198561C9cf5C176",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Optimism Sepolia": {
-          "off_ramp": "0xfFdE9E8c34A27BEBeaCcAcB7b3044A0A364455C9",
-          "commit_store": "0x74ED442ad211050e9C05Dc9A267E037E3d74A03B",
+          "off_ramp": "0xAA755Ef570986feEb6522377077e549e3013843E",
+          "commit_store": "0x5C7827EcE6a51AdaC36ef71aC01706deb1C7130d",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Sepolia Testnet": {
-          "off_ramp": "0xFb04129aD1EEDB741CC705ebC1978a7aB63e51f6",
-          "commit_store": "0x63f875240149d29136053C954Ca164a9BfA81F77",
+          "off_ramp": "0x7Ad494C173f5845c6B4028a06cDcC6d3108bc960",
+          "commit_store": "0x104A1c8b05D37fE732094595Fe696AFc7EAB8668",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "WeMix Testnet": {
-          "off_ramp": "0xdE8451E952Eb43350614839cCAA84f7C8701a09C",
-          "commit_store": "0xaCdaBa07ECad81dc634458b98673931DD9d3Bc14",
+          "off_ramp": "0xa85481273f8C112e96ED7476202F06D6131cf069",
+          "commit_store": "0x9FdF1D555e37dB09B0d151FEa53c134C88C4DeFd",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -719,122 +744,122 @@ Data = """
       "wrapped_native": "0x097D90c9d3E0B50Ca60e1ae45F6A81010f9FB534",
       "src_contracts": {
         "Arbitrum Sepolia": {
-          "on_ramp": "0xe4Dd3B16E09c016402585a8aDFdB4A18f772a07e",
+          "on_ramp": "0xBc09627e58989Ba8F1eDA775e486467d2A00944F",
           "deployed_at": 0
         },
         "Avalanche Fuji": {
-          "on_ramp": "0x0477cA0a35eE05D3f9f424d88bC0977ceCf339D4",
+          "on_ramp": "0x12492154714fBD28F28219f6fc4315d19de1025B",
           "deployed_at": 0
         },
         "BSC Testnet": {
-          "on_ramp": "0xD990f8aFA5BCB02f95eEd88ecB7C68f5998bD618",
+          "on_ramp": "0x7a75b3818412fe0028590feE8270ba9E3fd01DBe",
           "deployed_at": 0
         },
         "Base Sepolia": {
-          "on_ramp": "0x2B70a05320cB069e0fB55084D402343F832556E7",
+          "on_ramp": "0x8F35B097022135E0F46831f798a240Cc8c4b0B01",
           "deployed_at": 0
         },
         "Blast Sepolia": {
-          "on_ramp": "0xDB75E9D9ca7577CcBd7232741be954cf26194a66",
+          "on_ramp": "0x4ADA60556dA05FcF53a79359e37a3E13FebA22Bf",
           "deployed_at": 0
         },
         "Celo Alfajores": {
-          "on_ramp": "0x3C86d16F52C10B2ff6696a0e1b8E0BcfCC085948",
+          "on_ramp": "0x1163D1F7D75eEb1C4f4c6912d3cF9642027aFD30",
           "deployed_at": 0
         },
         "Gnosis Chiado": {
-          "on_ramp": "0x3E842E3A79A00AFdd03B52390B1caC6306Ea257E",
+          "on_ramp": "0x831A7DbE6af8601427A0ADa89b642d4b59007eED",
           "deployed_at": 0
         },
         "Metis Sepolia": {
-          "on_ramp": "0x1C4640914cd57c5f02a68048A0fbb0E12d904223",
+          "on_ramp": "0xabB5A4f99DFEb4a3912e8Acc0660A008c76dA8c3",
           "deployed_at": 0
         },
         "Mode Sepolia": {
-          "on_ramp": "0xc630fbD4D0F6AEB00aD0793FB827b54fBB78e981",
+          "on_ramp": "0x2Eb0842925fb7aA6045e951e98e8b4b3aFFaBB54",
           "deployed_at": 0
         },
         "Optimism Sepolia": {
-          "on_ramp": "0x69CaB5A0a08a12BaFD8f5B195989D709E396Ed4d",
+          "on_ramp": "0xACDfd7a98d853FA3914047Cd46e7f5D53BBC9FbB",
           "deployed_at": 0
         },
         "Polygon Amoy": {
-          "on_ramp": "0x9f656e0361Fb5Df2ac446102c8aB31855B591692",
+          "on_ramp": "0xf9765c80F6448e6d4d02BeF4a6b4152131A2F513",
           "deployed_at": 0
         },
         "WeMix Testnet": {
-          "on_ramp": "0xedFc22336Eb0B9B11Ff37C07777db27BCcDe3C65",
+          "on_ramp": "0xd72c3c132B76F5D232C37dF3bF8f04392D552e0F",
           "deployed_at": 0
         },
         "ZKSync Sepolia": {
-          "on_ramp": "0x1Acb3A885feA37bdA30AB99b99327b14391f500F",
+          "on_ramp": "0xA2865E4f36760f5fa5c8F958336120f2DF0d974b",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Arbitrum Sepolia": {
-          "off_ramp": "0xF18896AB20a09A29e64fdEbA99FDb8EC328f43b1",
-          "commit_store": "0x93Ff9Dd39Dc01eac1fc4d2c9211D95Ee458CAB94",
+          "off_ramp": "0xD2f5edfD4561d6E7599F6c6888Bd353cAFd0c55E",
+          "commit_store": "0x240420BC6bCDc067e668c7492D69fe06B3CF80cE",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Avalanche Fuji": {
-          "off_ramp": "0x000b26f604eAadC3D874a4404bde6D64a97d95ca",
-          "commit_store": "0x2dD9273F8208B8393350508131270A6574A69784",
+          "off_ramp": "0x1DEBa99dC8e2A77832461BD386d83D9FCb133137",
+          "commit_store": "0x139E06b6dBB1a0C41A1686C091795879c943765A",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "BSC Testnet": {
-          "off_ramp": "0xdE2d8E126e08d675fCD7fFa5a6CE49925f3Dc692",
-          "commit_store": "0x0050ac355a82caB31194507f94174297bf0655A7",
+          "off_ramp": "0x04305BD9D9CA6730517f79c3D9c6828BC2D25Ecb",
+          "commit_store": "0x32edD59840CD9e474A280cf1707439F2Bd5872d4",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Base Sepolia": {
-          "off_ramp": "0x31c0B81832B333419f0DfD36A69F502cF9094aed",
-          "commit_store": "0xDFcde9d698a2B32DB2537DC9B752Cadd1D846a52",
+          "off_ramp": "0x662738DC7DE4f7eC63d9f73Cdf9BeA5A58DdcC15",
+          "commit_store": "0x1e46bAC486Dd878cD57B62845530A52343e39693",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Blast Sepolia": {
-          "off_ramp": "0x4e897e5cF3aC307F0541B2151A88bCD781c153a3",
-          "commit_store": "0xB656652841F347178e193951C4663652aCe36B74",
+          "off_ramp": "0x049A424cF894709f044bc70177F8F6b792adc3F6",
+          "commit_store": "0x496fE96E440Fc683478a08Df92A1c5E23E412b1C",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Celo Alfajores": {
-          "off_ramp": "0xB435E0f73c18C5a12C324CA1d02F81F2C3e6e761",
-          "commit_store": "0xbc5d74957F171e75F92c8F0E1C317A25a56a416D",
+          "off_ramp": "0x4F146d34Be5E273e576ef158Bd7070eC22708D20",
+          "commit_store": "0xEeB665281c7ab51d25423898f730Ab078c69dd42",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Gnosis Chiado": {
-          "off_ramp": "0x7db0115A0b3AAb01d30bf81123c5DD7B0C41Add5",
-          "commit_store": "0x6640723Ea801178c4383FA016b9781e7ef1016EF",
+          "off_ramp": "0xB424365EEEEA58A36C7EC858f926f4e8275dDEb3",
+          "commit_store": "0xE95c2135e3330E953BB49068d32Fcba368Acd456",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Metis Sepolia": {
-          "off_ramp": "0x4DB693A93E9d5196ECD42EC56CDEAe99dFC652ED",
-          "commit_store": "0xBfACd78F1412B6f93Ac23409bf456aFec1ABd845",
+          "off_ramp": "0x46DE6201c258f5948135cd0262f91e48Cb8e3828",
+          "commit_store": "0x3A27Fd059A4eF0e96B0643283A44a56A8d6CF34A",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Mode Sepolia": {
-          "off_ramp": "0xbEfd8D65F6643De54F0b1268A3bf4618ff85dcB4",
-          "commit_store": "0x0C161D3470b45Cc677661654C30ce4AdE6aCD288",
+          "off_ramp": "0x052E52fdd48719A6084366eA184FC44cb8C25DC2",
+          "commit_store": "0xBBb9baA314eB023E3F9291Aaf4107B6708341B50",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Optimism Sepolia": {
-          "off_ramp": "0xD50590D4438411EDe47029b0FD7901A7145E5Df6",
-          "commit_store": "0xe85EEE9Fd434A7b8a586Ee086E828abF41839479",
+          "off_ramp": "0xbfa6f6AAE31acB3A285e80026d6475C1a50d1d0F",
+          "commit_store": "0xB5FbA97Dc61ec68771a92a15360d9C32c9d054E7",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Polygon Amoy": {
-          "off_ramp": "0x5032cbC0C4aEeD25bb6E45D8B3fAF05DB0688C5d",
-          "commit_store": "0xe6201C9996Cc7B6E828E10CbE937E693d577D318",
+          "off_ramp": "0xC3e550B6aaFA5539df8bbCc5B0991e587f438e75",
+          "commit_store": "0xd57866D97ca26dfaE34088a3EeE4657BAFaac5f9",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "WeMix Testnet": {
-          "off_ramp": "0x46b639a3C1a4CBfD326b94a2dB7415c27157282f",
-          "commit_store": "0x7b74554678816b045c1e7409327E086bD436aa46",
+          "off_ramp": "0x445F41C6aa7e910021786e860d7cfe3E7fcC6640",
+          "commit_store": "0x307dDE3c696E399b5837456FbCe03b1Ad76D46E3",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "ZKSync Sepolia": {
-          "off_ramp": "0xBaABd4166C892a1081a26535875A8fA3f22937b2",
-          "commit_store": "0xfda2e83F4D3f42B7629134ecD6E4b29FB8A7A07B",
+          "off_ramp": "0x9f5dC467A5c97068A1c2987486B8b768275627eD",
+          "commit_store": "0x6e4601DA99a046e4bde60d051568E3E1F35E3097",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -854,68 +879,59 @@ Data = """
       "wrapped_native": "0xbE3686643c05f00eC46e73da594c78098F7a9Ae7",
       "src_contracts": {
         "Arbitrum Sepolia": {
-          "on_ramp": "0xA9DE3F7A617D67bC50c56baaCb9E0373C15EbfC6",
+          "on_ramp": "0xa5Be8C619F61505548992D9820c5c485b030C7B0",
           "deployed_at": 0
         },
         "Avalanche Fuji": {
-          "on_ramp": "0xC4aC84da458ba8e40210D2dF94C76E9a41f70069",
+          "on_ramp": "0x7802B6804bbE7486229ac6D3519f0057c50b40a9",
           "deployed_at": 0
         },
         "BSC Testnet": {
-          "on_ramp": "0x5AD6eed6Be0ffaDCA4105050CF0E584D87E0c2F1",
-          "deployed_at": 0
-        },
-        "Kroma Sepolia": {
-          "on_ramp": "0x428C4dc89b6Bf908B82d77C9CBceA786ea8cc7D0",
+          "on_ramp": "0xd25B8c70CB43022Bdc3aC417E2Cf5159294d95A1",
           "deployed_at": 0
         },
         "Optimism Sepolia": {
-          "on_ramp": "0x1961a7De751451F410391c251D4D4F98D71B767D",
+          "on_ramp": "0xB37607C6BD4562F32967dE87D14663D59e3f655d",
           "deployed_at": 0
         },
         "Polygon Amoy": {
-          "on_ramp": "0xd55148e841e76265B484d399eC71b7076ecB1216",
+          "on_ramp": "0x0c972752F9aC3255cE45b440f9bBC6500676c4e6",
           "deployed_at": 0
         },
         "Sepolia Testnet": {
-          "on_ramp": "0x4d57C6d8037C65fa66D6231844785a428310a735",
+          "on_ramp": "0x1CD55c65f85681Dfae47c62e6D93340D25006BbB",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Arbitrum Sepolia": {
-          "off_ramp": "0xeB1dFaB2464Bf0574D43e764E0c758f92e7ecAFb",
-          "commit_store": "0xcEaCa2B7890065c485f3E58657358a185Ad33791",
+          "off_ramp": "0xB5492C8A71130B486fAD1091Db683584767A3957",
+          "commit_store": "0x1e151ED27E2F48EcFBd5b4374d0fc4869e07c397",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Avalanche Fuji": {
-          "off_ramp": "0x98e811Df9D2512f1aaf58D534607F583D6c54A4F",
-          "commit_store": "0x8e538351F6E5B2daF3c90C565C3738bca69a2716",
+          "off_ramp": "0x60536c757c2BBf72cC68A1933F7e336d03Bb68fe",
+          "commit_store": "0x2fF725556A04b47eB40BbA11d9F51e8fbbee9F07",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "BSC Testnet": {
-          "off_ramp": "0xB0e7f0fCcD3c961C473E7c44D939C1cDb4Cec1cB",
-          "commit_store": "0x4B56D8d53f1A6e0117B09700067De99581aA5542",
-          "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
-        },
-        "Kroma Sepolia": {
-          "off_ramp": "0xD685D2d224dd6D0Db2D56497db6270D77D9a7966",
-          "commit_store": "0x7e062D6880779a0347e7742058C1b1Ee4AA0B137",
+          "off_ramp": "0xb858077FbE1E55cD7a9092Eb6d5403e068c14EAf",
+          "commit_store": "0x0EF13C7c95C27A9EA477363a26a09Cff44ba38F9",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Optimism Sepolia": {
-          "off_ramp": "0xA5f97Bc69Bf06e7C37B93265c5457420A92c5F4b",
-          "commit_store": "0xd48b9213583074f518D8f4336FDf35370D450132",
+          "off_ramp": "0x995Fc17FC12b67f75D3cBf3bC71BD9af65671E78",
+          "commit_store": "0xD0825e3D8e61b67a06A93426749d38bCF73Ddb02",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Polygon Amoy": {
-          "off_ramp": "0x6c8f5999B06FDE17B11E4e3C1062b761766F960f",
-          "commit_store": "0x957c3c2056192e58A8485eF31165fC490d474239",
+          "off_ramp": "0xd7b5B4F8FF7a87cC92f7B3058365862859d9E057",
+          "commit_store": "0xa8f2bb4e831caA5E2794AaD014030E378208d4Bc",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         },
         "Sepolia Testnet": {
-          "off_ramp": "0x8AB103843ED9D28D2C5DAf5FdB9c3e1CE2B6c876",
-          "commit_store": "0x7d5297c5506ee2A7Ef121Da9bE02b6a6AD30b392",
+          "off_ramp": "0xa7E2F97Be7798327A49CACD022f33c0E7EfD4897",
+          "commit_store": "0x6fe69eE4eC9FD768193a40129A3Ba3dF140b2208",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }
@@ -923,20 +939,26 @@ Data = """
     "ZKSync Sepolia": {
       "is_native_fee_token": true,
       "fee_token": "0x4317b2eCD41851173175005783322D29E9bAee9E",
+      "bridge_tokens": [
+        "0xFf6d0c1518A8104611f482eb2801CaF4f13c9dEb"
+      ],
+      "bridge_tokens_pools": [
+        "0xA16cfA090aA6888AE8Beb92F8bfD316DD05767C9"
+      ],
       "arm": "0x926b4f90610Aa448f27c8e0Fd0afa4A17B7305F9",
       "router": "0xA1fdA8aa9A8C4b945C45aD30647b01f07D7A0B16",
       "price_registry": "0x648B6BB09bE1C5766C8AC578B9B4aC8497eA671F",
       "wrapped_native": "0x4317b2eCD41851173175005783322D29E9bAee9E",
       "src_contracts": {
         "Sepolia Testnet": {
-          "on_ramp": "0x79a9a5e9e318e8e109776569574814bbf935125a",
+          "on_ramp": "0xC38536521fde8556351aB7C4D3ea23b64AFbBbab",
           "deployed_at": 0
         }
       },
       "dest_contracts": {
         "Sepolia Testnet": {
-          "off_ramp": "0x18FF69051479796175852578725Fc74F58E963F8",
-          "commit_store": "0xF694b4FD7889480dca3CD41244e8e3395a9EFBa0",
+          "off_ramp": "0x19Ea9A42cd3682928aF19990dDb3904250D00a1D",
+          "commit_store": "0x20BF9037927bFadaF028D43ae07d1afccfB8fa85",
           "receiver_dapp": "0xea387241d834D04CC408f4C2FE7ef2c477E4B3E7"
         }
       }


### PR DESCRIPTION
Update the contracts to 1.5 in mainnet, prod-testnet and update latest beta contracts.
Modify the wait timeout for slower finality chains.
Changes to slack notification settings. Report only when there is failure and in #ccip-testing channel.
