### PR TITLE
CCIP-4803 flaky test: don't send nil to errorChan

### DIFF
--- a/core/services/ocr2/plugins/ccip/tokendata/lbtc/lbtc_test.go
+++ b/core/services/ocr2/plugins/ccip/tokendata/lbtc/lbtc_test.go
@@ -278,11 +278,12 @@ func TestLBTCReader_rateLimiting(t *testing.T) {
 					_, err := lbtcService.ReadTokenData(ctx, cciptypes.EVM2EVMOnRampCCIPSendRequestedWithMeta{
 						EVM2EVMMessage: cciptypes.EVM2EVMMessage{
 							SourceTokenData: [][]byte{srcTokenData},
-							TokenAmounts:    []cciptypes.TokenAmount{{Token: ccipcalc.EvmAddrToGeneric(utils.ZeroAddress), Amount: nil}}, // trigger failure due to wrong address
+							TokenAmounts:    []cciptypes.TokenAmount{{Token: ccipcalc.EvmAddrToGeneric(utils.ZeroAddress), Amount: nil}},
 						},
 					}, 0)
-
-					errorChan <- err
+					if err != nil {
+						errorChan <- err
+					}
 				}()
 			}
 


### PR DESCRIPTION
## Motivation
Sometimes request manages to complete within unrealistic timeout and fails with `panic: runtime error: invalid memory address or nil pointer dereference` because in that case it sends `nil` in `errorChan`

## Solution
Don't send `nil` into `errorChan`. Test still will be able to detect faulty behaviour if err is defined in test case `if tc.err != ""`