### PR TITLE
Add chaintype.ChainZircuit to chaintypes with rollup support

### DIFF
--- a/core/chains/evm/gas/rollups/l1_oracle.go
+++ b/core/chains/evm/gas/rollups/l1_oracle.go
@@ -44,7 +44,15 @@ const (
 	PollPeriod = 6 * time.Second
 )
 
-var supportedChainTypes = []chaintype.ChainType{chaintype.ChainArbitrum, chaintype.ChainOptimismBedrock, chaintype.ChainKroma, chaintype.ChainScroll, chaintype.ChainZkSync, chaintype.ChainMantle}
+var supportedChainTypes = []chaintype.ChainType{
+	chaintype.ChainArbitrum,
+	chaintype.ChainOptimismBedrock,
+	chaintype.ChainKroma,
+	chaintype.ChainScroll,
+	chaintype.ChainZkSync,
+	chaintype.ChainMantle,
+	chaintype.ChainZircuit,
+}
 
 func IsRollupWithL1Support(chainType chaintype.ChainType) bool {
 	return slices.Contains(supportedChainTypes, chainType)


### PR DESCRIPTION
## Motivation
- Zircuit's chaintype was recently changed from `optimismBedrock` to `zircuit`
- This means `IsRollupWithL1Support()` started returning false for zircuit
- Which in turn meant no L1 oracle was created for Zircuit 

## Solution
- Add zircuit to `supportedChainTypes`